### PR TITLE
Better timestamp handling

### DIFF
--- a/src/CloudNative.CloudEvents.Amqp/AmqpCloudEventMessage.cs
+++ b/src/CloudNative.CloudEvents.Amqp/AmqpCloudEventMessage.cs
@@ -59,13 +59,20 @@ namespace CloudNative.CloudEvents.Amqp
                 if (!attribute.Key.Equals(CloudEventAttributes.DataAttributeName(cloudEvent.SpecVersion)) &&
                     !attribute.Key.Equals(CloudEventAttributes.DataContentTypeAttributeName(cloudEvent.SpecVersion)))
                 {
+                    string key = "cloudEvents:" + attribute.Key;
                     if (attribute.Value is Uri)
                     {
-                        this.ApplicationProperties.Map.Add("cloudEvents:" + attribute.Key, attribute.Value.ToString());
+                        this.ApplicationProperties.Map.Add(key, attribute.Value.ToString());
                     }
-                    else if (attribute.Value is DateTime || attribute.Value is DateTime || attribute.Value is string)
+                    else if (attribute.Value is DateTimeOffset dto)
                     {
-                        this.ApplicationProperties.Map.Add("cloudEvents:" + attribute.Key, attribute.Value);
+                        // AMQPNetLite doesn't support DateTimeOffset values, so convert to UTC.
+                        // That means we can't roundtrip events with non-UTC timestamps, but that's not awful.
+                        this.ApplicationProperties.Map.Add(key, dto.UtcDateTime);
+                    }
+                    else if (attribute.Value is string)
+                    {
+                        this.ApplicationProperties.Map.Add(key, attribute.Value);
                     }
                     else
                     {

--- a/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
@@ -89,14 +89,14 @@ namespace CloudNative.CloudEvents
                 {
                     continue;
                 }
-                if (keyValuePair.Key == CloudEventAttributes.SourceAttributeName() ||
-                    keyValuePair.Key == CloudEventAttributes.DataSchemaAttributeName())
+                if (keyValuePair.Key == CloudEventAttributes.SourceAttributeName(specVersion) ||
+                    keyValuePair.Key == CloudEventAttributes.DataSchemaAttributeName(specVersion))
                 {
                     attributes[keyValuePair.Key] = new Uri((string)keyValuePair.Value);
                 }
-                else if (keyValuePair.Key == CloudEventAttributes.TimeAttributeName())
+                else if (keyValuePair.Key == CloudEventAttributes.TimeAttributeName(specVersion))
                 {
-                    attributes[keyValuePair.Key] = DateTime.Parse((string)keyValuePair.Value);
+                    attributes[keyValuePair.Key] = Timestamps.Parse((string)keyValuePair.Value);
                 }
                 else
                 {
@@ -121,24 +121,24 @@ namespace CloudNative.CloudEvents
                     continue;
                 }
 
-                if (keyValuePair.Value is ContentType && !string.IsNullOrEmpty(((ContentType)keyValuePair.Value).MediaType))
+                if (keyValuePair.Value is ContentType valueContentType && !string.IsNullOrEmpty(valueContentType.MediaType))
                 {
-                    recordAttributes[keyValuePair.Key] = ((ContentType)keyValuePair.Value).ToString();
+                    recordAttributes[keyValuePair.Key] = valueContentType.ToString();
                 }
-                else if (keyValuePair.Value is Uri)
+                else if (keyValuePair.Value is Uri uri)
                 {
-                    recordAttributes[keyValuePair.Key] = ((Uri)keyValuePair.Value).ToString();
+                    recordAttributes[keyValuePair.Key] = uri .ToString();
                 }
-                else if (keyValuePair.Value is DateTime)
+                else if (keyValuePair.Value is DateTimeOffset timestamp)
                 {
-                    recordAttributes[keyValuePair.Key] = ((DateTime)keyValuePair.Value).ToString("o");
+                    recordAttributes[keyValuePair.Key] = Timestamps.Format(timestamp);
                 }
                 else if (cloudEvent.SpecVersion == CloudEventsSpecVersion.V1_0 &&
                          keyValuePair.Key.Equals(CloudEventAttributes.DataAttributeName(cloudEvent.SpecVersion)))
                 {
-                    if (keyValuePair.Value is Stream)
+                    if (keyValuePair.Value is Stream stream)
                     {
-                        using (var sr = new BinaryReader((Stream)keyValuePair.Value))
+                        using (var sr = new BinaryReader(stream))
                         {
                             record.Add("data", sr.ReadBytes((int)sr.BaseStream.Length));
                         }

--- a/src/CloudNative.CloudEvents/CloudEvent.cs
+++ b/src/CloudNative.CloudEvents/CloudEvent.cs
@@ -26,7 +26,7 @@ namespace CloudNative.CloudEvents
         /// <param name="id">'id' of the CloudEvent</param>
         /// <param name="time">'time' of the CloudEvent</param>
         /// <param name="extensions">Extensions to be added to this CloudEvents</param>
-        public CloudEvent(string type, Uri source, string id = null, DateTime? time = null,
+        public CloudEvent(string type, Uri source, string id = null, DateTimeOffset? time = null,
             params ICloudEventExtension[] extensions) : this(CloudEventsSpecVersion.Default, type, source, id, time, extensions)
         {
         }
@@ -40,13 +40,13 @@ namespace CloudNative.CloudEvents
         /// <param name="id">'id' of the CloudEvent</param>
         /// <param name="time">'time' of the CloudEvent</param>
         /// <param name="extensions">Extensions to be added to this CloudEvents</param>
-        public CloudEvent(CloudEventsSpecVersion specVersion, string type, Uri source, string id = null, DateTime? time = null,
+        public CloudEvent(CloudEventsSpecVersion specVersion, string type, Uri source, string id = null, DateTimeOffset? time = null,
             params ICloudEventExtension[] extensions) : this(specVersion, extensions)
         {
             Type = type;
             Source = source;
             Id = id ?? Guid.NewGuid().ToString();
-            Time = time ?? DateTime.UtcNow;
+            Time = time ?? DateTimeOffset.UtcNow;
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace CloudNative.CloudEvents
         /// <param name="id">'id' of the CloudEvent</param>
         /// <param name="time">'time' of the CloudEvent</param>
         /// <param name="extensions">Extensions to be added to this CloudEvents</param>
-        public CloudEvent(CloudEventsSpecVersion specVersion, string type, Uri source, string subject, string id = null, DateTime? time = null,
+        public CloudEvent(CloudEventsSpecVersion specVersion, string type, Uri source, string subject, string id = null, DateTimeOffset? time = null,
             params ICloudEventExtension[] extensions) : this(specVersion, type, source, id, time, extensions)
         {
             Subject = subject;
@@ -179,9 +179,9 @@ namespace CloudNative.CloudEvents
         /// CloudEvents 'time' attribute. Timestamp of when the event happened.
         /// </summary>
         /// <see cref="https://github.com/cloudevents/spec/blob/master/spec.md#time"/>
-        public DateTime? Time
+        public DateTimeOffset? Time
         {
-            get => (DateTime?)attributes[CloudEventAttributes.TimeAttributeName(attributes.SpecVersion)];
+            get => (DateTimeOffset?)attributes[CloudEventAttributes.TimeAttributeName(attributes.SpecVersion)];
             set => attributes[CloudEventAttributes.TimeAttributeName(attributes.SpecVersion)] = value;
         }
 

--- a/src/CloudNative.CloudEvents/CloudEventAttributes.cs
+++ b/src/CloudNative.CloudEvents/CloudEventAttributes.cs
@@ -7,8 +7,6 @@ namespace CloudNative.CloudEvents
     using System;
     using System.Collections;
     using System.Collections.Generic;
-    using System.Collections.Specialized;
-    using System.Globalization;
     using System.Net.Mime;
 
     /// <summary>
@@ -319,17 +317,16 @@ namespace CloudNative.CloudEvents
             }
             else if (key.Equals(TimeAttributeName(this.SpecVersion), StringComparison.InvariantCultureIgnoreCase))
             {
-                if (value is DateTime)
+                if (value is DateTimeOffset)
                 {
                     return true;
                 }
 
                 if (value is string)
                 {
-                    if (DateTime.TryParse((string)value, CultureInfo.InvariantCulture,
-                        DateTimeStyles.AssumeUniversal, out var dateTimeVal))
+                    if (Timestamps.TryParse((string)value, out var result))
                     {
-                        value = dateTimeVal;
+                        value = result;
                         return true;
                     }
                 }

--- a/src/CloudNative.CloudEvents/CloudEventContent.cs
+++ b/src/CloudNative.CloudEvents/CloudEventContent.cs
@@ -12,7 +12,6 @@ namespace CloudNative.CloudEvents
     using System.Net.Mime;
     using System.Text;
     using System.Threading.Tasks;
-    using System.Xml;
 
     /// <summary>
     /// This class is for use with `HttpClient` and constructs content and headers for
@@ -108,7 +107,7 @@ namespace CloudNative.CloudEvents
                     {
                         string text => WebUtility.UrlEncode(text),
                         ContentType contentType => contentType.ToString(),
-                        DateTime dt => XmlConvert.ToString(dt, XmlDateTimeSerializationMode.Utc),
+                        DateTimeOffset dto => Timestamps.Format(dto),
                         Uri uri => uri.ToString(),
                         int integer => integer.ToString(),
                         _ => WebUtility.UrlEncode(Encoding.UTF8.GetString(

--- a/src/CloudNative.CloudEvents/HttpClientExtension.cs
+++ b/src/CloudNative.CloudEvents/HttpClientExtension.cs
@@ -494,7 +494,7 @@ namespace CloudNative.CloudEvents
                 switch (attributeValue)
                 {
                     case string text: return text;
-                    case DateTime dateTime: return dateTime.ToString("u");
+                    case DateTimeOffset dateTimeOffset: return Timestamps.Format(dateTimeOffset);
                     case Uri uri: return uri.ToString();
                     case int integer: return integer.ToString(CultureInfo.InvariantCulture);
                     default:

--- a/src/CloudNative.CloudEvents/Timestamps.cs
+++ b/src/CloudNative.CloudEvents/Timestamps.cs
@@ -1,0 +1,199 @@
+﻿// Copyright 2021 Cloud Native Foundation. 
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+
+namespace CloudNative.CloudEvents
+{
+    /// <summary>
+    /// Helper methods for CloudEvent timestamp attributes, which are represented
+    /// as <see cref="DateTimeOffset"/> values within the SDK, and use RFC-3339
+    /// for string representations (e.g. in headers).
+    /// </summary>
+    public static class Timestamps
+    {
+        private const long TicksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
+
+        /// <summary>
+        /// Length of shortest valid value ("yyyy-MM-ddTHH:mm:ssZ")
+        /// </summary>
+        private const int MinLength = 20;
+
+        /// <summary>
+        /// Earliest position of UTC offset indicator in a valid timestamp.
+        /// </summary>
+        private const int MinOffsetIndex = 19;
+
+        /// <summary>
+        /// Length of longest the date/time part of valid value that we'll actually parse
+        /// ("yyyy-MM-ddTHH:mm:ss.FFFFFFF"). Further subsecond digits may be present, but
+        /// we'll ignore them.
+        /// </summary>
+        private const int MaxDateTimeParseLength = 27;
+
+        /// <summary>
+        /// Maximum number of minutes in an offset: DateTimeOffset only handles up to +/- 14 hours.
+        /// </summary>
+        private const int MaxOffsetMinutes = 14 * 60;
+
+        private static readonly char[] offsetLeadingCharacters = { 'Z', '+', '-' };
+
+        /// <summary>
+        /// Attempts to parse a string as an RFC-3339-formatted date/time and UTC offset.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <param name="result"></param>
+        /// <returns></returns>
+        public static bool TryParse(string input, out DateTimeOffset result)
+        {
+            // TODO: Check this and add a test
+            if (input is null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+            if (input.Length < MinLength) // "yyyy-MM-ddTHH:mm:ssZ" is the shortest possible value.
+            {
+                result = default;
+                return false;
+            }
+            // Find the UTC offset indicator, by starting at index 19 (the earliest possible index)
+            // and looking for Z, + or -.
+            int offsetIndex = input.IndexOfAny(offsetLeadingCharacters, MinOffsetIndex);
+            if (offsetIndex == -1)
+            {
+                result = default;
+                return false;
+            }
+            if (!TryParseLocalPart(input, offsetIndex, out var localPart) ||
+                !TryParseOffset(input, offsetIndex, out var offset))
+            {
+                result = default;
+                return false;
+            }
+            result = new DateTimeOffset(localPart, offset);
+            return true;
+        }
+
+        private static bool TryParseLocalPart(string input, int offsetIndex, out DateTime localPart)
+        {
+            // Find the end of the text we want to parse with DateTime.TryParseExact.
+            // We truncate timestamps that have sub-tick precision, but we need to validate that any later characters are digits.
+            string textToParse;
+            if (offsetIndex <= MaxDateTimeParseLength)
+            {
+                textToParse = input.Substring(0, offsetIndex);
+            }
+            else
+            {
+                for (int index = MaxDateTimeParseLength; index < offsetIndex; index++)
+                {
+                    if (!IsAsciiDigit(input[index]))
+                    {
+                        localPart = default;
+                        return false;
+                    }
+                }
+                textToParse = input.Substring(0, MaxDateTimeParseLength);
+            }
+            return DateTime.TryParseExact(
+                textToParse, "yyyy-MM-dd'T'HH:mm:ss.FFFFFFF",
+                CultureInfo.InvariantCulture, DateTimeStyles.None,
+                out localPart);
+        }
+
+        private static bool TryParseOffset(string input, int offsetIndex, out TimeSpan offset)
+        {
+            char prefix = input[offsetIndex]; // We already know this will be Z, + or -
+            if (prefix == 'Z')
+            {
+                offset = TimeSpan.Zero; // This is the value we want whether or not the length is right
+                return input.Length == offsetIndex + 1; // We expect the Z to be the end of the string
+            }
+            // Non-Z offsets much be exactly in the format +XX:YY or -XX:YY, so we can check the length and
+            // expected characters very straightforwardly.
+            if (input.Length != offsetIndex + 6 ||
+                !IsAsciiDigit(input[offsetIndex + 1]) ||
+                !IsAsciiDigit(input[offsetIndex + 2]) ||
+                input[offsetIndex + 3] != ':' ||
+                !IsAsciiDigit(input[offsetIndex + 4]) ||
+                !IsAsciiDigit(input[offsetIndex + 5]))
+            {
+                offset = default;
+                return false;
+            }
+
+            // Parse the digits as simply as possible.
+            int hours = ParseDigit(input[offsetIndex + 1]) * 10 + ParseDigit(input[offsetIndex + 2]);
+            int minutes = ParseDigit(input[offsetIndex + 4]) * 10 + ParseDigit(input[offsetIndex + 5]);
+            int totalMinutes = hours * 60 + minutes;
+            if (minutes >= 60 || totalMinutes > MaxOffsetMinutes)
+            {
+                return false;
+            }
+
+            // Handle the sign
+            if (input[offsetIndex] == '-')
+            {
+                totalMinutes = -totalMinutes;
+            }
+
+            offset = TimeSpan.FromMinutes(totalMinutes);
+            return true;
+
+            static int ParseDigit(char c) => c - '0';
+        }
+
+        private static bool IsAsciiDigit(char c) => c >= '0' && c <= '9';
+
+        /// <summary>
+        /// Parses a string as an RFC-3339-formatted date/time and UTC offset.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static DateTimeOffset Parse(string input) =>
+            TryParse(input, out var result) ? result : throw new FormatException("Invalid timestamp");
+
+        /// <summary>
+        /// Converts a <see cref="DateTimeOffset"/> value to a string using RFC-3339 format.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The sub-second precision in the result is determined by the first of the following conditions
+        /// to be met:
+        /// If the value is a whole number of seconds, the result contains no fractional-second
+        /// indicator at all.
+        /// If the sub-second value is a whole number of milliseconds, the result will contain three
+        /// digits of sub-second precision.
+        /// If the sub-second value is a whole number of microseconds, the result will contain six
+        /// digits of sub-second precision.
+        /// Otherwise, the result will contain 7 digits of sub-second precision. (This is the maximum
+        /// precision of <see cref="DateTimeOffset"/>.)
+        /// </para>
+        /// <para>
+        /// If the UTC offset is zero, this is represented as a suffix of 'Z';
+        /// otherwise, the offset is represented in the "+HH:mm" or "-HH:mm" format.
+        /// </para>
+        /// </remarks>
+        /// <param name="value">The value to convert to an RFC-3339 format string.</param>
+        /// <returns>The formatted string.</returns>
+        public static string Format(DateTimeOffset value)
+        {
+            var ticks = value.Ticks;
+            string formatString =
+                value.Offset.Ticks == 0 ?
+                    // UTC+0 branch: hard-code 'Z'
+                    (ticks % TimeSpan.TicksPerSecond == 0 ? "yyyy-MM-dd'T'HH:mm:ss'Z'" :
+                    ticks % TimeSpan.TicksPerMillisecond == 0 ? "yyyy-MM-dd'T'HH:mm:ss.fff'Z'" :
+                    ticks % TicksPerMicrosecond == 0 ? "yyyy-MM-dd'T'HH:mm:ss.ffffff'Z'" :
+                    "yyyy-MM-dd'T'HH:mm:ss.fffffff'Z'") :
+                    // Non-UTC branch: use zzz to format the offset
+                    (ticks % TimeSpan.TicksPerSecond == 0 ? "yyyy-MM-dd'T'HH:mm:sszzz" :
+                    ticks % TimeSpan.TicksPerMillisecond == 0 ? "yyyy-MM-dd'T'HH:mm:ss.fffzzz" :
+                    ticks % TicksPerMicrosecond == 0 ? "yyyy-MM-dd'T'HH:mm:ss.ffffffzzz" :
+                    "yyyy-MM-dd'T'HH:mm:ss.fffffffzzz");
+            return value.ToString(formatString, CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/test/CloudNative.CloudEvents.UnitTests/AvroTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/AvroTest.cs
@@ -8,6 +8,7 @@ namespace CloudNative.CloudEvents.UnitTests
     using System.Net.Mime;
     using System.Text;
     using Xunit;
+    using static TestHelpers;
 
     public class AvroTest
     {
@@ -36,7 +37,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal(cloudEvent2.Type, cloudEvent.Type);
             Assert.Equal(cloudEvent2.Source, cloudEvent.Source);
             Assert.Equal(cloudEvent2.Id, cloudEvent.Id);
-            Assert.Equal(cloudEvent2.Time.Value.ToUniversalTime(), cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual(cloudEvent2.Time.Value, cloudEvent.Time.Value);
             Assert.Equal(cloudEvent2.DataContentType, cloudEvent.DataContentType);
             Assert.Equal(cloudEvent2.Data, cloudEvent.Data);
         }
@@ -55,8 +56,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
             Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), cloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
 
@@ -78,8 +78,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
             Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), cloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
 

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventContentTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventContentTest.cs
@@ -39,6 +39,6 @@ namespace CloudNative.CloudEvents.UnitTests
 
         static CloudEvent CreateEmptyCloudEvent() =>
             new CloudEvent(CloudEventsSpecVersion.V1_0, "type",
-                new Uri("https://source"), "subject", "id", DateTime.UtcNow);
+                new Uri("https://source"), "subject", "id", DateTimeOffset.UtcNow);
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventTest.cs
@@ -14,7 +14,7 @@ namespace CloudNative.CloudEvents.UnitTests
         public void SetAttributePropertiesToNull()
         {
             var cloudEvent = new CloudEvent(CloudEventsSpecVersion.V1_0, "type",
-                new Uri("https://source"), "subject", "id", DateTime.UtcNow)
+                new Uri("https://source"), "subject", "id", DateTimeOffset.UtcNow)
             {
                 Data = "some data",
                 DataContentType = new ContentType("text/plain"),

--- a/test/CloudNative.CloudEvents.UnitTests/ConstructorTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/ConstructorTest.cs
@@ -7,9 +7,12 @@ namespace CloudNative.CloudEvents.UnitTests
     using System;
     using System.Net.Mime;
     using Xunit;
+    using static TestHelpers;
 
     public class ConstructorTest
     {
+        private static readonly DateTimeOffset sampleTimestamp = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero);
+
         [Fact]
         public void CreateBaseEvent1()
         {
@@ -17,7 +20,7 @@ namespace CloudNative.CloudEvents.UnitTests
                 new Uri("https://github.com/cloudevents/spec/pull/123"))
             {
                 Id = "A234-1234-1234",
-                Time = new DateTime(2018, 4, 5, 17, 31, 0, DateTimeKind.Utc),
+                Time = sampleTimestamp,
                 DataContentType = new ContentType(MediaTypeNames.Text.Xml),
                 Data = "<much wow=\"xml\"/>"
             };
@@ -30,8 +33,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
             Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), cloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
 
@@ -47,7 +49,7 @@ namespace CloudNative.CloudEvents.UnitTests
                 "com.github.pull.create",
                 new Uri("https://github.com/cloudevents/spec/pull/123"),
                 "A234-1234-1234",
-                new DateTime(2018, 4, 5, 17, 31, 0, DateTimeKind.Utc))
+                sampleTimestamp)
             {
                 DataContentType = new ContentType(MediaTypeNames.Text.Xml),
                 Data = "<much wow=\"xml\"/>"
@@ -61,8 +63,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
             Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), cloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
 
@@ -79,7 +80,7 @@ namespace CloudNative.CloudEvents.UnitTests
                 new Uri("https://github.com/cloudevents/spec/pull/123"))
             {
                 Id = "A234-1234-1234",
-                Time = new DateTime(2018, 4, 5, 17, 31, 0, DateTimeKind.Utc),
+                Time = sampleTimestamp,
                 DataContentType = new ContentType(MediaTypeNames.Text.Xml),
                 Data = "<much wow=\"xml\"/>"
             };
@@ -92,8 +93,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
             Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), cloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
 
@@ -109,7 +109,7 @@ namespace CloudNative.CloudEvents.UnitTests
                 new Uri("https://github.com/cloudevents/spec/pull/123"))
             {
                 Id = "A234-1234-1234",
-                Time = new DateTime(2018, 4, 5, 17, 31, 0, DateTimeKind.Utc),
+                Time = sampleTimestamp,
                 DataContentType = new ContentType(MediaTypeNames.Text.Xml),
                 Data = "<much wow=\"xml\"/>"
             };
@@ -124,8 +124,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
             Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), cloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
 
@@ -142,7 +141,7 @@ namespace CloudNative.CloudEvents.UnitTests
                 new Uri("https://github.com/cloudevents/spec/pull/123"))
             {
                 Id = "A234-1234-1234",
-                Time = new DateTime(2018, 4, 5, 17, 31, 0, DateTimeKind.Utc),
+                Time = sampleTimestamp,
                 DataContentType = new ContentType(MediaTypeNames.Text.Xml),
                 Data = "<much wow=\"xml\"/>"
             };
@@ -156,8 +155,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
             Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), cloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
 
@@ -172,7 +170,7 @@ namespace CloudNative.CloudEvents.UnitTests
                 "com.github.pull.create",
                 new Uri("https://github.com/cloudevents/spec/pull/123"),
                 "A234-1234-1234",
-                new DateTime(2018, 4, 5, 17, 31, 0, DateTimeKind.Utc),
+                sampleTimestamp,
                 new ComExampleExtension1Extension()
                 {
                     ComExampleExtension1 = "value"
@@ -186,8 +184,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
             Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), cloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
 

--- a/test/CloudNative.CloudEvents.UnitTests/ExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/ExtensionsTest.cs
@@ -9,6 +9,7 @@ namespace CloudNative.CloudEvents.UnitTests
     using System.Text;
     using CloudNative.CloudEvents.Extensions;
     using Xunit;
+    using static TestHelpers;
 
     public class ExtensionsTest
     {
@@ -72,9 +73,8 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                cloudEvent.Time.Value.ToUniversalTime());
-            
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
+
             Assert.Equal("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", cloudEvent.Extension<DistributedTracingExtension>().TraceParent);
             Assert.Equal("rojo=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01,congo=lZWRzIHRoNhcm5hbCBwbGVhc3VyZS4=", cloudEvent.Extension<DistributedTracingExtension>().TraceState);
         }
@@ -91,8 +91,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
 
             Assert.Equal("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", cloudEvent.Extension<DistributedTracingExtension>().TraceParent);
             Assert.Equal("rojo=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01,congo=lZWRzIHRoNhcm5hbCBwbGVhc3VyZS4=", cloudEvent.Extension<DistributedTracingExtension>().TraceState);
@@ -107,8 +106,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
 
             Assert.Equal("Integer", cloudEvent.Extension<SequenceExtension>().SequenceType);
             Assert.Equal("25", cloudEvent.Extension<SequenceExtension>().Sequence);
@@ -126,8 +124,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
 
             Assert.Equal("Integer", cloudEvent.Extension<SequenceExtension>().SequenceType);
             Assert.Equal("25", cloudEvent.Extension<SequenceExtension>().Sequence);
@@ -142,8 +139,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
 
             Assert.Equal(25, cloudEvent.Extension<IntegerSequenceExtension>().Sequence);
         }
@@ -160,8 +156,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
 
             Assert.Equal(25, cloudEvent.Extension<IntegerSequenceExtension>().Sequence);
         }
@@ -175,8 +170,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
 
             Assert.Equal(1, cloudEvent.Extension<SamplingExtension>().SampledRate.Value);
         }
@@ -193,8 +187,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
 
             Assert.Equal(1, cloudEvent.Extension<SamplingExtension>().SampledRate.Value);
         }

--- a/test/CloudNative.CloudEvents.UnitTests/HttpTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/HttpTest.cs
@@ -13,9 +13,12 @@ namespace CloudNative.CloudEvents.UnitTests
     using System.Net.Mime;
     using System.Threading.Tasks;
     using Xunit;
+    using static TestHelpers;
 
     public class HttpTest : IDisposable
     {
+        private static readonly DateTimeOffset sampleTimestamp = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero);
+
         const string listenerAddress = "http://localhost:52671/";
 
         const string testContextHeader = "testcontext";
@@ -94,7 +97,7 @@ namespace CloudNative.CloudEvents.UnitTests
                         new Uri("https://github.com/cloudevents/spec/pull/123"))
                     {
                         Id = "A234-1234-1234",
-                        Time = new DateTime(2018, 4, 5, 17, 31, 0, DateTimeKind.Utc),
+                        Time = sampleTimestamp,
                         DataContentType = new ContentType(MediaTypeNames.Text.Xml),
                         Data = "<much wow=\"xml\"/>"
                     };
@@ -134,8 +137,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
             Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                receivedCloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual(sampleTimestamp, receivedCloudEvent.Time.Value);
             Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), receivedCloudEvent.DataContentType);
             using (var sr = new StreamReader((Stream)receivedCloudEvent.Data))
             {
@@ -154,7 +156,7 @@ namespace CloudNative.CloudEvents.UnitTests
                 new Uri("https://github.com/cloudevents/spec/pull/123"))
             {
                 Id = "A234-1234-1234",
-                Time = new DateTime(2018, 4, 5, 17, 31, 0, DateTimeKind.Utc),
+                Time = sampleTimestamp,
                 DataContentType = new ContentType(MediaTypeNames.Text.Xml),
                 Data = "<much wow=\"xml\"/>"
             };
