### PR TITLE
Add aspnet core support

### DIFF
--- a/CloudEvents.sln
+++ b/CloudEvents.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29001.49
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CloudNative.CloudEvents", "src\CloudNative.CloudEvents\CloudNative.CloudEvents.csproj", "{C5DC9F44-7C03-4A70-80EF-7A29696455EB}"
 EndProject
@@ -23,7 +23,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CloudNative.CloudEvents.Amq
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CloudNative.CloudEvents.Kafka", "src\CloudNative.CloudEvents.Kafka\CloudNative.CloudEvents.Kafka.csproj", "{193D6D9D-C1A0-459E-86CF-F207CDF0FC73}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CloudNative.CloudEvents.AspNetCore", "src\CloudNative.CloudEvents.AspNetCore\CloudNative.CloudEvents.AspNetCore.csproj", "{C726DD78-2D56-48D3-928A-D10226E3750B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CloudNative.CloudEvents.AspNetCore", "src\CloudNative.CloudEvents.AspNetCore\CloudNative.CloudEvents.AspNetCore.csproj", "{C726DD78-2D56-48D3-928A-D10226E3750B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CloudNative.CloudEvents.AspNetCoreSample", "samples\CloudNative.CloudEvents.AspNetCoreSample\CloudNative.CloudEvents.AspNetCoreSample.csproj", "{9760D744-D1BF-40E3-BD6F-7F639BFB9188}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CloudNative.CloudEvents.IntegrationTests", "test\CloudNative.CloudEvents.IntegrationTests\CloudNative.CloudEvents.IntegrationTests.csproj", "{9639E4FD-0438-4901-B57F-EFF773B19D5A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -121,7 +125,34 @@ Global
 		{C726DD78-2D56-48D3-928A-D10226E3750B}.Release|x64.Build.0 = Release|Any CPU
 		{C726DD78-2D56-48D3-928A-D10226E3750B}.Release|x86.ActiveCfg = Release|Any CPU
 		{C726DD78-2D56-48D3-928A-D10226E3750B}.Release|x86.Build.0 = Release|Any CPU
+<<<<<<< HEAD
 >>>>>>> dde2c54... add support for parsing ASP.NET Core HTTP requests into CloudEvents
+=======
+		{9760D744-D1BF-40E3-BD6F-7F639BFB9188}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9760D744-D1BF-40E3-BD6F-7F639BFB9188}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9760D744-D1BF-40E3-BD6F-7F639BFB9188}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9760D744-D1BF-40E3-BD6F-7F639BFB9188}.Debug|x64.Build.0 = Debug|Any CPU
+		{9760D744-D1BF-40E3-BD6F-7F639BFB9188}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9760D744-D1BF-40E3-BD6F-7F639BFB9188}.Debug|x86.Build.0 = Debug|Any CPU
+		{9760D744-D1BF-40E3-BD6F-7F639BFB9188}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9760D744-D1BF-40E3-BD6F-7F639BFB9188}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9760D744-D1BF-40E3-BD6F-7F639BFB9188}.Release|x64.ActiveCfg = Release|Any CPU
+		{9760D744-D1BF-40E3-BD6F-7F639BFB9188}.Release|x64.Build.0 = Release|Any CPU
+		{9760D744-D1BF-40E3-BD6F-7F639BFB9188}.Release|x86.ActiveCfg = Release|Any CPU
+		{9760D744-D1BF-40E3-BD6F-7F639BFB9188}.Release|x86.Build.0 = Release|Any CPU
+		{9639E4FD-0438-4901-B57F-EFF773B19D5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9639E4FD-0438-4901-B57F-EFF773B19D5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9639E4FD-0438-4901-B57F-EFF773B19D5A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9639E4FD-0438-4901-B57F-EFF773B19D5A}.Debug|x64.Build.0 = Debug|Any CPU
+		{9639E4FD-0438-4901-B57F-EFF773B19D5A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9639E4FD-0438-4901-B57F-EFF773B19D5A}.Debug|x86.Build.0 = Debug|Any CPU
+		{9639E4FD-0438-4901-B57F-EFF773B19D5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9639E4FD-0438-4901-B57F-EFF773B19D5A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9639E4FD-0438-4901-B57F-EFF773B19D5A}.Release|x64.ActiveCfg = Release|Any CPU
+		{9639E4FD-0438-4901-B57F-EFF773B19D5A}.Release|x64.Build.0 = Release|Any CPU
+		{9639E4FD-0438-4901-B57F-EFF773B19D5A}.Release|x86.ActiveCfg = Release|Any CPU
+		{9639E4FD-0438-4901-B57F-EFF773B19D5A}.Release|x86.Build.0 = Release|Any CPU
+>>>>>>> 66259c5... Added sample along with some integration tests
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CloudEvents.sln
+++ b/CloudEvents.sln
@@ -99,7 +99,6 @@ Global
 		{39EF4DB0-9890-4CAD-A36E-F7E25D2E72EF}.Release|x64.Build.0 = Release|Any CPU
 		{39EF4DB0-9890-4CAD-A36E-F7E25D2E72EF}.Release|x86.ActiveCfg = Release|Any CPU
 		{39EF4DB0-9890-4CAD-A36E-F7E25D2E72EF}.Release|x86.Build.0 = Release|Any CPU
