### PR TITLE
Versioning support for 0.1 and 0.2

### DIFF
--- a/src/CloudNative.CloudEvents/CloudEvent.cs
+++ b/src/CloudNative.CloudEvents/CloudEvent.cs
@@ -15,7 +15,7 @@ namespace CloudNative.CloudEvents
     {
         public const string MediaType = "application/cloudevents";
 
-        readonly IDictionary<string, object> attributes;
+        readonly CloudEventAttributes attributes;
 
         /// <summary>
         /// Create a new CloudEvent instance.
@@ -26,7 +26,21 @@ namespace CloudNative.CloudEvents
         /// <param name="time">'time' of the CloudEvent</param>
         /// <param name="extensions">Extensions to be added to this CloudEvents</param>
         public CloudEvent(string type, Uri source, string id = null, DateTime? time = null,
-            params ICloudEventExtension[] extensions) : this(extensions)
+            params ICloudEventExtension[] extensions) : this(CloudEventsSpecVersion.V0_2, type, source, id, time, extensions)
+        {
+        }
+
+        /// <summary>
+        /// Create a new CloudEvent instance.
+        /// </summary>
+        /// <param name="specVersion">CloudEvents specification version</param>
+        /// <param name="type">'type' of the CloudEvent</param>
+        /// <param name="source">'source' of the CloudEvent</param>
+        /// <param name="id">'id' of the CloudEvent</param>
+        /// <param name="time">'time' of the CloudEvent</param>
+        /// <param name="extensions">Extensions to be added to this CloudEvents</param>
+        public CloudEvent(CloudEventsSpecVersion specVersion, string type, Uri source, string id = null, DateTime? time = null,
+            params ICloudEventExtension[] extensions) : this(specVersion, extensions)
         {
             Type = type;
             Source = source;
@@ -37,11 +51,11 @@ namespace CloudNative.CloudEvents
         /// <summary>
         /// Create a new CloudEvent instance
         /// </summary>
+        /// <param name="specVersion">CloudEvents specification version</param>
         /// <param name="extensions">Extensions to be added to this CloudEvents</param>
-        internal CloudEvent(IEnumerable<ICloudEventExtension> extensions)
+        internal CloudEvent(CloudEventsSpecVersion specVersion, IEnumerable<ICloudEventExtension> extensions)
         {
-            attributes = new CloudEventAttributes(extensions);
-            SpecVersion = "0.2";
+            attributes = new CloudEventAttributes(specVersion, extensions);
             this.Extensions = new Dictionary<Type, ICloudEventExtension>();
             if (extensions != null)
             {
@@ -61,8 +75,8 @@ namespace CloudNative.CloudEvents
         /// <see cref="https://github.com/cloudevents/spec/blob/master/spec.md#contenttype"/>
         public ContentType ContentType
         {
-            get => attributes[CloudEventAttributes.ContentTypeAttributeName] as ContentType;
-            set => attributes[CloudEventAttributes.ContentTypeAttributeName] = value;
+            get => attributes[CloudEventAttributes.ContentTypeAttributeName(attributes.SpecVersion)] as ContentType;
+            set => attributes[CloudEventAttributes.ContentTypeAttributeName(attributes.SpecVersion)] = value;
         }
 
         /// <summary>
@@ -73,8 +87,8 @@ namespace CloudNative.CloudEvents
         /// <see cref="https://github.com/cloudevents/spec/blob/master/spec.md#data-1"/>
         public object Data
         {
-            get => attributes[CloudEventAttributes.DataAttributeName];
-            set => attributes[CloudEventAttributes.DataAttributeName] = value;
+            get => attributes[CloudEventAttributes.DataAttributeName(attributes.SpecVersion)];
+            set => attributes[CloudEventAttributes.DataAttributeName(attributes.SpecVersion)] = value;
         }
 
         /// <summary>
@@ -89,8 +103,8 @@ namespace CloudNative.CloudEvents
         /// <see cref="https://github.com/cloudevents/spec/blob/master/spec.md#id"/>
         public string Id
         {
-            get => attributes[CloudEventAttributes.IdAttributeName] as string;
-            set => attributes[CloudEventAttributes.IdAttributeName] = value;
+            get => attributes[CloudEventAttributes.IdAttributeName(attributes.SpecVersion)] as string;
+            set => attributes[CloudEventAttributes.IdAttributeName(attributes.SpecVersion)] = value;
         }
 
         /// <summary>
@@ -101,8 +115,8 @@ namespace CloudNative.CloudEvents
         /// <see cref="https://github.com/cloudevents/spec/blob/master/spec.md#schemaurl"/>
         public Uri SchemaUrl
         {
-            get => attributes[CloudEventAttributes.SchemaUrlAttributeName] as Uri;
-            set => attributes[CloudEventAttributes.SchemaUrlAttributeName] = value;
+            get => attributes[CloudEventAttributes.SchemaUrlAttributeName(attributes.SpecVersion)] as Uri;
+            set => attributes[CloudEventAttributes.SchemaUrlAttributeName(attributes.SpecVersion)] = value;
         }
 
         /// <summary>
@@ -114,8 +128,8 @@ namespace CloudNative.CloudEvents
         /// <see cref="https://github.com/cloudevents/spec/blob/master/spec.md#source"/>
         public Uri Source
         {
-            get => attributes[CloudEventAttributes.SourceAttributeName] as Uri;
-            set => attributes[CloudEventAttributes.SourceAttributeName] = value;
+            get => attributes[CloudEventAttributes.SourceAttributeName(attributes.SpecVersion)] as Uri;
+            set => attributes[CloudEventAttributes.SourceAttributeName(attributes.SpecVersion)] = value;
         }
 
         /// <summary>
@@ -123,10 +137,10 @@ namespace CloudNative.CloudEvents
         /// specification which the event uses. This enables the interpretation of the context.
         /// </summary>
         /// <see cref="https://github.com/cloudevents/spec/blob/master/spec.md#specversion"/>
-        public string SpecVersion
+        public CloudEventsSpecVersion SpecVersion
         {
-            get => attributes[CloudEventAttributes.SpecVersionAttributeName] as string;
-            set => attributes[CloudEventAttributes.SpecVersionAttributeName] = value;
+            get => attributes.SpecVersion;
+            set => attributes.SpecVersion = value;
         }
 
         /// <summary>
@@ -135,8 +149,8 @@ namespace CloudNative.CloudEvents
         /// <see cref="https://github.com/cloudevents/spec/blob/master/spec.md#time"/>
         public DateTime? Time
         {
-            get => (DateTime?)attributes[CloudEventAttributes.TimeAttributeName];
-            set => attributes[CloudEventAttributes.TimeAttributeName] = value;
+            get => (DateTime?)attributes[CloudEventAttributes.TimeAttributeName(attributes.SpecVersion)];
+            set => attributes[CloudEventAttributes.TimeAttributeName(attributes.SpecVersion)] = value;
         }
 
         /// <summary>
@@ -146,8 +160,8 @@ namespace CloudNative.CloudEvents
         /// <see cref="https://github.com/cloudevents/spec/blob/master/spec.md#type"/>
         public string Type
         {
-            get => attributes[CloudEventAttributes.TypeAttributeName] as string;
-            set => attributes[CloudEventAttributes.TypeAttributeName] = value;
+            get => attributes[CloudEventAttributes.TypeAttributeName(attributes.SpecVersion)] as string;
+            set => attributes[CloudEventAttributes.TypeAttributeName(attributes.SpecVersion)] = value;
         }
 
         /// <summary>

--- a/src/CloudNative.CloudEvents/CloudEventContent.cs
+++ b/src/CloudNative.CloudEvents/CloudEventContent.cs
@@ -51,7 +51,7 @@ namespace CloudNative.CloudEvents
             }
             else
             {
-                inner = new InnerByteArrayContent(formatter.EncodeAttribute(CloudEventAttributes.DataAttributeName,
+                inner = new InnerByteArrayContent(formatter.EncodeAttribute(cloudEvent.SpecVersion, CloudEventAttributes.DataAttributeName(cloudEvent.SpecVersion),
                     cloudEvent.Data, cloudEvent.Extensions.Values));
             }
 
@@ -79,29 +79,27 @@ namespace CloudNative.CloudEvents
         {
             foreach (var attribute in cloudEvent.GetAttributes())
             {
-                switch (attribute.Key)
+                if (!(attribute.Key.Equals(CloudEventAttributes.DataAttributeName(cloudEvent.SpecVersion)) ||
+                      attribute.Key.Equals(CloudEventAttributes.ContentTypeAttributeName(cloudEvent.SpecVersion))))
                 {
-                    case CloudEventAttributes.DataAttributeName:
-                    case CloudEventAttributes.ContentTypeAttributeName:
-                        break;
-                    default:
-                        if (attribute.Value is string)
-                        {
-                            Headers.Add("ce-" + attribute.Key, attribute.Value.ToString());
-                        }
-                        else if (attribute.Value is DateTime)
-                        {
-                            Headers.Add("ce-" + attribute.Key, ((DateTime)attribute.Value).ToString("o"));
-                        }
-                        else if (attribute.Value is Uri || attribute.Value is int)
-                        {
-                            Headers.Add("ce-" + attribute.Key, attribute.Value.ToString());
-                        }
-                        else
-                        {
-                            Headers.Add("ce-" + attribute.Key, Encoding.UTF8.GetString(jsonFormatter.EncodeAttribute(attribute.Key, attribute.Value, cloudEvent.Extensions.Values)));
-                        }
-                        break;
+                    if (attribute.Value is string)
+                    {
+                        Headers.Add("ce-" + attribute.Key, attribute.Value.ToString());
+                    }
+                    else if (attribute.Value is DateTime)
+                    {
+                        Headers.Add("ce-" + attribute.Key, ((DateTime)attribute.Value).ToString("o"));
+                    }
+                    else if (attribute.Value is Uri || attribute.Value is int)
+                    {
+                        Headers.Add("ce-" + attribute.Key, attribute.Value.ToString());
+                    }
+                    else
+                    {
+                        Headers.Add("ce-" + attribute.Key,
+                            Encoding.UTF8.GetString(jsonFormatter.EncodeAttribute(cloudEvent.SpecVersion, attribute.Key, attribute.Value,
+                                cloudEvent.Extensions.Values)));
+                    }
                 }
             }
         }

--- a/src/CloudNative.CloudEvents/CloudEventsSpecVersion.cs
+++ b/src/CloudNative.CloudEvents/CloudEventsSpecVersion.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Cloud Native Foundation. 
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+namespace CloudNative.CloudEvents
+{
+    public enum CloudEventsSpecVersion
+    {
+        V0_1,
+        V0_2,
+        Default = V0_2
+    }
+}

--- a/src/CloudNative.CloudEvents/ICloudEventFormatter.cs
+++ b/src/CloudNative.CloudEvents/ICloudEventFormatter.cs
@@ -35,6 +35,7 @@ namespace CloudNative.CloudEvents
         /// <param name="contentType"></param>
         /// <returns></returns>
         byte[] EncodeStructuredEvent(CloudEvent cloudEvent, out ContentType contentType);
+      
         /// <summary>
         /// Decode an attribute from a byte array
         /// </summary>
@@ -42,7 +43,7 @@ namespace CloudNative.CloudEvents
         /// <param name="data"></param>
         /// <param name="extensions"></param>
         /// <returns></returns>
-        object DecodeAttribute(string name, byte[] data, IEnumerable<ICloudEventExtension> extensions);
+        object DecodeAttribute(CloudEventsSpecVersion specVersion, string name, byte[] data, IEnumerable<ICloudEventExtension> extensions);
         /// <summary>
         /// Encode an attribute into a byte array
         /// </summary>
@@ -50,6 +51,6 @@ namespace CloudNative.CloudEvents
         /// <param name="value"></param>
         /// <param name="extensions"></param>
         /// <returns></returns>
-        byte[] EncodeAttribute(string name, object value, IEnumerable<ICloudEventExtension> extensions);
+        byte[] EncodeAttribute(CloudEventsSpecVersion specVersion, string name, object value, IEnumerable<ICloudEventExtension> extensions);
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/AmqpTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/AmqpTest.cs
@@ -41,7 +41,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.True(message1.IsCloudEvent());
             var receivedCloudEvent = message1.ToCloudEvent();
 
-            Assert.Equal("0.2", receivedCloudEvent.SpecVersion);
+            Assert.Equal(CloudEventsSpecVersion.V0_2, receivedCloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
             Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
@@ -84,7 +84,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.True(message1.IsCloudEvent());
             var receivedCloudEvent = message1.ToCloudEvent();
 
-            Assert.Equal("0.2", receivedCloudEvent.SpecVersion);
+            Assert.Equal(CloudEventsSpecVersion.V0_2, receivedCloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
             Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);

--- a/test/CloudNative.CloudEvents.UnitTests/ConstructorTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/ConstructorTest.cs
@@ -26,7 +26,7 @@ namespace CloudNative.CloudEvents.UnitTests
             attrs["comexampleextension1"] = "value";
             attrs["comexampleextension2"] = new { othervalue = 5 };
 
-            Assert.Equal("0.2", cloudEvent.SpecVersion);
+            Assert.Equal(CloudEventsSpecVersion.V0_2, cloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
@@ -57,7 +57,7 @@ namespace CloudNative.CloudEvents.UnitTests
             attrs["comexampleextension1"] = "value";
             attrs["comexampleextension2"] = new { othervalue = 5 };
 
-            Assert.Equal("0.2", cloudEvent.SpecVersion);
+            Assert.Equal(CloudEventsSpecVersion.V0_2, cloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
@@ -70,6 +70,71 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("value", (string)attr["comexampleextension1"]);
             Assert.Equal(5, (int)((dynamic)attr["comexampleextension2"]).othervalue);
         }
+
+
+        [Fact]
+        public void CreateV0_1()
+        {
+            var cloudEvent = new CloudEvent(CloudEventsSpecVersion.V0_1, "com.github.pull.create",
+                new Uri("https://github.com/cloudevents/spec/pull/123"))
+            {
+                Id = "A234-1234-1234",
+                Time = new DateTime(2018, 4, 5, 17, 31, 0, DateTimeKind.Utc),
+                ContentType = new ContentType(MediaTypeNames.Text.Xml),
+                Data = "<much wow=\"xml\"/>"
+            };
+
+            var attrs = cloudEvent.GetAttributes();
+            attrs["comexampleextension1"] = "value";
+            attrs["comexampleextension2"] = new { othervalue = 5 };
+
+            Assert.Equal(CloudEventsSpecVersion.V0_1, cloudEvent.SpecVersion);
+            Assert.Equal("com.github.pull.create", cloudEvent.Type);
+            Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
+            Assert.Equal("A234-1234-1234", cloudEvent.Id);
+            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
+                cloudEvent.Time.Value.ToUniversalTime());
+            Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), cloudEvent.ContentType);
+            Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
+
+            var attr = cloudEvent.GetAttributes();
+            Assert.Equal("value", (string)attr["comexampleextension1"]);
+            Assert.Equal(5, (int)((dynamic)attr["comexampleextension2"]).othervalue);
+        }
+
+        [Fact]
+        public void CreateV0_1ConvertToV0_2()
+        {
+            var cloudEvent = new CloudEvent(CloudEventsSpecVersion.V0_1, "com.github.pull.create",
+                new Uri("https://github.com/cloudevents/spec/pull/123"))
+            {
+                Id = "A234-1234-1234",
+                Time = new DateTime(2018, 4, 5, 17, 31, 0, DateTimeKind.Utc),
+                ContentType = new ContentType(MediaTypeNames.Text.Xml),
+                Data = "<much wow=\"xml\"/>"
+            };
+
+            var attrs = cloudEvent.GetAttributes();
+            attrs["comexampleextension1"] = "value";
+            attrs["comexampleextension2"] = new { othervalue = 5 };
+
+            cloudEvent.SpecVersion = CloudEventsSpecVersion.V0_2;
+
+            Assert.Equal(CloudEventsSpecVersion.V0_2, cloudEvent.SpecVersion);
+            Assert.Equal("com.github.pull.create", cloudEvent.Type);
+            Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
+            Assert.Equal("A234-1234-1234", cloudEvent.Id);
+            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
+                cloudEvent.Time.Value.ToUniversalTime());
+            Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), cloudEvent.ContentType);
+            Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
+
+            var attr = cloudEvent.GetAttributes();
+            Assert.Equal("value", (string)attr["comexampleextension1"]);
+            Assert.Equal(5, (int)((dynamic)attr["comexampleextension2"]).othervalue);
+        }
+
+
 
         [Fact]
         public void CreateEventWithExtensions()
