### PR TITLE
v1.0 support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # main branch
-version: 0.1.{build}
+version: 0.9.{build}
 clone_depth: 15
 
 branches:

--- a/src/CloudNative.CloudEvents.Amqp/AmqpClientExtensions.cs
+++ b/src/CloudNative.CloudEvents.Amqp/AmqpClientExtensions.cs
@@ -79,7 +79,7 @@ namespace CloudNative.CloudEvents.Amqp
                     if (prop.Key is string &&
                         ((string)prop.Key).StartsWith(AmqpHeaderPrefix, StringComparison.InvariantCultureIgnoreCase))
                     {
-                        if (prop.Value is Map)
+                        if (cloudEvent.SpecVersion != CloudEventsSpecVersion.V1_0 && prop.Value is Map)
                         {
                             IDictionary<string, object> exp = new ExpandoObject();
                             foreach (var props in (Map)prop.Value)

--- a/src/CloudNative.CloudEvents/CloudEvent.cs
+++ b/src/CloudNative.CloudEvents/CloudEvent.cs
@@ -88,28 +88,11 @@ namespace CloudNative.CloudEvents
         /// This attribute enables the data attribute to carry any type of content, whereby
         /// format and encoding might differ from that of the chosen event format.
         /// </summary>
-        /// <see cref="https://github.com/cloudevents/spec/blob/master/spec.md#datacontenttype"/>
+        /// <see cref="https://github.com/cloudevents/spec/blob/master/spec.md#contenttype"/>
         public ContentType DataContentType
         {
             get => attributes[CloudEventAttributes.DataContentTypeAttributeName(attributes.SpecVersion)] as ContentType;
             set => attributes[CloudEventAttributes.DataContentTypeAttributeName(attributes.SpecVersion)] = value;
-        }
-
-        /// <summary>
-        /// CloudEvent 'datacontentencoding' attribute.
-        /// </summary>
-        /// <see cref="https://github.com/cloudevents/spec/blob/master/spec.md#datacontentencoding"/>
-        public string DataContentEncoding
-        {
-            get => attributes[CloudEventAttributes.DataContentEncodingAttributeName(attributes.SpecVersion)] as string;
-            set => attributes[CloudEventAttributes.DataContentEncodingAttributeName(attributes.SpecVersion)] = value;
-        }
-
-        [Obsolete("Cloud events 0.1 and 0.2 name replaced by 'DataContentType1'. Will be removed in an upcoming release.")]
-        public ContentType ContentType
-        {
-            get => DataContentType;
-            set => DataContentType = value;
         }
 
         /// <summary>
@@ -146,20 +129,10 @@ namespace CloudNative.CloudEvents
         /// different URL.
         /// </summary>
         /// <see cref="https://github.com/cloudevents/spec/blob/master/spec.md#schemaurl"/>
-        public Uri SchemaUrl
+        public Uri DataSchema
         {
-            get => attributes[CloudEventAttributes.SchemaUrlAttributeName(attributes.SpecVersion)] as Uri;
-            set => attributes[CloudEventAttributes.SchemaUrlAttributeName(attributes.SpecVersion)] = value;
-        }
-
-        /// <summary>
-        /// CloudEvents 'subject' attribute. 
-        /// </summary>
-        /// <see cref="https://github.com/cloudevents/spec/blob/master/spec.md#subject"/>
-        public string Subject
-        {
-            get => attributes[CloudEventAttributes.SubjectAttributeName(attributes.SpecVersion)] as string;
-            set => attributes[CloudEventAttributes.SubjectAttributeName(attributes.SpecVersion)] = value;
+            get => attributes[CloudEventAttributes.DataSchemaAttributeName(attributes.SpecVersion)] as Uri;
+            set => attributes[CloudEventAttributes.DataSchemaAttributeName(attributes.SpecVersion)] = value;
         }
 
         /// <summary>
@@ -184,6 +157,20 @@ namespace CloudNative.CloudEvents
         {
             get => attributes.SpecVersion;
             set => attributes.SpecVersion = value;
+        }
+
+        /// <summary>
+        /// CloudEvents 'subject' attribute. This describes the subject of the event in the context
+        /// of the event producer (identified by source). In publish-subscribe scenarios, a subscriber
+        /// will typically subscribe to events emitted by a source, but the source identifier alone
+        /// might not be sufficient as a qualifier for any specific event if the source context has
+        /// internal sub-structure.
+        /// </summary>
+        /// <see cref="https://github.com/cloudevents/spec/blob/master/spec.md#subject"/>
+        public string Subject
+        {
+            get => attributes[CloudEventAttributes.SubjectAttributeName(attributes.SpecVersion)] as string;
+            set => attributes[CloudEventAttributes.SubjectAttributeName(attributes.SpecVersion)] = value;
         }
 
         /// <summary>

--- a/src/CloudNative.CloudEvents/CloudEventsSpecVersion.cs
+++ b/src/CloudNative.CloudEvents/CloudEventsSpecVersion.cs
@@ -8,7 +8,7 @@ namespace CloudNative.CloudEvents
     {
         V0_1,
         V0_2,
-        V0_3,
-        Default = V0_3
+        V1_0,
+        Default = V1_0
     }
 }

--- a/src/CloudNative.CloudEvents/CloudEventsSpecVersion.cs
+++ b/src/CloudNative.CloudEvents/CloudEventsSpecVersion.cs
@@ -8,6 +8,7 @@ namespace CloudNative.CloudEvents
     {
         V0_1,
         V0_2,
+        V0_3,
         V1_0,
         Default = V1_0
     }

--- a/test/CloudNative.CloudEvents.UnitTests/AmqpTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/AmqpTest.cs
@@ -20,7 +20,7 @@ namespace CloudNative.CloudEvents.UnitTests
 
 
             var jsonEventFormatter = new JsonEventFormatter();
-            var cloudEvent = new CloudEvent(CloudEventsSpecVersion.V0_3,
+            var cloudEvent = new CloudEvent(CloudEventsSpecVersion.V1_0,
                 "com.github.pull.create",
                 source: new Uri("https://github.com/cloudevents/spec/pull"),
                 subject: "123")

--- a/test/CloudNative.CloudEvents.UnitTests/AmqpTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/AmqpTest.cs
@@ -33,8 +33,7 @@ namespace CloudNative.CloudEvents.UnitTests
 
             var attrs = cloudEvent.GetAttributes();
             attrs["comexampleextension1"] = "value";
-            attrs["comexampleextension2"] = new { othervalue = 5 };
-
+            
             var message = new AmqpCloudEventMessage(cloudEvent, ContentMode.Structured, new JsonEventFormatter());
             Assert.True(message.IsCloudEvent());
             var encodedAmqpMessage = message.Encode();
@@ -55,7 +54,6 @@ namespace CloudNative.CloudEvents.UnitTests
 
             var attr = receivedCloudEvent.GetAttributes();
             Assert.Equal("value", (string)attr["comexampleextension1"]);
-            Assert.Equal(5, (int)((dynamic)attr["comexampleextension2"]).othervalue);
         }
 
         [Fact]
@@ -77,8 +75,7 @@ namespace CloudNative.CloudEvents.UnitTests
 
             var attrs = cloudEvent.GetAttributes();
             attrs["comexampleextension1"] = "value";
-            attrs["comexampleextension2"] = new { othervalue = 5 };
-
+            
             var message = new AmqpCloudEventMessage(cloudEvent, ContentMode.Binary, new JsonEventFormatter());
             Assert.True(message.IsCloudEvent());
             var encodedAmqpMessage = message.Encode();
@@ -98,7 +95,7 @@ namespace CloudNative.CloudEvents.UnitTests
 
             var attr = receivedCloudEvent.GetAttributes();
             Assert.Equal("value", (string)attr["comexampleextension1"]);
-            Assert.Equal(5, (int)((dynamic)attr["comexampleextension2"]).othervalue);
+            
         }
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/ConstructorTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/ConstructorTest.cs
@@ -135,6 +135,35 @@ namespace CloudNative.CloudEvents.UnitTests
         }
 
 