-<<<<<<< HEAD
 		{193D6D9D-C1A0-459E-86CF-F207CDF0FC73}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{193D6D9D-C1A0-459E-86CF-F207CDF0FC73}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{193D6D9D-C1A0-459E-86CF-F207CDF0FC73}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -112,7 +111,6 @@ Global
 		{193D6D9D-C1A0-459E-86CF-F207CDF0FC73}.Release|x64.Build.0 = Release|Any CPU
 		{193D6D9D-C1A0-459E-86CF-F207CDF0FC73}.Release|x86.ActiveCfg = Release|Any CPU
 		{193D6D9D-C1A0-459E-86CF-F207CDF0FC73}.Release|x86.Build.0 = Release|Any CPU
-=======
 		{C726DD78-2D56-48D3-928A-D10226E3750B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C726DD78-2D56-48D3-928A-D10226E3750B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C726DD78-2D56-48D3-928A-D10226E3750B}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -125,9 +123,6 @@ Global
 		{C726DD78-2D56-48D3-928A-D10226E3750B}.Release|x64.Build.0 = Release|Any CPU
 		{C726DD78-2D56-48D3-928A-D10226E3750B}.Release|x86.ActiveCfg = Release|Any CPU
 		{C726DD78-2D56-48D3-928A-D10226E3750B}.Release|x86.Build.0 = Release|Any CPU
-<<<<<<< HEAD
->>>>>>> dde2c54... add support for parsing ASP.NET Core HTTP requests into CloudEvents
-=======
 		{9760D744-D1BF-40E3-BD6F-7F639BFB9188}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9760D744-D1BF-40E3-BD6F-7F639BFB9188}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9760D744-D1BF-40E3-BD6F-7F639BFB9188}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -152,7 +147,6 @@ Global
 		{9639E4FD-0438-4901-B57F-EFF773B19D5A}.Release|x64.Build.0 = Release|Any CPU
 		{9639E4FD-0438-4901-B57F-EFF773B19D5A}.Release|x86.ActiveCfg = Release|Any CPU
 		{9639E4FD-0438-4901-B57F-EFF773B19D5A}.Release|x86.Build.0 = Release|Any CPU