@@ -179,8 +181,7 @@ namespace CloudNative.CloudEvents.UnitTests
                     Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
                     Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
                     Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-                    Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                        receivedCloudEvent.Time.Value.ToUniversalTime());
+                    AssertTimestampsEqual(sampleTimestamp, cloudEvent.Time.Value);
                     Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), receivedCloudEvent.DataContentType);
 
                     // The non-ASCII attribute value should have been URL-encoded using UTF-8 for the header.
@@ -231,7 +232,7 @@ namespace CloudNative.CloudEvents.UnitTests
                         new Uri("https://github.com/cloudevents/spec/pull/123"))
                     {
                         Id = "A234-1234-1234",
-                        Time = new DateTime(2018, 4, 5, 17, 31, 0, DateTimeKind.Utc),
+                        Time = sampleTimestamp,
                         DataContentType = new ContentType(MediaTypeNames.Text.Xml),
                         Data = "<much wow=\"xml\"/>"
                     };
@@ -267,8 +268,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
             Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                receivedCloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual(sampleTimestamp, receivedCloudEvent.Time.Value);
             Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), receivedCloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
 
@@ -284,7 +284,7 @@ namespace CloudNative.CloudEvents.UnitTests
                 new Uri("https://github.com/cloudevents/spec/pull/123"))
             {
                 Id = "A234-1234-1234",
-                Time = new DateTime(2018, 4, 5, 17, 31, 0, DateTimeKind.Utc),
+                Time = sampleTimestamp,
                 DataContentType = new ContentType(MediaTypeNames.Text.Xml),
                 Data = "<much wow=\"xml\"/>"
             };