+        [Fact]
+        public void CreateV0_2ConvertToV1_0()
+        {
+            var cloudEvent = new CloudEvent(CloudEventsSpecVersion.V0_2, "com.github.pull.create",
+                new Uri("https://github.com/cloudevents/spec/pull/123"))
+            {
+                Id = "A234-1234-1234",
+                Time = new DateTime(2018, 4, 5, 17, 31, 0, DateTimeKind.Utc),
+                DataContentType = new ContentType(MediaTypeNames.Text.Xml),
+                Data = "<much wow=\"xml\"/>"
+            };
+
+            var attrs = cloudEvent.GetAttributes();
+            attrs["comexampleextension1"] = "value";
+
+            cloudEvent.SpecVersion = CloudEventsSpecVersion.V1_0;
+
+            Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
+            Assert.Equal("com.github.pull.create", cloudEvent.Type);
+            Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
+            Assert.Equal("A234-1234-1234", cloudEvent.Id);
+            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
+                cloudEvent.Time.Value.ToUniversalTime());
+            Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), cloudEvent.DataContentType);
+            Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
+
+            var attr = cloudEvent.GetAttributes();
+            Assert.Equal("value", (string)attr["comexampleextension1"]);
+        }
 
         [Fact]
         public void CreateEventWithExtensions()
@@ -147,13 +176,6 @@ namespace CloudNative.CloudEvents.UnitTests
                 new ComExampleExtension1Extension()
                 {
                     ComExampleExtension1 = "value"
-                },
-                new ComExampleExtension2Extension()
-                {
-                    ComExampleExtension2 = new ComExampleExtension2Data()
-                    {
-                        OtherValue = 5
-                    }
                 })
             {
                 DataContentType = new ContentType(MediaTypeNames.Text.Xml),
@@ -170,7 +192,6 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
 
             Assert.Equal("value", cloudEvent.Extension<ComExampleExtension1Extension>().ComExampleExtension1);
-            Assert.Equal(5, cloudEvent.Extension<ComExampleExtension2Extension>().ComExampleExtension2.OtherValue);
-        }
+         }
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/ExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/ExtensionsTest.cs
@@ -14,7 +14,7 @@ namespace CloudNative.CloudEvents.UnitTests
     {
         const string jsonDistTrace =
            "{\n" +
-           "    \"specversion\" : \"0.3\",\n" +
+           "    \"specversion\" : \"1.0\",\n" +
            "    \"type\" : \"com.github.pull.create\",\n" +
            "    \"source\" : \"https://github.com/cloudevents/spec/pull/123\",\n" +
            "    \"id\" : \"A234-1234-1234\",\n" +
@@ -27,7 +27,7 @@ namespace CloudNative.CloudEvents.UnitTests
 
         const string jsonSequence =
             "{\n" +
-            "    \"specversion\" : \"0.3\",\n" +
+            "    \"specversion\" : \"1.0\",\n" +
             "    \"type\" : \"com.github.pull.create\",\n" +
             "    \"source\" : \"https://github.com/cloudevents/spec/pull/123\",\n" +
             "    \"id\" : \"A234-1234-1234\",\n" +
@@ -40,7 +40,7 @@ namespace CloudNative.CloudEvents.UnitTests
 
         const string jsonSampledRate =
             "{\n" +
-            "    \"specversion\" : \"0.3\",\n" +
+            "    \"specversion\" : \"1.0\",\n" +
             "    \"type\" : \"com.github.pull.create\",\n" +
             "    \"source\" : \"https://github.com/cloudevents/spec/pull/123\",\n" +
             "    \"id\" : \"A234-1234-1234\",\n" +

--- a/test/CloudNative.CloudEvents.UnitTests/HttpTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/HttpTest.cs
@@ -103,8 +103,7 @@ namespace CloudNative.CloudEvents.UnitTests
 
                     var attrs = cloudEvent.GetAttributes();
                     attrs["comexampleextension1"] = "value";
-                    attrs["comexampleextension2"] = new { othervalue = 5 };
-
+ 
                     await context.Response.CopyFromAsync(cloudEvent, ContentMode.Binary, new JsonEventFormatter());
                     context.Response.StatusCode = (int)HttpStatusCode.OK;
                 }
