### PR TITLE
Add non optional arguments for CloudEvent ctor

### DIFF
--- a/src/CloudNative.CloudEvents/CloudEvent.cs
+++ b/src/CloudNative.CloudEvents/CloudEvent.cs
@@ -23,11 +23,34 @@ namespace CloudNative.CloudEvents
         /// </summary>
         /// <param name="type">'type' of the CloudEvent</param>
         /// <param name="source">'source' of the CloudEvent</param>
+        /// <param name="extensions">Extensions to be added to this CloudEvents</param>
+        public CloudEvent(string type, Uri source, params ICloudEventExtension[] extensions) : this(
+            CloudEventsSpecVersion.Default, type, source, null, null, extensions)
+        {
+        }
+
+        /// <summary>
+        /// Create a new CloudEvent instance.
+        /// </summary>
+        /// <param name="type">'type' of the CloudEvent</param>
+        /// <param name="source">'source' of the CloudEvent</param>
         /// <param name="id">'id' of the CloudEvent</param>
         /// <param name="time">'time' of the CloudEvent</param>
         /// <param name="extensions">Extensions to be added to this CloudEvents</param>
         public CloudEvent(string type, Uri source, string id = null, DateTime? time = null,
             params ICloudEventExtension[] extensions) : this(CloudEventsSpecVersion.Default, type, source, id, time, extensions)
+        {
+        }
+
+        /// <summary>
+        /// Create a new CloudEvent instance.
+        /// </summary>
+        /// <param name="specVersion">CloudEvents specification version</param>
+        /// <param name="type">'type' of the CloudEvent</param>
+        /// <param name="source">'source' of the CloudEvent</param>
+        /// <param name="extensions">Extensions to be added to this CloudEvents</param>
+        public CloudEvent(CloudEventsSpecVersion specVersion, string type, Uri source,
+            params ICloudEventExtension[] extensions) : this(specVersion, type, source, null, null, extensions)
         {
         }
 
@@ -47,6 +70,20 @@ namespace CloudNative.CloudEvents
             Source = source;
             Id = id ?? Guid.NewGuid().ToString();
             Time = time ?? DateTime.UtcNow;
+        }
+
+        /// <summary>
+        /// Create a new CloudEvent instance.
+        /// </summary>
+        /// <param name="specVersion">CloudEvents specification version</param>
+        /// <param name="type">'type' of the CloudEvent</param>
+        /// <param name="source">'source' of the CloudEvent</param>
+        /// <param name="subject">'subject' of the CloudEvent</param>
+        /// <param name="extensions">Extensions to be added to this CloudEvents</param>
+        public CloudEvent(CloudEventsSpecVersion specVersion, string type, Uri source, string subject,
+            params ICloudEventExtension[] extensions) : this(specVersion, type, source, null, null, extensions)
+        {
+            Subject = subject;
         }
 
         /// <summary>


### PR DESCRIPTION
I'm currently writing F# GCP Cloud Functions and writing tests for them, to construct a CloudEvent object I have to call this code:

```fsharp
let cloudEvent =
                CloudEvent
                    (MessagePublishedData.MessagePublishedCloudEventType,
                     Uri("//help", UriKind.RelativeOrAbsolute),
                     null,
                     Nullable())
```

I have to pass in `null` and `Nullable()` for the `id` and `time` arguments because although marked as optional in C#, F# clients still have to pass these in.

In this PR I have added extra constructors where the optional args do not exist but call the relevant ctor with null values