### PR TITLE
Issue 61 changed date-time in CE header to be in RFC 3339 format.

### DIFF
--- a/src/CloudNative.CloudEvents/HttpClientExtension.cs
+++ b/src/CloudNative.CloudEvents/HttpClientExtension.cs
@@ -12,6 +12,7 @@ namespace CloudNative.CloudEvents
     using System.Net.Mime;
     using System.Text;
     using System.Threading.Tasks;
+    using System.Xml;
     using Newtonsoft.Json;
 
     public static class HttpClientExtension
@@ -469,7 +470,7 @@ namespace CloudNative.CloudEvents
                     else if (attribute.Value is DateTime)
                     {
                         httpListenerResponse.Headers.Add(HttpHeaderPrefix + attribute.Key,
-                            ((DateTime)attribute.Value).ToString("u"));
+                            XmlConvert.ToString((DateTime)attribute.Value, XmlDateTimeSerializationMode.Utc));
                     }
                     else if (attribute.Value is Uri || attribute.Value is int)
                     {

--- a/test/CloudNative.CloudEvents.UnitTests/HttpTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/HttpTest.cs
@@ -130,6 +130,11 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
             Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
                 receivedCloudEvent.Time.Value.ToUniversalTime());
+
+            // Verify ce-time text format follows RFC 3339 specification. 
+            var ce_time_str = result.Headers.Where(hdr => hdr.Key == "ce-time").First().Value.First();
+            Assert.Equal("2018-04-05T17:31:00Z", ce_time_str);
+
             Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), receivedCloudEvent.DataContentType);
             using (var sr = new StreamReader((Stream)receivedCloudEvent.Data))
             {


### PR DESCRIPTION
Addresses issue #61.
CloudEvent header date-time format is not in RFC 3339 format. There needs to be a T between the date and the time.

E.g.: 2020-06-17 12:52:43Z Wrong!
2020-06-17T12:52:43Z Correct

Knative Eventing (broker filter) rejects non RFC 3339 formatted DateTime.