@@ -95,7 +160,7 @@ namespace CloudNative.CloudEvents.UnitTests
                 Data = "<much wow=\"xml\"/>"
             };
 
-            Assert.Equal("0.2", cloudEvent.SpecVersion);
+            Assert.Equal(CloudEventsSpecVersion.V0_2, cloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);

--- a/test/CloudNative.CloudEvents.UnitTests/ExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/ExtensionsTest.cs
@@ -55,7 +55,7 @@ namespace CloudNative.CloudEvents.UnitTests
         {
             var jsonFormatter = new JsonEventFormatter();
             var cloudEvent = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(jsonDistTrace), new DistributedTracingExtension());
-            Assert.Equal("0.2", cloudEvent.SpecVersion);
+            Assert.Equal(CloudEventsSpecVersion.V0_2, cloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
@@ -74,7 +74,7 @@ namespace CloudNative.CloudEvents.UnitTests
             var jsonData = jsonFormatter.EncodeStructuredEvent(cloudEvent1, out var contentType);
             var cloudEvent = jsonFormatter.DecodeStructuredEvent(jsonData, new DistributedTracingExtension());
 
-            Assert.Equal("0.2", cloudEvent.SpecVersion);
+            Assert.Equal(CloudEventsSpecVersion.V0_2, cloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
@@ -90,7 +90,7 @@ namespace CloudNative.CloudEvents.UnitTests
         {
             var jsonFormatter = new JsonEventFormatter();
             var cloudEvent = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(jsonSequence), new SequenceExtension());
-            Assert.Equal("0.2", cloudEvent.SpecVersion);
+            Assert.Equal(CloudEventsSpecVersion.V0_2, cloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
@@ -109,7 +109,7 @@ namespace CloudNative.CloudEvents.UnitTests
             var jsonData = jsonFormatter.EncodeStructuredEvent(cloudEvent1, out var contentType);
             var cloudEvent = jsonFormatter.DecodeStructuredEvent(jsonData, new SequenceExtension());
 
-            Assert.Equal("0.2", cloudEvent.SpecVersion);
+            Assert.Equal(CloudEventsSpecVersion.V0_2, cloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
@@ -125,7 +125,7 @@ namespace CloudNative.CloudEvents.UnitTests
         {
             var jsonFormatter = new JsonEventFormatter();
             var cloudEvent = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(jsonSequence), new IntegerSequenceExtension());
-            Assert.Equal("0.2", cloudEvent.SpecVersion);
+            Assert.Equal(CloudEventsSpecVersion.V0_2, cloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
@@ -143,7 +143,7 @@ namespace CloudNative.CloudEvents.UnitTests
             var jsonData = jsonFormatter.EncodeStructuredEvent(cloudEvent1, out var contentType);
             var cloudEvent = jsonFormatter.DecodeStructuredEvent(jsonData, new IntegerSequenceExtension());
 
-            Assert.Equal("0.2", cloudEvent.SpecVersion);
+            Assert.Equal(CloudEventsSpecVersion.V0_2, cloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
@@ -158,7 +158,7 @@ namespace CloudNative.CloudEvents.UnitTests
         {
             var jsonFormatter = new JsonEventFormatter();
             var cloudEvent = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(jsonSampledRate), new SamplingExtension());
-            Assert.Equal("0.2", cloudEvent.SpecVersion);
+            Assert.Equal(CloudEventsSpecVersion.V0_2, cloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
@@ -176,7 +176,7 @@ namespace CloudNative.CloudEvents.UnitTests
             var jsonData = jsonFormatter.EncodeStructuredEvent(cloudEvent1, out var contentType);
             var cloudEvent = jsonFormatter.DecodeStructuredEvent(jsonData, new SamplingExtension());
 
-            Assert.Equal("0.2", cloudEvent.SpecVersion);
+            Assert.Equal(CloudEventsSpecVersion.V0_2, cloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);

--- a/test/CloudNative.CloudEvents.UnitTests/HttpTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/HttpTest.cs
@@ -107,7 +107,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
             var receivedCloudEvent = result.ToCloudEvent();
 
-            Assert.Equal("0.2", receivedCloudEvent.SpecVersion);
+            Assert.Equal(CloudEventsSpecVersion.V0_2, receivedCloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
             Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
@@ -152,7 +152,7 @@ namespace CloudNative.CloudEvents.UnitTests
 
                     var receivedCloudEvent = context.Request.ToCloudEvent(new JsonEventFormatter());
 
-                    Assert.Equal("0.2", receivedCloudEvent.SpecVersion);
+                    Assert.Equal(CloudEventsSpecVersion.V0_2, receivedCloudEvent.SpecVersion);
                     Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
                     Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
                     Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
@@ -234,7 +234,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.True(result.IsCloudEvent());
             var receivedCloudEvent = result.ToCloudEvent();
 
-            Assert.Equal("0.2", receivedCloudEvent.SpecVersion);
+            Assert.Equal(CloudEventsSpecVersion.V0_2, receivedCloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
             Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
@@ -274,7 +274,7 @@ namespace CloudNative.CloudEvents.UnitTests
                 {
                     var receivedCloudEvent = context.Request.ToCloudEvent(new JsonEventFormatter());
 
-                    Assert.Equal("0.2", receivedCloudEvent.SpecVersion);
+                    Assert.Equal(CloudEventsSpecVersion.V0_2, receivedCloudEvent.SpecVersion);
                     Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
                     Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
                     Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
@@ -336,7 +336,7 @@ namespace CloudNative.CloudEvents.UnitTests
                 {
                     var receivedCloudEvent = context.Request.ToCloudEvent(new JsonEventFormatter());
 
-                    Assert.Equal("0.2", receivedCloudEvent.SpecVersion);
+                    Assert.Equal(CloudEventsSpecVersion.V0_2, receivedCloudEvent.SpecVersion);
                     Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
                     Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
                     Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);

--- a/test/CloudNative.CloudEvents.UnitTests/JsonTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/JsonTest.cs
@@ -44,11 +44,29 @@ namespace CloudNative.CloudEvents.UnitTests
         }
 
         [Fact]
+        public void ReserializeTestV0_2toV0_1()
+        {
+            var jsonFormatter = new JsonEventFormatter();
+            var cloudEvent = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(json));
+            cloudEvent.SpecVersion = CloudEventsSpecVersion.V0_1;
+            var jsonData = jsonFormatter.EncodeStructuredEvent(cloudEvent, out var contentType);
+            var cloudEvent2 = jsonFormatter.DecodeStructuredEvent(jsonData);
+
+            Assert.Equal(cloudEvent2.SpecVersion, cloudEvent.SpecVersion);
+            Assert.Equal(cloudEvent2.Type, cloudEvent.Type);
+            Assert.Equal(cloudEvent2.Source, cloudEvent.Source);
+            Assert.Equal(cloudEvent2.Id, cloudEvent.Id);
+            Assert.Equal(cloudEvent2.Time.Value.ToUniversalTime(), cloudEvent.Time.Value.ToUniversalTime());
+            Assert.Equal(cloudEvent2.ContentType, cloudEvent.ContentType);
+            Assert.Equal(cloudEvent2.Data, cloudEvent.Data);
+        }
+
+        [Fact]
         public void StructuredParseSuccess()
         {
             var jsonFormatter = new JsonEventFormatter();
             var cloudEvent = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(json));
-            Assert.Equal("0.2", cloudEvent.SpecVersion);
+            Assert.Equal(CloudEventsSpecVersion.V0_2, cloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
@@ -68,7 +86,7 @@ namespace CloudNative.CloudEvents.UnitTests
             var jsonFormatter = new JsonEventFormatter();
             var cloudEvent = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(json), new ComExampleExtension1Extension(),
                 new ComExampleExtension2Extension());
-            Assert.Equal("0.2", cloudEvent.SpecVersion);
+            Assert.Equal(CloudEventsSpecVersion.V0_2, cloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);

--- a/test/CloudNative.CloudEvents.UnitTests/MqttTests.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/MqttTests.cs
@@ -74,7 +74,7 @@ namespace CloudNative.CloudEvents.UnitTests
             await client.PublishAsync(new MqttCloudEventMessage(cloudEvent, new JsonEventFormatter()) { Topic = "abc" });
             var receivedCloudEvent = await tcs.Task;
 
-            Assert.Equal("0.2", receivedCloudEvent.SpecVersion);
+            Assert.Equal(CloudEventsSpecVersion.V0_2, receivedCloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
             Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);


### PR DESCRIPTION
Signed-off-by: clemensv <clemensv@microsoft.com>

This PR adds support for both 0.1 and 0.2 events and also allows to change the spec version on an event with automatic remapping of the underlying attribute names.