->>>>>>> 66259c5... Added sample along with some integration tests
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CloudEvents.sln
+++ b/CloudEvents.sln
@@ -23,6 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CloudNative.CloudEvents.Amq
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CloudNative.CloudEvents.Kafka", "src\CloudNative.CloudEvents.Kafka\CloudNative.CloudEvents.Kafka.csproj", "{193D6D9D-C1A0-459E-86CF-F207CDF0FC73}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CloudNative.CloudEvents.AspNetCore", "src\CloudNative.CloudEvents.AspNetCore\CloudNative.CloudEvents.AspNetCore.csproj", "{C726DD78-2D56-48D3-928A-D10226E3750B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -93,6 +95,7 @@ Global
 		{39EF4DB0-9890-4CAD-A36E-F7E25D2E72EF}.Release|x64.Build.0 = Release|Any CPU
 		{39EF4DB0-9890-4CAD-A36E-F7E25D2E72EF}.Release|x86.ActiveCfg = Release|Any CPU
 		{39EF4DB0-9890-4CAD-A36E-F7E25D2E72EF}.Release|x86.Build.0 = Release|Any CPU
+<<<<<<< HEAD
 		{193D6D9D-C1A0-459E-86CF-F207CDF0FC73}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{193D6D9D-C1A0-459E-86CF-F207CDF0FC73}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{193D6D9D-C1A0-459E-86CF-F207CDF0FC73}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -105,6 +108,20 @@ Global
 		{193D6D9D-C1A0-459E-86CF-F207CDF0FC73}.Release|x64.Build.0 = Release|Any CPU
 		{193D6D9D-C1A0-459E-86CF-F207CDF0FC73}.Release|x86.ActiveCfg = Release|Any CPU
 		{193D6D9D-C1A0-459E-86CF-F207CDF0FC73}.Release|x86.Build.0 = Release|Any CPU
+=======
+		{C726DD78-2D56-48D3-928A-D10226E3750B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C726DD78-2D56-48D3-928A-D10226E3750B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C726DD78-2D56-48D3-928A-D10226E3750B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C726DD78-2D56-48D3-928A-D10226E3750B}.Debug|x64.Build.0 = Debug|Any CPU
+		{C726DD78-2D56-48D3-928A-D10226E3750B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C726DD78-2D56-48D3-928A-D10226E3750B}.Debug|x86.Build.0 = Debug|Any CPU
+		{C726DD78-2D56-48D3-928A-D10226E3750B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C726DD78-2D56-48D3-928A-D10226E3750B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C726DD78-2D56-48D3-928A-D10226E3750B}.Release|x64.ActiveCfg = Release|Any CPU
+		{C726DD78-2D56-48D3-928A-D10226E3750B}.Release|x64.Build.0 = Release|Any CPU
+		{C726DD78-2D56-48D3-928A-D10226E3750B}.Release|x86.ActiveCfg = Release|Any CPU
+		{C726DD78-2D56-48D3-928A-D10226E3750B}.Release|x86.Build.0 = Release|Any CPU
+>>>>>>> dde2c54... add support for parsing ASP.NET Core HTTP requests into CloudEvents
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CloudEvents.v3.ncrunchsolution
+++ b/CloudEvents.v3.ncrunchsolution
@@ -1,0 +1,6 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <AllowParallelTestExecution>False</AllowParallelTestExecution>
+    <SolutionConfigured>True</SolutionConfigured>
+  </Settings>
+</SolutionConfiguration>

--- a/README.md
+++ b/README.md
@@ -224,14 +224,14 @@ var cloudEvent = await HttpContext.Request.ReadCloudEventAsync();
 ### HTTP - ASP.NET Core MVC
 
 If you would like to deserialize CloudEvents in actions directly, you can register the
-`CloudEventInputFormatter` in the MVC options:
+`CloudEventJsonInputFormatter` in the MVC options:
 
 ```C#
 public void ConfigureServices(IServiceCollection services)
 {
     services.AddMvc(opts =>
     {
-        opts.InputFormatters.Insert(0, new CloudEventInputFormatter());
+        opts.InputFormatters.Insert(0, new CloudEventJsonInputFormatter());
     });
 }
 ```

--- a/README.md
+++ b/README.md
@@ -212,6 +212,42 @@ await context.Response.CopyFromAsync(cloudEvent,
 context.Response.StatusCode = (int)HttpStatusCode.OK; 
 ```
 
+### HTTP - Microsoft.AspNetCore.Http.HttpRequest
+
+On the server-side, you can extract a CloudEvent from the server-side `HttpRequest` 
+with the `ToCloudEvent()` extension.
+
+```C#
+var cloudEvent = HttpContext.Request.ToCloudEvent();
+``` 
+
+### HTTP - ASP.Net Core MVC
+
+If you would like to deserialize CloudEvents in actions directly, you can register the
+`CloudEventInputFormatter` in the MVC options:
+
+```C#
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddMvc(opts =>
+    {
+        opts.InputFormatters.Insert(0, new CloudEventInputFormatter());
+    });
+}
+```
+
+This formatter will only intercept parameters where CloudEvent is the expected type.
+
+You can then receive CloudEvent objects in controller actions:
+
+```C#
+[HttpPost("resource")]
+public IActionResult ReceiveCloudEvent([FromBody] CloudEvent cloudEvent)
+{
+    return Ok();
+}
+```
+
 ### AMQP
 
 The SDK provides extensions for the [AMQPNetLite](https://github.com/Azure/amqpnetlite) package. 

--- a/README.md
+++ b/README.md
@@ -215,13 +215,13 @@ context.Response.StatusCode = (int)HttpStatusCode.OK;
 ### HTTP - Microsoft.AspNetCore.Http.HttpRequest
 
 On the server-side, you can extract a CloudEvent from the server-side `HttpRequest` 
-with the `ToCloudEvent()` extension.
+with the `ReadCloudEventAsync()` extension.
 
 ```C#
-var cloudEvent = HttpContext.Request.ToCloudEvent();
+var cloudEvent = await HttpContext.Request.ReadCloudEventAsync();
 ``` 
 
-### HTTP - ASP.Net Core MVC
+### HTTP - ASP.NET Core MVC
 
 If you would like to deserialize CloudEvents in actions directly, you can register the
 `CloudEventInputFormatter` in the MVC options:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 # main branch
 version: 0.9.{build}
 clone_depth: 15
+image: Visual Studio 2019
 
 branches:
    only:

--- a/samples/CloudNative.CloudEvents.AspNetCoreSample/CloudNative.CloudEvents.AspNetCoreSample.csproj
+++ b/samples/CloudNative.CloudEvents.AspNetCoreSample/CloudNative.CloudEvents.AspNetCoreSample.csproj
@@ -1,14 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\CloudNative.CloudEvents.AspNetCore\CloudNative.CloudEvents.AspNetCore.csproj" />

--- a/samples/CloudNative.CloudEvents.AspNetCoreSample/CloudNative.CloudEvents.AspNetCoreSample.csproj
+++ b/samples/CloudNative.CloudEvents.AspNetCoreSample/CloudNative.CloudEvents.AspNetCoreSample.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\CloudNative.CloudEvents.AspNetCore\CloudNative.CloudEvents.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\src\CloudNative.CloudEvents\CloudNative.CloudEvents.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/CloudNative.CloudEvents.AspNetCoreSample/Controllers/CloudEventController.cs
+++ b/samples/CloudNative.CloudEvents.AspNetCoreSample/Controllers/CloudEventController.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Cloud Native Foundation. 
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+namespace CloudNative.CloudEvents.AspNetCoreSample.Controllers
+{
+    using System.Collections.Generic;
+    using CloudNative.CloudEvents;
+    using Microsoft.AspNetCore.Mvc;
+
+    [Route("api/events")]
+    [ApiController]
+    public class CloudEventController : ControllerBase
+    {
+        [HttpPost("receive")]
+        public ActionResult<IEnumerable<string>> ReceiveCloudEvent([FromBody] CloudEvent cloudEvent)
+        {
+            return Ok($"Received event with ID {cloudEvent.Id}");
+        }
+    }
+}

--- a/samples/CloudNative.CloudEvents.AspNetCoreSample/Controllers/CloudEventController.cs
+++ b/samples/CloudNative.CloudEvents.AspNetCoreSample/Controllers/CloudEventController.cs
@@ -7,6 +7,7 @@ namespace CloudNative.CloudEvents.AspNetCoreSample.Controllers
     using System.Collections.Generic;
     using CloudNative.CloudEvents;
     using Microsoft.AspNetCore.Mvc;
+    using Newtonsoft.Json;
 
     [Route("api/events")]
     [ApiController]
@@ -15,7 +16,7 @@ namespace CloudNative.CloudEvents.AspNetCoreSample.Controllers
         [HttpPost("receive")]
         public ActionResult<IEnumerable<string>> ReceiveCloudEvent([FromBody] CloudEvent cloudEvent)
         {
-            return Ok($"Received event with ID {cloudEvent.Id}");
+            return Ok($"Received event with ID {cloudEvent.Id}, attributes: {JsonConvert.SerializeObject(cloudEvent.GetAttributes())}");
         }
     }
 }

--- a/samples/CloudNative.CloudEvents.AspNetCoreSample/Program.cs
+++ b/samples/CloudNative.CloudEvents.AspNetCoreSample/Program.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Cloud Native Foundation. 
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+namespace CloudNative.CloudEvents.AspNetCoreSample
+{
+    using Microsoft.AspNetCore;
+    using Microsoft.AspNetCore.Hosting;
+
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateWebHostBuilder(args).Build().Run();
+        }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>();
+    }
+}

--- a/samples/CloudNative.CloudEvents.AspNetCoreSample/Properties/launchSettings.json
+++ b/samples/CloudNative.CloudEvents.AspNetCoreSample/Properties/launchSettings.json
@@ -1,0 +1,19 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:64908",
+      "sslPort": 0
+    }
+  },
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/CloudNative.CloudEvents.AspNetCoreSample/Startup.cs
+++ b/samples/CloudNative.CloudEvents.AspNetCoreSample/Startup.cs
@@ -25,7 +25,7 @@ namespace CloudNative.CloudEvents.AspNetCoreSample
         {
             services.AddControllers(opts =>
             {
-                opts.InputFormatters.Insert(0, new CloudEventInputFormatter());
+                opts.InputFormatters.Insert(0, new CloudEventJsonInputFormatter());
             });
         }
 

--- a/samples/CloudNative.CloudEvents.AspNetCoreSample/Startup.cs
+++ b/samples/CloudNative.CloudEvents.AspNetCoreSample/Startup.cs
@@ -9,6 +9,7 @@ namespace CloudNative.CloudEvents.AspNetCoreSample
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
 
     public class Startup
     {
@@ -22,21 +23,26 @@ namespace CloudNative.CloudEvents.AspNetCoreSample
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc(opts =>
+            services.AddControllers(opts =>
             {
                 opts.InputFormatters.Insert(0, new CloudEventInputFormatter());
             });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseMvc();
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
         }
     }
 }

--- a/samples/CloudNative.CloudEvents.AspNetCoreSample/Startup.cs
+++ b/samples/CloudNative.CloudEvents.AspNetCoreSample/Startup.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Cloud Native Foundation. 
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+namespace CloudNative.CloudEvents.AspNetCoreSample
+{
+    using CloudNative.CloudEvents;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc(opts =>
+            {
+                opts.InputFormatters.Insert(0, new CloudEventInputFormatter());
+            });
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseMvc();
+        }
+    }
+}

--- a/samples/CloudNative.CloudEvents.AspNetCoreSample/appsettings.Development.json
+++ b/samples/CloudNative.CloudEvents.AspNetCoreSample/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/samples/CloudNative.CloudEvents.AspNetCoreSample/appsettings.json
+++ b/samples/CloudNative.CloudEvents.AspNetCoreSample/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/CloudNative.CloudEvents.AspNetCore/CloudEventInputFormatter.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/CloudEventInputFormatter.cs
@@ -35,9 +35,15 @@ namespace CloudNative.CloudEvents
 
             var request = context.HttpContext.Request;
 
-            var cloudEvent = request.ToCloudEvent(new JsonEventFormatter());
-
-            return InputFormatterResult.SuccessAsync(cloudEvent);
+            try
+            {
+                var cloudEvent = request.ToCloudEvent();
+                return InputFormatterResult.SuccessAsync(cloudEvent);
+            }
+            catch (Exception)
+            {
+                return InputFormatterResult.FailureAsync();
+            }
         }
 
         protected override bool CanReadType(Type type)

--- a/src/CloudNative.CloudEvents.AspNetCore/CloudEventInputFormatter.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/CloudEventInputFormatter.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Cloud Native Foundation. 
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+namespace CloudNative.CloudEvents
+{
+    using System;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Mvc.Formatters;
+    using Microsoft.Net.Http.Headers;
+
+    public class CloudEventInputFormatter : TextInputFormatter
+    {
+        public CloudEventInputFormatter()
+        {
+            SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/json"));
+            SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/cloudevents"));
+
+            SupportedEncodings.Add(Encoding.UTF8);
+            SupportedEncodings.Add(Encoding.Unicode);
+        }
+
+        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context, Encoding encoding)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (encoding == null)
+            {
+                throw new ArgumentNullException(nameof(encoding));
+            }
+
+            var request = context.HttpContext.Request;
+
+            var cloudEvent = request.ToCloudEvent(new JsonEventFormatter());
+
+            return InputFormatterResult.SuccessAsync(cloudEvent);
+        }
+
+        protected override bool CanReadType(Type type)
+        {
+            if (type == typeof(CloudEvent))
+            {
+                return base.CanReadType(type);
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/CloudNative.CloudEvents.AspNetCore/CloudEventInputFormatter.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/CloudEventInputFormatter.cs
@@ -21,7 +21,7 @@ namespace CloudNative.CloudEvents
             SupportedEncodings.Add(Encoding.Unicode);
         }
 
-        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context, Encoding encoding)
+        public override async Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context, Encoding encoding)
         {
             if (context == null)
             {
@@ -37,12 +37,12 @@ namespace CloudNative.CloudEvents
 
             try
             {
-                var cloudEvent = request.ToCloudEvent();
-                return InputFormatterResult.SuccessAsync(cloudEvent);
+                var cloudEvent = await request.ReadCloudEventAsync();
+                return await InputFormatterResult.SuccessAsync(cloudEvent);
             }
             catch (Exception)
             {
-                return InputFormatterResult.FailureAsync();
+                return await InputFormatterResult.FailureAsync();
             }
         }
 

--- a/src/CloudNative.CloudEvents.AspNetCore/CloudEventJsonInputFormatter.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/CloudEventJsonInputFormatter.cs
@@ -15,7 +15,7 @@ namespace CloudNative.CloudEvents
         public CloudEventJsonInputFormatter()
         {
             SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/json"));
-            SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/cloudevents"));
+            SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/cloudevents+json"));
 
             SupportedEncodings.Add(Encoding.UTF8);
             SupportedEncodings.Add(Encoding.Unicode);

--- a/src/CloudNative.CloudEvents.AspNetCore/CloudEventJsonInputFormatter.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/CloudEventJsonInputFormatter.cs
@@ -10,9 +10,9 @@ namespace CloudNative.CloudEvents
     using Microsoft.AspNetCore.Mvc.Formatters;
     using Microsoft.Net.Http.Headers;
 
-    public class CloudEventInputFormatter : TextInputFormatter
+    public class CloudEventJsonInputFormatter : TextInputFormatter
     {
-        public CloudEventInputFormatter()
+        public CloudEventJsonInputFormatter()
         {
             SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/json"));
             SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/cloudevents"));

--- a/src/CloudNative.CloudEvents.AspNetCore/CloudNative.CloudEvents.AspNetCore.csproj
+++ b/src/CloudNative.CloudEvents.AspNetCore/CloudNative.CloudEvents.AspNetCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CloudNative.CloudEvents\CloudNative.CloudEvents.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/CloudNative.CloudEvents.AspNetCore/CloudNative.CloudEvents.AspNetCore.csproj
+++ b/src/CloudNative.CloudEvents.AspNetCore/CloudNative.CloudEvents.AspNetCore.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CloudNative.CloudEvents.AspNetCore/CloudNative.CloudEvents.AspNetCore.csproj
+++ b/src/CloudNative.CloudEvents.AspNetCore/CloudNative.CloudEvents.AspNetCore.csproj
@@ -1,7 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageVersion>0.1</PackageVersion>
+    <Description>ASP.Net Core extensions for CloudNative.CloudEvents</Description>
+    <Copyright>Copyright Cloud Native Foundation</Copyright>
+    <RepositoryUrl>https://github.com/cloudevents/sdk-csharp</RepositoryUrl>
+    <PackageProjectUrl>https://cloudevents.io</PackageProjectUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CloudNative.CloudEvents.AspNetCore/CloudNative.CloudEvents.AspNetCore.csproj
+++ b/src/CloudNative.CloudEvents.AspNetCore/CloudNative.CloudEvents.AspNetCore.csproj
@@ -5,7 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtension.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtension.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) Cloud Native Foundation. 
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+namespace CloudNative.CloudEvents
+{
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Primitives;
+    using Newtonsoft.Json;
+    using System;
+    using System.Net.Mime;
+
+    public static class HttpRequestExtension
+    {
+        const string HttpHeaderPrefix = "ce-";
+
+        const string SpecVersionHttpHeader1 = HttpHeaderPrefix + "cloudEventsVersion";
+
+        const string SpecVersionHttpHeader2 = HttpHeaderPrefix + "specversion";
+
+        static JsonEventFormatter jsonFormatter = new JsonEventFormatter();
+
+        /// <summary>
+        /// Converts this HTTP request into a CloudEvent object, with the given extensions.
+        /// </summary>
+        /// <param name="httpRequest">HTTP request</param>
+        /// <param name="extensions">List of extension instances</param>
+        /// <returns>A CloudEvent instance or 'null' if the request message doesn't hold a CloudEvent</returns>
+        public static CloudEvent ToCloudEvent(this HttpRequest httpRequest,
+            params ICloudEventExtension[] extensions)
+        {
+            return ToCloudEvent(httpRequest, null, extensions);
+        }
+
+        /// <summary>
+        /// Converts this HTTP request into a CloudEvent object, with the given extensions,
+        /// overriding the formatter.
+        /// </summary>
+        /// <param name="httpRequest">HTTP request</param>
+        /// <param name="formatter"></param>
+        /// <param name="extensions">List of extension instances</param>
+        /// <returns>A CloudEvent instance or 'null' if the request message doesn't hold a CloudEvent</returns>
+        public static CloudEvent ToCloudEvent(this HttpRequest httpRequest,
+            ICloudEventFormatter formatter = null,
+            params ICloudEventExtension[] extensions)
+        {
+            if (httpRequest.ContentType != null &&
+                httpRequest.ContentType.StartsWith(CloudEvent.MediaType,
+                    StringComparison.InvariantCultureIgnoreCase))
+            {
+                // handle structured mode
+                if (formatter == null)
+                {
+                    // if we didn't get a formatter, pick one
+                    if (httpRequest.ContentType.EndsWith(JsonEventFormatter.MediaTypeSuffix,
+                        StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        formatter = jsonFormatter;
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException("Unsupported CloudEvents encoding");
+                    }
+                }
+
+                return formatter.DecodeStructuredEvent(httpRequest.Body, extensions);
+            }
+            else
+            {
+                CloudEventsSpecVersion version = CloudEventsSpecVersion.Default;
+                if (httpRequest.Headers[SpecVersionHttpHeader1] != StringValues.Empty)
+                {
+                    version = CloudEventsSpecVersion.V0_1;
+                }
+
+                if (httpRequest.Headers[SpecVersionHttpHeader2] != StringValues.Empty)
+                {
+                    version = httpRequest.Headers[SpecVersionHttpHeader2] == "0.2"
+                        ? CloudEventsSpecVersion.V0_2
+                        : CloudEventsSpecVersion.Default;
+                }
+
+                var cloudEvent = new CloudEvent(version, extensions);
+                var attributes = cloudEvent.GetAttributes();
+                foreach (var httpRequestHeader in httpRequest.Headers.Keys)
+                {
+                    if (httpRequestHeader.Equals(SpecVersionHttpHeader1,
+                            StringComparison.InvariantCultureIgnoreCase) ||
+                        httpRequestHeader.Equals(SpecVersionHttpHeader2, StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    if (httpRequestHeader.StartsWith(HttpHeaderPrefix, StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        string headerValue = httpRequest.Headers[httpRequestHeader];
+                        if (headerValue.StartsWith("{") && headerValue.EndsWith("}") ||
+                            headerValue.StartsWith("[") && headerValue.EndsWith("]"))
+                        {
+                            attributes[httpRequestHeader.Substring(3)] =
+                                JsonConvert.DeserializeObject(headerValue);
+                        }
+                        else
+                        {
+                            attributes[httpRequestHeader.Substring(3)] = headerValue;
+                            attributes[httpRequestHeader.Substring(3)] = headerValue;
+                        }
+                    }
+                }
+
+                cloudEvent.ContentType = httpRequest.ContentType != null
+                    ? new ContentType(httpRequest.ContentType)
+                    : null;
+                cloudEvent.Data = httpRequest.Body;
+                return cloudEvent;
+            }
+        }
+
+    }
+}

--- a/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtension.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtension.cs
@@ -75,9 +75,18 @@ namespace CloudNative.CloudEvents
 
                 if (httpRequest.Headers[SpecVersionHttpHeader2] != StringValues.Empty)
                 {
-                    version = httpRequest.Headers[SpecVersionHttpHeader2] == "0.2"
-                        ? CloudEventsSpecVersion.V0_2
-                        : CloudEventsSpecVersion.Default;
+                    switch (httpRequest.Headers[SpecVersionHttpHeader2])
+                    {
+                        case "0.2":
+                            version = CloudEventsSpecVersion.V0_2;
+                            break;
+                        case "0.3":
+                            version = CloudEventsSpecVersion.V0_3;
+                            break;
+                        default:
+                            version = CloudEventsSpecVersion.Default;
+                            break;
+                    }
                 }
 
                 var cloudEvent = new CloudEvent(version, extensions);
@@ -108,7 +117,7 @@ namespace CloudNative.CloudEvents
                     }
                 }
 
-                cloudEvent.ContentType = httpRequest.ContentType != null
+                cloudEvent.DataContentType = httpRequest.ContentType != null
                     ? new ContentType(httpRequest.ContentType)
                     : null;
                 cloudEvent.Data = httpRequest.Body;

--- a/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtension.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtension.cs
@@ -8,7 +8,9 @@ namespace CloudNative.CloudEvents
     using Microsoft.Extensions.Primitives;
     using Newtonsoft.Json;
     using System;
+    using System.IO;
     using System.Net.Mime;
+    using System.Text;
     using System.Threading.Tasks;
 
     public static class HttpRequestExtension
@@ -122,7 +124,7 @@ namespace CloudNative.CloudEvents
                 cloudEvent.DataContentType = httpRequest.ContentType != null
                     ? new ContentType(httpRequest.ContentType)
                     : null;
-                cloudEvent.Data = httpRequest.Body;
+                cloudEvent.Data = await new StreamReader(httpRequest.Body, Encoding.UTF8).ReadToEndAsync();
                 return cloudEvent;
             }
         }

--- a/src/CloudNative.CloudEvents/CloudEvent.cs
+++ b/src/CloudNative.CloudEvents/CloudEvent.cs
@@ -69,7 +69,7 @@ namespace CloudNative.CloudEvents
         /// </summary>
         /// <param name="specVersion">CloudEvents specification version</param>
         /// <param name="extensions">Extensions to be added to this CloudEvents</param>
-        internal CloudEvent(CloudEventsSpecVersion specVersion, IEnumerable<ICloudEventExtension> extensions)
+        public CloudEvent(CloudEventsSpecVersion specVersion, IEnumerable<ICloudEventExtension> extensions)
         {
             attributes = new CloudEventAttributes(specVersion, extensions);
             this.Extensions = new Dictionary<Type, ICloudEventExtension>();

--- a/src/CloudNative.CloudEvents/ICloudEventFormatter.cs
+++ b/src/CloudNative.CloudEvents/ICloudEventFormatter.cs
@@ -7,6 +7,7 @@ namespace CloudNative.CloudEvents
     using System.Collections.Generic;
     using System.IO;
     using System.Net.Mime;
+    using System.Threading.Tasks;
 
 
     /// <summary>
@@ -21,6 +22,13 @@ namespace CloudNative.CloudEvents
         /// <param name="extensions"></param>
         /// <returns></returns>
         CloudEvent DecodeStructuredEvent(Stream data, IEnumerable<ICloudEventExtension> extensions);
+        /// <summary>
+        /// Decode a structured event from a stream asynchonously
+        /// </summary>
+        /// <param name="data"></param>
+        /// <param name="extensions"></param>
+        /// <returns></returns>
+        Task<CloudEvent> DecodeStructuredEventAsync(Stream data, IEnumerable<ICloudEventExtension> extensions);
         /// <summary>
         /// Decode a structured event from a byte array
         /// </summary>

--- a/src/CloudNative.CloudEvents/JsonEventFormatter.cs
+++ b/src/CloudNative.CloudEvents/JsonEventFormatter.cs
@@ -5,12 +5,12 @@
 namespace CloudNative.CloudEvents
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using System.Net.Mime;
     using System.Text;
+    using System.Threading.Tasks;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
 
@@ -25,6 +25,13 @@ namespace CloudNative.CloudEvents
         public CloudEvent DecodeStructuredEvent(Stream data, params ICloudEventExtension[] extensions)
         {
             return DecodeStructuredEvent(data, (IEnumerable<ICloudEventExtension>)extensions);
+        }
+
+        public async Task<CloudEvent> DecodeStructuredEventAsync(Stream data, IEnumerable<ICloudEventExtension> extensions)
+        {
+            var jsonReader = new JsonTextReader(new StreamReader(data, Encoding.UTF8, true, 8192, true));
+            var jObject = await JObject.LoadAsync(jsonReader);
+            return DecodeJObject(jObject, extensions);
         }
 
         public CloudEvent DecodeStructuredEvent(Stream data, IEnumerable<ICloudEventExtension> extensions = null)

--- a/test/CloudNative.CloudEvents.IntegrationTests/AspNetCore/CloudEventControllerTests.cs
+++ b/test/CloudNative.CloudEvents.IntegrationTests/AspNetCore/CloudEventControllerTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Cloud Native Foundation. 
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+namespace CloudNative.CloudEvents.IntegrationTests.AspNetCore
+{
+    using System;
+    using System.Net;
+    using System.Threading.Tasks;
+    using CloudNative.CloudEvents.AspNetCoreSample;
+    using Microsoft.AspNetCore.Mvc.Testing;
+    using Xunit;
+
+    public class CloudEventControllerTests : IClassFixture<WebApplicationFactory<Startup>>
+    {
+        private readonly WebApplicationFactory<Startup> _factory;
+
+        public CloudEventControllerTests(WebApplicationFactory<Startup> factory)
+        {
+            _factory = factory;
+        }
+
+        [Fact]
+        public async Task Controller_WithValidCloudEvent_DeserializesUsingPipeline()
+        {
+            // Arrange
+            var cloudEvent = new CloudEvent("test-type", new Uri("urn:integration-tests"))
+            {
+                Id = Guid.NewGuid().ToString(),
+            };
+            var content = new CloudEventContent(cloudEvent, ContentMode.Structured, new JsonEventFormatter());
+
+            // Act
+            var result = await _factory.CreateClient().PostAsync("/api/events/receive", content);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+            Assert.Contains(cloudEvent.Id, await result.Content.ReadAsStringAsync());
+        }
+    }
+}

--- a/test/CloudNative.CloudEvents.IntegrationTests/AspNetCore/CloudEventControllerTests.cs
+++ b/test/CloudNative.CloudEvents.IntegrationTests/AspNetCore/CloudEventControllerTests.cs
@@ -24,10 +24,15 @@ namespace CloudNative.CloudEvents.IntegrationTests.AspNetCore
         public async Task Controller_WithValidCloudEvent_DeserializesUsingPipeline()
         {
             // Arrange
+            var expectedExtensionKey = "comexampleextension1";
+            var expectedExtensionValue = Guid.NewGuid().ToString();
             var cloudEvent = new CloudEvent("test-type", new Uri("urn:integration-tests"))
             {
                 Id = Guid.NewGuid().ToString(),
             };
+            var attrs = cloudEvent.GetAttributes();
+            attrs[expectedExtensionKey] = expectedExtensionValue;
+
             var content = new CloudEventContent(cloudEvent, ContentMode.Structured, new JsonEventFormatter());
 
             // Act
@@ -36,6 +41,7 @@ namespace CloudNative.CloudEvents.IntegrationTests.AspNetCore
             // Assert
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
             Assert.Contains(cloudEvent.Id, await result.Content.ReadAsStringAsync());
+            Assert.Contains($"\"{expectedExtensionKey}\":\"{expectedExtensionValue}\"", await result.Content.ReadAsStringAsync());
         }
     }
 }

--- a/test/CloudNative.CloudEvents.IntegrationTests/AspNetCore/CloudEventControllerTests.cs
+++ b/test/CloudNative.CloudEvents.IntegrationTests/AspNetCore/CloudEventControllerTests.cs
@@ -6,6 +6,7 @@ namespace CloudNative.CloudEvents.IntegrationTests.AspNetCore
 {
     using System;
     using System.Net;
+    using System.Net.Http.Headers;
     using System.Threading.Tasks;
     using CloudNative.CloudEvents.AspNetCoreSample;
     using Microsoft.AspNetCore.Mvc.Testing;
@@ -20,8 +21,10 @@ namespace CloudNative.CloudEvents.IntegrationTests.AspNetCore
             _factory = factory;
         }
 
-        [Fact]
-        public async Task Controller_WithValidCloudEvent_DeserializesUsingPipeline()
+        [Theory]
+        [InlineData("application/cloudevents+json")]
+        [InlineData("application/json")]
+        public async Task Controller_WithValidCloudEvent_DeserializesUsingPipeline(string contentType)
         {
             // Arrange
             var expectedExtensionKey = "comexampleextension1";
@@ -34,6 +37,7 @@ namespace CloudNative.CloudEvents.IntegrationTests.AspNetCore
             attrs[expectedExtensionKey] = expectedExtensionValue;
 
             var content = new CloudEventContent(cloudEvent, ContentMode.Structured, new JsonEventFormatter());
+            content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
 
             // Act
             var result = await _factory.CreateClient().PostAsync("/api/events/receive", content);

--- a/test/CloudNative.CloudEvents.IntegrationTests/CloudNative.CloudEvents.IntegrationTests.csproj
+++ b/test/CloudNative.CloudEvents.IntegrationTests/CloudNative.CloudEvents.IntegrationTests.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\samples\CloudNative.CloudEvents.AspNetCoreSample\CloudNative.CloudEvents.AspNetCoreSample.csproj" />
+    <ProjectReference Include="..\..\src\CloudNative.CloudEvents\CloudNative.CloudEvents.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/CloudNative.CloudEvents.IntegrationTests/CloudNative.CloudEvents.IntegrationTests.csproj
+++ b/test/CloudNative.CloudEvents.IntegrationTests/CloudNative.CloudEvents.IntegrationTests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/test/CloudNative.CloudEvents.IntegrationTests/CloudNative.CloudEvents.IntegrationTests.csproj
+++ b/test/CloudNative.CloudEvents.IntegrationTests/CloudNative.CloudEvents.IntegrationTests.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/test/CloudNative.CloudEvents.IntegrationTests/Properties/launchSettings.json
+++ b/test/CloudNative.CloudEvents.IntegrationTests/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:65094/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "CloudNative.CloudEvents.IntegrationTests": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:65095/"
+    }
+  }
+}


### PR DESCRIPTION
Hi!

I took the changes made by @friism, updated for 0.3 and added an input formatter for the MVC pipeline.

I believe this is a change that will make CloudEvents much easier to consume, instead of having to receive the wrong type only to deserialize yourself (as mentioned in #20).

I've outlined the new process in the README.md file.

Open to suggestions if you have any.

Hope this change is a welcome one, and can be merged. :)