### PR TITLE
Improvements to CloudEventAttributes consistency

### DIFF
--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -1,8 +1,17 @@
 <Project>
   <PropertyGroup>
+    <!-- Make the repository root available for other properties -->
+    <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))</RepoRoot>
+
     <!-- Disable deterministic source paths for sample projects -->
     <DeterministicSourcePaths>False</DeterministicSourcePaths>
 
+    <!-- Build properties -->
+    <AssemblyOriginatorKeyFile>$(RepoRoot)/CloudEventsSdk.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>True</SignAssembly>
+    <Deterministic>True</Deterministic>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    
     <!-- Never pack any sample projects -->
     <IsPackable>False</IsPackable>
   </PropertyGroup>

--- a/src/CloudNative.CloudEvents/AssemblyInfo.cs
+++ b/src/CloudNative.CloudEvents/AssemblyInfo.cs
@@ -1,0 +1,12 @@
+﻿// Copyright 2021 Cloud Native Foundation. 
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CloudNative.CloudEvents.UnitTests,PublicKey="
+    + "0024000004800000940000000602000000240000525341310004000001000100e945e99352d0b8"
+    + "90ddb645995bc05ef5a22497d97e78196b9f6148ea33b0c1b219f0c28df523878d1d8c9d042a02"
+    + "f005777461dffe455b348f82b39fcbc64985ef091295c0ad2dcb265c23589e9ce8e48dbe84c8e1"
+    + "7fc37555938b2669aea7575cee288809065aa9dc04dff67ce1dfc5a3167770323c1a2c632f0eb2"
+    + "f8c64acf")]

--- a/src/CloudNative.CloudEvents/CloudEventAttributes.cs
+++ b/src/CloudNative.CloudEvents/CloudEventAttributes.cs
@@ -232,7 +232,12 @@ namespace CloudNative.CloudEvents
 
         void ICollection<KeyValuePair<string, object>>.Clear()
         {
+            // Clearing the collection doesn't remove the spec version attribute.
+            // Preserve it, clear the dictionary, then put it back.
+            string specAttributeName = SpecVersionAttributeName(this.SpecVersion);
+            string specAttributeValue = (string) this[specAttributeName];
             dict.Clear();
+            dict[specAttributeName] = specAttributeValue;
         }
 
         bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> item)

--- a/src/CloudNative.CloudEvents/CloudEventAttributes.cs
+++ b/src/CloudNative.CloudEvents/CloudEventAttributes.cs
@@ -267,11 +267,19 @@ namespace CloudNative.CloudEvents
 
         bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> item)
         {
+            if (item.Key.Equals(SpecVersionAttributeName(this.SpecVersion), StringComparison.InvariantCultureIgnoreCase))
+            {
+                throw new InvalidOperationException(Strings.ErrorSpecVersionCannotBeCleared);
+            }
             return dict.Remove(item);
         }
 
         bool IDictionary<string, object>.Remove(string key)
         {
+            if (key.Equals(SpecVersionAttributeName(this.SpecVersion), StringComparison.InvariantCultureIgnoreCase))
+            {
+                throw new InvalidOperationException(Strings.ErrorSpecVersionCannotBeCleared);
+            }
             return dict.Remove(key);
         }
 

--- a/src/CloudNative.CloudEvents/CloudEventAttributes.cs
+++ b/src/CloudNative.CloudEvents/CloudEventAttributes.cs
@@ -211,12 +211,21 @@ namespace CloudNative.CloudEvents
         void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> item)
         {
             object value = item.Value;
+            // Note: can't throw ArgumentNullException as the null value is only part of the argument.
+            if (value is null)
+            {
+                throw new InvalidOperationException(Strings.ErrorCannotAddNullAttributeValue);
+            }
             ValidateAndNormalize(item.Key, ref value);
             dict.Add(item.Key, value);
         }
 
         void IDictionary<string, object>.Add(string key, object value)
         {
+            if (value is null)
+            {
+                throw new ArgumentNullException(nameof(value), Strings.ErrorCannotAddNullAttributeValue);
+            }
             ValidateAndNormalize(key, ref value);
             dict.Add(key, value);
         }