@@ -321,8 +321,7 @@ namespace CloudNative.CloudEvents.UnitTests
                     Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
                     Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
                     Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-                    Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                        receivedCloudEvent.Time.Value.ToUniversalTime());
+                    AssertTimestampsEqual(sampleTimestamp, cloudEvent.Time.Value);
                     Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), receivedCloudEvent.DataContentType);
                     Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
 
@@ -359,7 +358,7 @@ namespace CloudNative.CloudEvents.UnitTests
                 new Uri("https://github.com/cloudevents/spec/pull/123"))
             {
                 Id = "A234-1234-1234",
-                Time = new DateTime(2018, 4, 5, 17, 31, 0, DateTimeKind.Utc),
+                Time = sampleTimestamp,
                 DataContentType = new ContentType(MediaTypeNames.Text.Xml),
                 Data = "<much wow=\"xml\"/>"
             };
@@ -384,8 +383,7 @@ namespace CloudNative.CloudEvents.UnitTests
                     Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
                     Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
                     Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-                    Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                        receivedCloudEvent.Time.Value.ToUniversalTime());
+                    AssertTimestampsEqual(sampleTimestamp, cloudEvent.Time.Value);
                     Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), receivedCloudEvent.DataContentType);
                     using (var sr = new StreamReader((Stream) receivedCloudEvent.Data))
                     {
@@ -427,7 +425,7 @@ namespace CloudNative.CloudEvents.UnitTests
                 new Uri("https://github.com/cloudevents/spec/pull/123"))
             {
                 Id = "A234-1234-1234",
-                Time = new DateTime(2018, 4, 5, 17, 31, 0, DateTimeKind.Utc),
+                Time = sampleTimestamp,
                 DataContentType = new ContentType(MediaTypeNames.Text.Xml),
                 Data = "<much wow=\"xml\"/>"
             };