@@ -127,7 +126,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
             var receivedCloudEvent = result.ToCloudEvent();
 
-            Assert.Equal(CloudEventsSpecVersion.Default, receivedCloudEvent.SpecVersion);
+            Assert.Equal(CloudEventsSpecVersion.V1_0, receivedCloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
             Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
@@ -141,7 +140,6 @@ namespace CloudNative.CloudEvents.UnitTests
 
             var attr = receivedCloudEvent.GetAttributes();
             Assert.Equal("value", (string)attr["comexampleextension1"]);
-            Assert.Equal(5, (int)((dynamic)attr["comexampleextension2"]).othervalue);
         }
 
         [Fact]
@@ -158,8 +156,7 @@ namespace CloudNative.CloudEvents.UnitTests
 
             var attrs = cloudEvent.GetAttributes();
             attrs["comexampleextension1"] = "value";
-            attrs["comexampleextension2"] = new { othervalue = 5 };
-
+  
             string ctx = Guid.NewGuid().ToString();
             var content = new CloudEventContent(cloudEvent, ContentMode.Binary, new JsonEventFormatter());
             content.Headers.Add(testContextHeader, ctx);
@@ -172,7 +169,7 @@ namespace CloudNative.CloudEvents.UnitTests
 
                     var receivedCloudEvent = context.Request.ToCloudEvent(new JsonEventFormatter());
 
