### PR TITLE
README - Fixe some little errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ it as a 0.3 event.
 | cloudEventsVersion | specversion | specversion | `CloudEvent.SpecVersion` | `System.String` 
 | eventTime | time | time | `CloudEvent.Time` | `System.DateTime` 
 | source | source | source | `CloudEvent.Source` | `System.Uri` 
-| - | - | subject | `CloudEvent.Source` | `System.String` 
+| - | - | subject | `CloudEvent.Subject` | `System.String` 
 | schemaUrl | schemaurl | schemaurl | `CloudEvent.SchemaUrl` | `System.Uri`
 | contentType | contenttype | datacontenttype | `CloudEvent.ContentType` | `System.Net.Mime.ContentType` 
 | - | - | datacontentencoding | `CloudEvent.DataContentEncoding` | `System.String` | 
@@ -216,8 +216,8 @@ context.Response.StatusCode = (int)HttpStatusCode.OK;
 
 The SDK provides extensions for the [AMQPNetLite](https://github.com/Azure/amqpnetlite) package. 
 
-For AMQP support, you must reference the `CloudNative.CloudEvents.Mqtt` assembly and 
-reference the namespace in your code with `using CloudNative.CloudEvents.Mqtt`.
+For AMQP support, you must reference the `CloudNative.CloudEvents.Amqp` assembly and 
+reference the namespace in your code with `using CloudNative.CloudEvents.Amqp`.
 
 The `AmqpCloudEventMessage` extends the `AMQPNetLite.Message` class. The constructor
 allows creating a new AMQP message that holds a CloudEvent in either structured or binary 


### PR DESCRIPTION
There was :
- a bad reference to the `CloudNative.CloudEvents.Amqp` namespace, 
- the `Subject` property of type `CloudEvent` was not correcly pointed in the 'Property name' column of the table.

I saw the issues while reading the README