@@ -455,8 +453,7 @@ namespace CloudNative.CloudEvents.UnitTests
                     Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
                     Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
                     Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-                    Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                        receivedCloudEvent.Time.Value.ToUniversalTime());
+                    AssertTimestampsEqual(sampleTimestamp, cloudEvent.Time.Value);
                     Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), receivedCloudEvent.DataContentType);
                     Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
 

--- a/test/CloudNative.CloudEvents.UnitTests/JsonTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/JsonTest.cs
@@ -8,6 +8,7 @@ namespace CloudNative.CloudEvents.UnitTests
     using System.Net.Mime;
     using System.Text;
     using Xunit;
+    using static TestHelpers;
 
     public class JsonTest
     {
@@ -50,7 +51,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal(cloudEvent2.Type, cloudEvent.Type);
             Assert.Equal(cloudEvent2.Source, cloudEvent.Source);
             Assert.Equal(cloudEvent2.Id, cloudEvent.Id);
-            Assert.Equal(cloudEvent2.Time.Value.ToUniversalTime(), cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual(cloudEvent2.Time, cloudEvent.Time);
             Assert.Equal(cloudEvent2.DataContentType, cloudEvent.DataContentType);
             Assert.Equal(cloudEvent2.Data, cloudEvent.Data);
         }
@@ -67,7 +68,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal(cloudEvent2.Type, cloudEvent.Type);
             Assert.Equal(cloudEvent2.Source, cloudEvent.Source);
             Assert.Equal(cloudEvent2.Id, cloudEvent.Id);
-            Assert.Equal(cloudEvent2.Time.Value.ToUniversalTime(), cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual(cloudEvent2.Time, cloudEvent.Time);
             Assert.Equal(cloudEvent2.DataContentType, cloudEvent.DataContentType);
             Assert.Equal(cloudEvent2.Data, cloudEvent.Data);
         }
@@ -85,7 +86,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal(cloudEvent2.Type, cloudEvent.Type);
             Assert.Equal(cloudEvent2.Source, cloudEvent.Source);
             Assert.Equal(cloudEvent2.Id, cloudEvent.Id);
-            Assert.Equal(cloudEvent2.Time.Value.ToUniversalTime(), cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual(cloudEvent2.Time, cloudEvent.Time);
             Assert.Equal(cloudEvent2.DataContentType, cloudEvent.DataContentType);
             Assert.Equal(cloudEvent2.Data, cloudEvent.Data);
         }
@@ -103,7 +104,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal(cloudEvent2.Type, cloudEvent.Type);
             Assert.Equal(cloudEvent2.Source, cloudEvent.Source);
             Assert.Equal(cloudEvent2.Id, cloudEvent.Id);
-            Assert.Equal(cloudEvent2.Time.Value.ToUniversalTime(), cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual(cloudEvent2.Time, cloudEvent.Time);
             Assert.Equal(cloudEvent2.DataContentType, cloudEvent.DataContentType);
             Assert.Equal(cloudEvent2.Data, cloudEvent.Data);
         }
@@ -117,8 +118,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
             Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), cloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
 