@@ -266,7 +275,7 @@ namespace CloudNative.CloudEvents
             return dict.TryGetValue(key, out value);
         }
 
-        internal virtual bool ValidateAndNormalize(string key, ref object value)
+        private bool ValidateAndNormalize(string key, ref object value)
         {
             if (key.Equals(TypeAttributeName(this.SpecVersion), StringComparison.InvariantCultureIgnoreCase))
             {
@@ -297,7 +306,7 @@ namespace CloudNative.CloudEvents
             }
             else if (key.Equals(TimeAttributeName(this.SpecVersion), StringComparison.InvariantCultureIgnoreCase))
             {
-                if (value is null || value is DateTime)
+                if (value is DateTime)
                 {
                     return true;
                 }
@@ -343,7 +352,7 @@ namespace CloudNative.CloudEvents
             }
             else if (key.Equals(DataSchemaAttributeName(this.SpecVersion), StringComparison.InvariantCultureIgnoreCase))
             {
-                if (value is null || value is Uri)
+                if (value is Uri)
                 {
                     return true;
                 }
@@ -361,7 +370,7 @@ namespace CloudNative.CloudEvents
             }
             else if (key.Equals(DataContentTypeAttributeName(this.SpecVersion), StringComparison.InvariantCultureIgnoreCase))
             {
-                if (value is null || value is ContentType)
+                if (value is ContentType)
                 {
                     return true;
                 }

--- a/src/CloudNative.CloudEvents/CloudEventAttributes.cs
+++ b/src/CloudNative.CloudEvents/CloudEventAttributes.cs
@@ -146,6 +146,16 @@ namespace CloudNative.CloudEvents
             } 
             set
             {
+                if (value is null)
+                {
+                    if (key.Equals(SpecVersionAttributeName(this.SpecVersion), StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        throw new InvalidOperationException(Strings.ErrorSpecVersionCannotBeCleared);
+                    }
+                    dict.Remove(key);
+                    return;
+                }
+
                 ValidateAndNormalize(key, ref value);
                 dict[key] = value;
             }

--- a/src/CloudNative.CloudEvents/Strings.Designer.cs
+++ b/src/CloudNative.CloudEvents/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace CloudNative.CloudEvents {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -138,6 +138,15 @@ namespace CloudNative.CloudEvents {
         internal static string ErrorSourceValueIsNotAUri {
             get {
                 return ResourceManager.GetString("ErrorSourceValueIsNotAUri", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The &apos;specversion&apos; attribute cannot be cleared.
+        /// </summary>
+        internal static string ErrorSpecVersionCannotBeCleared {
+            get {
+                return ResourceManager.GetString("ErrorSpecVersionCannotBeCleared", resourceCulture);
             }
         }
         

--- a/src/CloudNative.CloudEvents/Strings.Designer.cs
+++ b/src/CloudNative.CloudEvents/Strings.Designer.cs
@@ -61,6 +61,15 @@ namespace CloudNative.CloudEvents {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Null values cannot be added as attributes.
+        /// </summary>
+        internal static string ErrorCannotAddNullAttributeValue {
+            get {
+                return ResourceManager.GetString("ErrorCannotAddNullAttributeValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The &apos;contenttype&apos; attribute value must be a content-type expression compliant with RFC2046.
         /// </summary>
         internal static string ErrorContentTypeIsNotRFC2046 {

--- a/src/CloudNative.CloudEvents/Strings.resx
+++ b/src/CloudNative.CloudEvents/Strings.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ErrorCannotAddNullAttributeValue" xml:space="preserve">
+    <value>Null values cannot be added as attributes</value>
+  </data>
   <data name="ErrorContentTypeIsNotRFC2046" xml:space="preserve">
     <value>The 'contenttype' attribute value must be a content-type expression compliant with RFC2046</value>
   </data>

--- a/src/CloudNative.CloudEvents/Strings.resx
+++ b/src/CloudNative.CloudEvents/Strings.resx
@@ -144,6 +144,9 @@
   <data name="ErrorSourceValueIsNotAUri" xml:space="preserve">
     <value>The 'source' attribute value must be a valid absolute or relative URI</value>
   </data>
+  <data name="ErrorSpecVersionCannotBeCleared" xml:space="preserve">
+    <value>The 'specversion' attribute cannot be cleared</value>
+  </data>
   <data name="ErrorSpecVersionValueIsNotAString" xml:space="preserve">
     <value>The 'specversion' attribute value must be a string</value>
   </data>

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventAttributesTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventAttributesTest.cs
@@ -1,0 +1,33 @@
+﻿// Copyright 2020 Cloud Native Foundation. 
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace CloudNative.CloudEvents.UnitTests
+{
+    public class CloudEventAttributesTest
+    {
+        static readonly IEnumerable<ICloudEventExtension> emptyExtensions = new ICloudEventExtension[0];
+
+        [Fact]
+        public void Indexer_SetToNullValue_RegularAttribute()
+        {
+            var attributes = new CloudEventAttributes(CloudEventsSpecVersion.Default, emptyExtensions);
+            string attributeName = CloudEventAttributes.TypeAttributeName();
+            attributes[attributeName] = "some event type";
+            attributes[attributeName] = null;
+            Assert.Null(attributes[attributeName]);
+        }
+
+        [Fact]
+        public void Indexer_SetToNullValue_SpecVersion()
+        {
+            var attributes = new CloudEventAttributes(CloudEventsSpecVersion.Default, emptyExtensions);
+            string attributeName = CloudEventAttributes.SpecVersionAttributeName();
+            Assert.Throws<InvalidOperationException>(() => attributes[attributeName] = null);
+        }
+    }
+}

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventAttributesTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventAttributesTest.cs
@@ -46,5 +46,21 @@ namespace CloudNative.CloudEvents.UnitTests
             var pair = KeyValuePair.Create(attributeName, default(object));
             Assert.Throws<InvalidOperationException>(() => attributes.Add(pair));
         }
+
+        [Fact]
+        public void Clear_PreservesSpecVersion()
+        {
+            IDictionary<string, object> attributes = new CloudEventAttributes(CloudEventsSpecVersion.Default, emptyExtensions);
+            string specVersionAttributeName = CloudEventAttributes.SpecVersionAttributeName();
+            string specVersionValue = (string) attributes[specVersionAttributeName];
+            attributes[CloudEventAttributes.TypeAttributeName()] = "some event type";
+            Assert.Equal(2, attributes.Count);
+            attributes.Clear();
+
+            // We'd normally expect an empty dictionary now, but CloudEventAttributes always preserves the spec version.
+            var entry = Assert.Single(attributes);
+            Assert.Equal(CloudEventAttributes.SpecVersionAttributeName(), entry.Key);
+            Assert.Equal(specVersionValue, entry.Value);
+        }
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventAttributesTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventAttributesTest.cs
@@ -62,5 +62,23 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal(CloudEventAttributes.SpecVersionAttributeName(), entry.Key);
             Assert.Equal(specVersionValue, entry.Value);
         }
+
+        [Fact]
+        public void Dictionary_Remove_SpecVersion()
+        {
+            IDictionary<string, object> attributes = new CloudEventAttributes(CloudEventsSpecVersion.Default, emptyExtensions);
+            string specVersionAttributeName = CloudEventAttributes.SpecVersionAttributeName();
+            Assert.Throws<InvalidOperationException>(() => attributes.Remove(specVersionAttributeName));
+        }
+
+        [Fact]
+        public void Collection_Remove_SpecVersion()
+        {
+            ICollection<KeyValuePair<string, object>> attributes = new CloudEventAttributes(CloudEventsSpecVersion.Default, emptyExtensions);
+            string specVersionAttributeName = CloudEventAttributes.SpecVersionAttributeName();
+            // The value part is irrelevant; we throw on any attempt to remove a pair with a key that's the spec attribute version.
+            var pair = KeyValuePair.Create(specVersionAttributeName, new object());
+            Assert.Throws<InvalidOperationException>(() => attributes.Remove(pair));
+        }
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventAttributesTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventAttributesTest.cs
@@ -29,5 +29,22 @@ namespace CloudNative.CloudEvents.UnitTests
             string attributeName = CloudEventAttributes.SpecVersionAttributeName();
             Assert.Throws<InvalidOperationException>(() => attributes[attributeName] = null);
         }
+
+        [Fact]
+        public void Dictionary_Add_NullValue()
+        {
+            IDictionary<string, object> attributes = new CloudEventAttributes(CloudEventsSpecVersion.Default, emptyExtensions);
+            string attributeName = CloudEventAttributes.TypeAttributeName();
+            Assert.Throws<ArgumentNullException>(() => attributes.Add(attributeName, null));
+        }
+
+        [Fact]
+        public void Collection_Add_NullValue()
+        {
+            ICollection<KeyValuePair<string, object>> attributes = new CloudEventAttributes(CloudEventsSpecVersion.Default, emptyExtensions);
+            string attributeName = CloudEventAttributes.TypeAttributeName();
+            var pair = KeyValuePair.Create(attributeName, default(object));
+            Assert.Throws<InvalidOperationException>(() => attributes.Add(pair));
+        }
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventTest.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2020 Cloud Native Foundation. 
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using System;
+using System.Net.Mime;
+using Xunit;
+
+namespace CloudNative.CloudEvents.UnitTests
+{
+    public class CloudEventTest
+    {
+        [Fact]
+        public void SetAttributePropertiesToNull()
+        {
+            var cloudEvent = new CloudEvent(CloudEventsSpecVersion.V1_0, "type",
+                new Uri("https://source"), "subject", "id", DateTime.UtcNow)
+            {
+                Data = "some data",
+                DataContentType = new ContentType("text/plain"),
+                DataSchema = new Uri("https://schema")
+            };
+
+            cloudEvent.Type = null;
+            cloudEvent.Source = null;
+            cloudEvent.Subject = null;
+            cloudEvent.Id = null;
+            cloudEvent.Time = null;
+            cloudEvent.Data = null;
+            cloudEvent.DataContentType = null;
+            cloudEvent.DataSchema = null;
+
+            Assert.Null(cloudEvent.Type);
+            Assert.Null(cloudEvent.Source);
+            Assert.Null(cloudEvent.Subject);
+            Assert.Null(cloudEvent.Id);
+            Assert.Null(cloudEvent.Time);
+            Assert.Null(cloudEvent.Data);
+            Assert.Null(cloudEvent.DataContentType);
+            Assert.Null(cloudEvent.DataSchema);
+        }
+    }
+}

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,8 +1,17 @@
 <Project>
   <PropertyGroup>
+    <!-- Make the repository root available for other properties -->
+    <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))</RepoRoot>
+
     <!-- Disable deterministic source paths for test projects -->
     <DeterministicSourcePaths>False</DeterministicSourcePaths>
 
+    <!-- Build properties -->
+    <AssemblyOriginatorKeyFile>$(RepoRoot)/CloudEventsSdk.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>True</SignAssembly>
+    <Deterministic>True</Deterministic>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    
     <!-- Never pack any test projects -->
     <IsPackable>False</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
- Allow every attribute *except* spec version to be cleared via the indexer (setting the value to null)
- Prevent null values being added with the Add method
- Avoid ever losing the spec version attribute