-                    Assert.Equal(CloudEventsSpecVersion.Default, receivedCloudEvent.SpecVersion);
+                    Assert.Equal(CloudEventsSpecVersion.V1_0, receivedCloudEvent.SpecVersion);
                     Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
                     Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
                     Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
@@ -187,7 +184,6 @@ namespace CloudNative.CloudEvents.UnitTests
 
                     var attr = receivedCloudEvent.GetAttributes();
                     Assert.Equal("value", (string)attr["comexampleextension1"]);
-                    Assert.Equal(5, (int)((dynamic)attr["comexampleextension2"]).othervalue);
                     context.Response.StatusCode = (int)HttpStatusCode.NoContent;
                 }
                 catch (Exception e)
@@ -229,8 +225,7 @@ namespace CloudNative.CloudEvents.UnitTests
 
                     var attrs = cloudEvent.GetAttributes();
                     attrs["comexampleextension1"] = "value";
-                    attrs["comexampleextension2"] = new { othervalue = 5 };
-
+    
                     await context.Response.CopyFromAsync(cloudEvent, ContentMode.Structured, new JsonEventFormatter());
                     context.Response.StatusCode = (int)HttpStatusCode.OK;
                 }
@@ -254,7 +249,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.True(result.IsCloudEvent());
             var receivedCloudEvent = result.ToCloudEvent();
 
-            Assert.Equal(CloudEventsSpecVersion.Default, receivedCloudEvent.SpecVersion);
+            Assert.Equal(CloudEventsSpecVersion.V1_0, receivedCloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
             Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
@@ -265,7 +260,6 @@ namespace CloudNative.CloudEvents.UnitTests
 
             var attr = receivedCloudEvent.GetAttributes();
             Assert.Equal("value", (string)attr["comexampleextension1"]);
-            Assert.Equal(5, (int)((dynamic)attr["comexampleextension2"]).othervalue);
         }
 
         [Fact]