@@ -136,8 +136,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
             Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), cloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
 
@@ -155,8 +154,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
             Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), cloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
 
@@ -173,8 +171,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                cloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
             Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), cloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
 

--- a/test/CloudNative.CloudEvents.UnitTests/MqttTests.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/MqttTests.cs
@@ -17,6 +17,7 @@ namespace CloudNative.CloudEvents.UnitTests
     using MQTTnet;
     using MQTTnet.Client;
     using MQTTnet.Server;
+    using static TestHelpers;
 
     public class MqttTest : IDisposable
     {
@@ -46,7 +47,7 @@ namespace CloudNative.CloudEvents.UnitTests
                 new Uri("https://github.com/cloudevents/spec/pull/123"))
             {
                 Id = "A234-1234-1234",
-                Time = new DateTime(2018, 4, 5, 17, 31, 0, DateTimeKind.Utc),
+                Time = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero),
                 DataContentType = new ContentType(MediaTypeNames.Text.Xml),
                 Data = "<much wow=\"xml\"/>"
             };
@@ -77,19 +78,12 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
             Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-            Assert.Equal(DateTime.Parse("2018-04-05T17:31:00Z").ToUniversalTime(),
-                receivedCloudEvent.Time.Value.ToUniversalTime());
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time.Value);
             Assert.Equal(new ContentType(MediaTypeNames.Text.Xml), receivedCloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
 
             var attr = receivedCloudEvent.GetAttributes();
             Assert.Equal("value", (string)attr["comexampleextension1"]);
-            
-
-
-
-
         }
