### PR TITLE
Don't push to NuGet from AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,11 +39,3 @@ test_script:
   - cmd: dotnet test 
 on_finish :
   # any cleanup in here
-deploy:
-  provider: NuGet
-  api_key:
-    secure: twb6ozXbDJpPxiagxYozpVR7VX3CP33jjER4mX6J4CEFHpWmItO2Yi8nIn6TsUgI
-  skip_symbols: false
-  artifact: /.*\.nupkg/
-  on:
-      APPVEYOR_REPO_TAG: true


### PR DESCRIPTION
We can potentially turn the AppVeyor integration down entirely later
on, but at least for now let's make sure packages are pushed manually.

Signed-off-by: Jon Skeet <jonskeet@google.com>