### PR TITLE
Update the release trigger to install .NET Core 2.1

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -15,7 +15,13 @@ jobs:
     - name: Check out our repo
       uses: actions/checkout@v2
 
-    # Install the .NET Core 3.1 SDK for build and test
+    # We need just the .NET Core 2.1 runtime for testing    
+    - name: Setup .NET Core 2.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 2.1.x
+
+    # Build with .NET Core 3.1 SDK
     - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1
       with:


### PR DESCRIPTION
(This is so we can run the tests against netcoreapp2.1.)

Signed-off-by: Jon Skeet <jonskeet@google.com>

(This should fix the error shown in https://github.com/cloudevents/sdk-csharp/runs/1384172532)