-
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/TestHelpers.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/TestHelpers.cs
@@ -1,0 +1,61 @@
+﻿// Copyright 2021 Cloud Native Foundation. 
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+using Xunit;
+
+namespace CloudNative.CloudEvents.UnitTests
+{
+    /// <summary>
+    /// Helpers for test code, e.g. common non-trivial assertions.
+    /// </summary>
+    internal class TestHelpers
+    {
+        /// <summary>
+        /// Asserts that two timestamp values are equal, expressing the expected value as a
+        /// string for compact testing.
+        /// </summary>
+        /// <param name="expected">The expected value, as a string</param>
+        /// <param name="actual">The value to test against</param>
+        internal static void AssertTimestampsEqual(string expected, DateTimeOffset actual)
+        {
+            // TODO: Use common RFC-3339 parsing code when we have it.
+            DateTimeOffset expectedDto = DateTimeOffset.ParseExact(expected, "yyyy-MM-dd'T'HH:mm:ss.FFFFFFFK", CultureInfo.InvariantCulture);
+            AssertTimestampsEqual(expectedDto, actual);
+        }
+
+        /// <summary>
+        /// Asserts that two timestamp values are equal, in both "instant being represented"
+        /// and "UTC offset".
+        /// </summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="actual">The value to test against</param>
+        internal static void AssertTimestampsEqual(DateTimeOffset expected, DateTimeOffset actual)
+        {
+            Assert.Equal(expected.UtcDateTime, actual.UtcDateTime);
+            Assert.Equal(expected.Offset, actual.Offset);
+        }
+
+        /// <summary>
+        /// Asserts that two timestamp values are equal, in both "instant being represented"
+        /// and "UTC offset". This overload accepts nullable values, and requires that both
+        /// values are null or neither is.
+        /// </summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="actual">The value to test against</param>
+        internal static void AssertTimestampsEqual(DateTimeOffset? expected, DateTimeOffset? actual)
+        {
+            if (expected is null && actual is null)
+            {
+                return;
+            }
+            if (expected is null || actual is null)
+            {
+                Assert.True(false, "Expected both values to be null, or neither to be null");
+            }
+            AssertTimestampsEqual(expected.Value, actual.Value);
+        }
+    }
+}

