### PR TITLE
Fix CloudEventContent's handling of headers

### DIFF
--- a/src/CloudNative.CloudEvents/CloudEventContent.cs
+++ b/src/CloudNative.CloudEvents/CloudEventContent.cs
@@ -33,7 +33,6 @@ namespace CloudNative.CloudEvents
             {
                 inner = new InnerByteArrayContent(formatter.EncodeStructuredEvent(cloudEvent, out var contentType));
                 Headers.ContentType = new MediaTypeHeaderValue(contentType.MediaType);
-                MapHeaders(cloudEvent);
                 return;
             }
 
@@ -55,7 +54,7 @@ namespace CloudNative.CloudEvents
                     cloudEvent.Data, cloudEvent.Extensions.Values));
             }
 
-            Headers.ContentType = new MediaTypeHeaderValue(cloudEvent.DataContentType?.MediaType);
+            Headers.ContentType = new MediaTypeHeaderValue(cloudEvent.DataContentType?.MediaType ?? "application/json");
             MapHeaders(cloudEvent);
         }
 

--- a/src/CloudNative.CloudEvents/CloudEventContent.cs
+++ b/src/CloudNative.CloudEvents/CloudEventContent.cs
@@ -58,7 +58,10 @@ namespace CloudNative.CloudEvents
                     cloudEvent.Data, cloudEvent.Extensions.Values));
             }
 
-            Headers.ContentType = new MediaTypeHeaderValue(cloudEvent.DataContentType?.MediaType ?? "application/json");
+            var mediaType = cloudEvent.DataContentType?.MediaType
+                ?? throw new ArgumentException(Strings.ErrorContentTypeUnspecified, nameof(cloudEvent));
+
+            Headers.ContentType = new MediaTypeHeaderValue(mediaType);
             MapHeaders(cloudEvent, includeDataContentType: false);
         }
 