@@ -282,8 +276,7 @@ namespace CloudNative.CloudEvents.UnitTests
 
             var attrs = cloudEvent.GetAttributes();
             attrs["comexampleextension1"] = "value";
-            attrs["comexampleextension2"] = new { othervalue = 5 };
-
+        
             string ctx = Guid.NewGuid().ToString();
             var content = new CloudEventContent(cloudEvent, ContentMode.Structured, new JsonEventFormatter());
             content.Headers.Add(testContextHeader, ctx);
@@ -294,7 +287,7 @@ namespace CloudNative.CloudEvents.UnitTests
                 {
                     var receivedCloudEvent = context.Request.ToCloudEvent(new JsonEventFormatter());
 
-                    Assert.Equal(CloudEventsSpecVersion.Default, receivedCloudEvent.SpecVersion);
+                    Assert.Equal(CloudEventsSpecVersion.V1_0, receivedCloudEvent.SpecVersion);
                     Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
                     Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
                     Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
@@ -305,7 +298,6 @@ namespace CloudNative.CloudEvents.UnitTests
 
                     var attr = receivedCloudEvent.GetAttributes();
                     Assert.Equal("value", (string)attr["comexampleextension1"]);
-                    Assert.Equal(5, (int)((dynamic)attr["comexampleextension2"]).othervalue);
                     context.Response.StatusCode = (int)HttpStatusCode.NoContent;
                 }
                 catch (Exception e)
@@ -342,8 +334,7 @@ namespace CloudNative.CloudEvents.UnitTests
 
             var attrs = cloudEvent.GetAttributes();
             attrs["comexampleextension1"] = "value";
-            attrs["comexampleextension2"] = new { othervalue = 5 };
-
+            
             string ctx = Guid.NewGuid().ToString();
             HttpWebRequest httpWebRequest = WebRequest.CreateHttp(listenerAddress + "ep");
             httpWebRequest.Method = "POST";
@@ -356,7 +347,7 @@ namespace CloudNative.CloudEvents.UnitTests
                 {
                     var receivedCloudEvent = context.Request.ToCloudEvent(new JsonEventFormatter());
 
-                    Assert.Equal(CloudEventsSpecVersion.Default, receivedCloudEvent.SpecVersion);
+                    Assert.Equal(CloudEventsSpecVersion.V1_0, receivedCloudEvent.SpecVersion);
                     Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
                     Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
                     Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
@@ -367,7 +358,6 @@ namespace CloudNative.CloudEvents.UnitTests
 
                     var attr = receivedCloudEvent.GetAttributes();
                     Assert.Equal("value", (string)attr["comexampleextension1"]);
-                    Assert.Equal(5, (int)((dynamic)attr["comexampleextension2"]).othervalue);
                     context.Response.StatusCode = (int)HttpStatusCode.NoContent;
                 }
                 catch (Exception e)

--- a/test/CloudNative.CloudEvents.UnitTests/MqttTests.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/MqttTests.cs
@@ -53,7 +53,6 @@ namespace CloudNative.CloudEvents.UnitTests
 
             var attrs = cloudEvent.GetAttributes();
             attrs["comexampleextension1"] = "value";
-            attrs["comexampleextension2"] = new { othervalue = 5 };
 
              var client = new MqttFactory().CreateMqttClient();
 
@@ -85,7 +84,6 @@ namespace CloudNative.CloudEvents.UnitTests
 
             var attr = receivedCloudEvent.GetAttributes();
             Assert.Equal("value", (string)attr["comexampleextension1"]);
-            Assert.Equal(5, (int)((dynamic)attr["comexampleextension2"]).othervalue);
             
 
 


### PR DESCRIPTION
This PR adds v1.0 support. This includes aligning all strongly named attributes to the 1.0 level and dropping of "DataContentEncoding", which is a breaking change.