--- a/test/CloudNative.CloudEvents.UnitTests/TimestampsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/TimestampsTest.cs
@@ -1,0 +1,177 @@
+﻿// Copyright 2021 Cloud Native Foundation. 
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using System;
+using Xunit;
+
+namespace CloudNative.CloudEvents.UnitTests
+{
+    using static TestHelpers;
+
+    public class TimestampsTest
+    {
+        // TryParse and Parse are tested together, as they're effectively alternatives for the same thing.
+
+        /// <summary>
+        /// Just a selection of simple tests; this is not trying to be exhaustive.
+        /// (The other parse tests check specific aspects more thoroughly.)
+        /// </summary>
+        [Theory]
+        [InlineData("2021-01-18T14:52:01Z", 2021, 1, 18, 14, 52, 1, 0, 0)]
+        [InlineData("2000-02-29T01:23:45.678+01:30", 2000, 2, 29, 1, 23, 45, 6_780_000, 90)]
+        [InlineData("2000-02-29T01:23:45-01:30", 2000, 2, 29, 1, 23, 45, 0, -90)]
+        void Parse_Success_Simple(string text, int year, int month, int day, int hour, int minute, int second, int ticks, int offsetMinutes)
+        {
+            var expected = new DateTimeOffset(year, month, day, hour, minute, second, 0, TimeSpan.FromMinutes(offsetMinutes))
+                .AddTicks(ticks);
+            AssertParseSuccess(expected, text);
+        }
+
+        [Theory]
+        [InlineData("", 0)]
+        [InlineData(".0", 0)]
+        [InlineData(".1", 1_000_000)]
+        [InlineData(".12", 1_200_000)]
+        [InlineData(".123", 1_230_000)]
+        [InlineData(".1234", 1_234_000)]
+        [InlineData(".12345", 1_234_500)]
+        [InlineData(".123456", 1_234_560)]
+        [InlineData(".1234567", 1_234_567)]
+        // We truncate nanoseconds to the tick
+        [InlineData(".12345678", 1_234_567)]
+        [InlineData(".123456789", 1_234_567)]
+        // (Realistically we're unlikely to get any values with greater precision than nanoseconds, but
+        // we might as well test it.)
+        [InlineData(".12345678912345", 1_234_567)]
+        void Parse_Success_VaryingFractionalSeconds(string fractionalPart, int expectedTicks)
+        {
+            string text = $"2021-01-18T14:52:01{fractionalPart}+05:00";
+            DateTimeOffset expected = new DateTimeOffset(2021, 1, 18, 14, 52, 1, 0, TimeSpan.FromHours(5))
+                .AddTicks(expectedTicks);
+            AssertParseSuccess(expected, text);
+        }
+
+        [Theory]
+        [InlineData("Z", 0)]
+        // Alternative way of representing UTC (this is perfectly valid).
+        [InlineData("+00:00", 0)]
+        // This is the "unknown local offset". We treat this as UTC, as there is no reasonable
+        // way to express it as a DateTimeOffset, and that's better than failing. It's unlikely
+        // we'll ever see this, and arguably it's not really a "timestamp" at that point anyway.
+        [InlineData("-00:00", 0)]
+        [InlineData("+01:00", 60)]
+        [InlineData("-01:00", -60)]
+        [InlineData("+01:30", 90)]
+        [InlineData("-01:30", -90)]
+        // Extreme values
+        [InlineData("+14:00", 14 * 60)]
+        [InlineData("-14:00", -14 * 60)]
+        void Parse_Success_VaryingUtcOffset(string offsetPart, int expectedOffsetMinutes)
+        {
+            // No fractional seconds
+            string text = $"2021-01-18T14:52:01{offsetPart}";
+            DateTimeOffset expected = new DateTimeOffset(2021, 1, 18, 14, 52, 1, 0, TimeSpan.FromMinutes(expectedOffsetMinutes));
+            AssertParseSuccess(expected, text);
+
+            // Single check for fractional seconds
+            text = $"2021-01-18T14:52:01.500{offsetPart}";
+            expected = expected.AddMilliseconds(500);
+            AssertParseSuccess(expected, text);
+        }
+
+        static void AssertParseSuccess(DateTimeOffset expected, string text)
+        {
+            var parsed = Timestamps.Parse(text);
+            AssertTimestampsEqual(expected, parsed);
+
+            Assert.True(Timestamps.TryParse(text, out parsed));
+            AssertTimestampsEqual(expected, parsed);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("garbage")]
+        [InlineData("garbage that is long enough")]
+        [InlineData("2021-01-18T14:52:01")] // No UTC offset indicator
+        [InlineData("2021-01-18T14:52:01.1234567XYZ")] // Garbage after 7 significant digits of sub-second
+        [InlineData("2021-01-18T14:52:01Z01")] // Text after UTC offset indicator
+        [InlineData("2021-01-18T14:52:01X")] // Garbage UTC offset indicator
+        [InlineData("2021-01-18T14:52:01+XX:XX")] // Garbage UTC offset indicator (but right length)
+        [InlineData("2021-01-18T14:52:01+01")] // Hour-only UTC offset indicator
+        [InlineData("2021-01-18T14:52:01+01:30:30")] // Sub-minute UTC offset indicator
+        [InlineData("2021-01-18T14:52:01+14:01")] // UTC offset indicator out of range
+        [InlineData("2021-01-18T14:52:01-14:01")] // UTC offset indicator out of range
+        [InlineData("2021-01-18T14:52:01-00:60")] // UTC offset indicator with invalid minutes
+        [InlineData("2021-01-18 14:52:01Z")] // Space instead of 'T'
+        [InlineData("2100-02-29T14:52:01Z")] // Feb 29th in non-leap-year
+        [InlineData("10000-01-01T00:00:00Z")] // Year out of range
+        [InlineData("2021-13-01T00:00:00Z")] // Month out of range
+        [InlineData("2021-01-50T00:00:00Z")] // Day out of range
+        [InlineData("2021-01-18T24:00:00Z")] // Hour out of range
+        [InlineData("2021-01-18T14:60:00Z")] // Minute out of range
+        [InlineData("2021-01-18T14:00:60Z")] // Second out of range
+        [InlineData("100-01-01T00:00:00Z")] // Non-padded year
+        [InlineData("2021-1-01T00:00:00Z")] // Non-padded month
+        [InlineData("2021-01-1T00:00:00Z")] // Non-padded day
+        [InlineData("2021-01-01T1:00:00Z")] // Non-padded hour
+        [InlineData("2021-01-01T00:1:00Z")] // Non-padded minute
+        [InlineData("2021-01-01T00:01:1Z")] // Non-padded second
+        [InlineData("2021-01-01T00:01Z")] // No second part
+        void Parse_Failure(string text)
+        {
+            Assert.False(Timestamps.TryParse(text, out _));
+            Assert.Throws<FormatException>(() => Timestamps.Parse(text));
+        }
+
+        /// <summary>
+        /// As we're already testing parsing thoroughly, the simplest way of providing
+        /// a value to format is to parse a string. Many examples will round-trip, in which
+        /// case it's simple just to provide the information once.
+        /// <see cref="Format_NonRoundtrip(string, string)"/> tests situations which don't round-trip.
+        /// </summary>
+        /// <param name="input"></param>
+        [Theory]
+        [InlineData("2021-01-18T14:52:01Z")]
+        [InlineData("2000-02-29T01:23:45.678+01:30")]
+        [InlineData("2000-02-29T01:23:45-01:30")]
+        [InlineData("2000-02-29T01:23:45.678+10:00")]
+        [InlineData("2000-02-29T01:23:45-10:00")]
+        [InlineData("2021-01-18T14:52:01.100Z")]
+        [InlineData("2021-01-18T14:52:01.120Z")]
+        [InlineData("2021-01-18T14:52:01.123Z")]
+        [InlineData("2021-01-18T14:52:01.123400Z")]
+        [InlineData("2021-01-18T14:52:01.123450Z")]
+        [InlineData("2021-01-18T14:52:01.123456Z")]
+        [InlineData("2021-01-18T14:52:01.1234567Z")]
+        void Format_Roundtrip(string input)
+        {
+            var parsed = Timestamps.Parse(input);
+            var formatted = Timestamps.Format(parsed);
+            Assert.Equal(input, formatted);
+        }
+
+        [Theory]
+        // Zero offset normalized to Z
+        [InlineData("2021-01-18T14:52:01+00:00", "2021-01-18T14:52:01Z")]
+        [InlineData("2021-01-18T14:52:01-00:00", "2021-01-18T14:52:01Z")]
+        // Second precision
+        [InlineData("2000-02-29T01:23:45.000-01:30", "2000-02-29T01:23:45-01:30")]
+        // Millisecond precision
+        [InlineData("2000-02-29T01:23:45.67+01:30", "2000-02-29T01:23:45.670+01:30")]
+        [InlineData("2000-02-29T01:23:45.678000+01:30", "2000-02-29T01:23:45.678+01:30")]
+        [InlineData("2000-02-29T01:23:45.6780000000+01:30", "2000-02-29T01:23:45.678+01:30")]
+        // Microssecond precision
+        [InlineData("2000-02-29T01:23:45.6781+01:30", "2000-02-29T01:23:45.678100+01:30")]
+        [InlineData("2000-02-29T01:23:45.6781000+01:30", "2000-02-29T01:23:45.678100+01:30")]
+        [InlineData("2000-02-29T01:23:45.6781000000+01:30", "2000-02-29T01:23:45.678100+01:30")]
+        // Tick precision
+        [InlineData("2021-01-18T14:52:01.123456789Z", "2021-01-18T14:52:01.1234567Z")]
+        void Format_NonRoundtrip(string input, string expectedFormatted)
+        {
+            var parsed = Timestamps.Parse(input);
+            var formatted = Timestamps.Format(parsed);
+            Assert.Equal(expectedFormatted, formatted);
+        }
+    }
+}


### PR DESCRIPTION
I'd advise reviewing one commit at a time.

I expect there are still some "interesting" cases that aren't covered yet, but which will be fixed as we improve CloudEventAttributes and CloudEventFormatter for other issues.