--- a/src/CloudNative.CloudEvents/CloudNative.CloudEvents.csproj
+++ b/src/CloudNative.CloudEvents/CloudNative.CloudEvents.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>CNCF CloudEvents SDK</Description>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CloudNative.CloudEvents/Strings.Designer.cs
+++ b/src/CloudNative.CloudEvents/Strings.Designer.cs
@@ -79,6 +79,15 @@ namespace CloudNative.CloudEvents {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The &apos;datacontenttype&apos; attribute value must be specified.
+        /// </summary>
+        internal static string ErrorContentTypeUnspecified {
+            get {
+                return ResourceManager.GetString("ErrorContentTypeUnspecified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The &apos;datacontentencoding&apos; field is not a string.
         /// </summary>
         internal static string ErrorDataContentEncodingIsNotAString {

--- a/src/CloudNative.CloudEvents/Strings.resx
+++ b/src/CloudNative.CloudEvents/Strings.resx
@@ -123,6 +123,9 @@
   <data name="ErrorContentTypeIsNotRFC2046" xml:space="preserve">
     <value>The 'contenttype' attribute value must be a content-type expression compliant with RFC2046</value>
   </data>
+  <data name="ErrorContentTypeUnspecified" xml:space="preserve">
+    <value>The 'datacontenttype' attribute value must be specified</value>
+  </data>
   <data name="ErrorDataContentEncodingIsNotAString" xml:space="preserve">
     <value>The 'datacontentencoding' field is not a string</value>
   </data>

--- a/test/CloudNative.CloudEvents.IntegrationTests/AspNetCore/CloudEventControllerTests.cs
+++ b/test/CloudNative.CloudEvents.IntegrationTests/AspNetCore/CloudEventControllerTests.cs
@@ -4,12 +4,11 @@
 
 namespace CloudNative.CloudEvents.IntegrationTests.AspNetCore
 {
-    using System;
-    using System.Net;
-    using System.Net.Http.Headers;
-    using System.Threading.Tasks;
     using CloudNative.CloudEvents.AspNetCoreSample;
     using Microsoft.AspNetCore.Mvc.Testing;
+    using System;
+    using System.Net;
+    using System.Threading.Tasks;
     using Xunit;
 
     public class CloudEventControllerTests : IClassFixture<WebApplicationFactory<Startup>>
@@ -22,9 +21,9 @@ namespace CloudNative.CloudEvents.IntegrationTests.AspNetCore
         }
 
         [Theory]
-        [InlineData("application/cloudevents+json")]
-        [InlineData("application/json")]
-        public async Task Controller_WithValidCloudEvent_DeserializesUsingPipeline(string contentType)
+        [InlineData(ContentMode.Structured)]
+        [InlineData(ContentMode.Binary)]
+        public async Task Controller_WithValidCloudEvent_DeserializesUsingPipeline(ContentMode contentMode)
         {
             // Arrange
             var expectedExtensionKey = "comexampleextension1";
@@ -36,8 +35,7 @@ namespace CloudNative.CloudEvents.IntegrationTests.AspNetCore
             var attrs = cloudEvent.GetAttributes();
             attrs[expectedExtensionKey] = expectedExtensionValue;
 
-            var content = new CloudEventContent(cloudEvent, ContentMode.Structured, new JsonEventFormatter());
-            content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+            var content = new CloudEventContent(cloudEvent, contentMode, new JsonEventFormatter());
 
             // Act
             var result = await _factory.CreateClient().PostAsync("/api/events/receive", content);

--- a/test/CloudNative.CloudEvents.IntegrationTests/AspNetCore/CloudEventControllerTests.cs
+++ b/test/CloudNative.CloudEvents.IntegrationTests/AspNetCore/CloudEventControllerTests.cs
@@ -8,6 +8,7 @@ namespace CloudNative.CloudEvents.IntegrationTests.AspNetCore
     using Microsoft.AspNetCore.Mvc.Testing;
     using System;
     using System.Net;
+    using System.Net.Mime;
     using System.Threading.Tasks;
     using Xunit;
 
@@ -31,6 +32,7 @@ namespace CloudNative.CloudEvents.IntegrationTests.AspNetCore
             var cloudEvent = new CloudEvent("test-type-æøå", new Uri("urn:integration-tests"))
             {
                 Id = Guid.NewGuid().ToString(),
+                DataContentType = new ContentType("application/json")
             };
             var attrs = cloudEvent.GetAttributes();
             attrs[expectedExtensionKey] = expectedExtensionValue;

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventContentTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventContentTest.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2021 Cloud Native Foundation. 
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using System;
+using System.Net.Http.Headers;
+using System.Net.Mime;
+using Xunit;
+
+namespace CloudNative.CloudEvents.UnitTests
+{
+    public class CloudEventContentTest
+    {
+        [Fact]
+        void ContentType_FromCloudEvent_BinaryMode()
+        {
+            var cloudEvent = CreateEmptyCloudEvent();
+            cloudEvent.DataContentType = new ContentType("text/plain");
+            var content = new CloudEventContent(cloudEvent, ContentMode.Binary, new JsonEventFormatter());
+            var expectedContentType = new MediaTypeHeaderValue("text/plain");
+            Assert.Equal(expectedContentType, content.Headers.ContentType);
+        }
+
+        [Fact]
+        void ContentType_MissingFromCloudEvent_BinaryMode()
+        {
+            var cloudEvent = CreateEmptyCloudEvent();
+            var exception = Assert.Throws<ArgumentException>(() => new CloudEventContent(cloudEvent, ContentMode.Binary, new JsonEventFormatter()));
+            Assert.StartsWith(Strings.ErrorContentTypeUnspecified, exception.Message);
+        }
+
+        static CloudEvent CreateEmptyCloudEvent() =>
+            new CloudEvent(CloudEventsSpecVersion.V1_0, "type",
+                new Uri("https://source"), "subject", "id", DateTime.UtcNow);
+    }
+}

--- a/test/CloudNative.CloudEvents.UnitTests/HttpTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/HttpTest.cs
@@ -301,8 +301,19 @@ namespace CloudNative.CloudEvents.UnitTests
             {
                 try
                 {
-                    // Structured events do not contain any CloudEvent HTTP headers.
-                    Assert.Empty(context.Request.Headers.AllKeys.Where(key => key.StartsWith("ce-")));
+                    // Structured events contain a copy of the CloudEvent attributes as HTTP headers.
+                    var headers = context.Request.Headers;
+                    Assert.Equal("1.0", headers["ce-specversion"]);
+                    Assert.Equal("com.github.pull.create", headers["ce-type"]);
+                    Assert.Equal("https://github.com/cloudevents/spec/pull/123", headers["ce-source"]);
+                    Assert.Equal("A234-1234-1234", headers["ce-id"]);
+                    Assert.Equal("2018-04-05T17:31:00Z", headers["ce-time"]);
+                    // Note that datacontenttype is mapped in this case, but would not be included in binary mode.
+                    Assert.Equal("text/xml", headers["ce-datacontenttype"]);
+                    Assert.Equal("application/cloudevents+json", context.Request.ContentType);
+                    Assert.Equal("value", headers["ce-comexampleextension1"]);
+                    // The non-ASCII attribute value should have been URL-encoded using UTF-8 for the header.
+                    Assert.Equal("%C3%A6%C3%B8%C3%A5", headers["ce-utf8examplevalue"]);
 
                     var receivedCloudEvent = context.Request.ToCloudEvent(new JsonEventFormatter());
 


### PR DESCRIPTION
- For structured mode, we shouldn't map attributes to HTTP headers
- For binary mode, we should default the media content type to application/json
- UrlEncode and UrlDecode headers in binary mode
- Adds more testing of headers

Fixes #67 and #69.

Signed-off-by: Jon Skeet <jonskeet@google.com>