### PR TITLE
Make the spec version of an event immutable

### DIFF
--- a/src/CloudNative.CloudEvents/CloudEvent.cs
+++ b/src/CloudNative.CloudEvents/CloudEvent.cs
@@ -71,8 +71,13 @@ namespace CloudNative.CloudEvents
         /// <param name="specVersion">CloudEvents specification version</param>
         /// <param name="extensions">Extensions to be added to this CloudEvents</param>
         public CloudEvent(CloudEventsSpecVersion specVersion, IEnumerable<ICloudEventExtension> extensions)
+            : this(new CloudEventAttributes(specVersion, extensions), extensions)
         {
-            attributes = new CloudEventAttributes(specVersion, extensions);
+        }
+
+        private CloudEvent(CloudEventAttributes attributes, IEnumerable<ICloudEventExtension> extensions)
+        {
+            this.attributes = attributes;
             var extensionMap = new Dictionary<Type, ICloudEventExtension>();
             if (extensions != null)
             {
@@ -155,11 +160,11 @@ namespace CloudNative.CloudEvents
         /// specification which the event uses. This enables the interpretation of the context.
         /// </summary>
         /// <see cref="https://github.com/cloudevents/spec/blob/master/spec.md#specversion"/>
-        public CloudEventsSpecVersion SpecVersion
-        {
-            get => attributes.SpecVersion;
-            set => attributes.SpecVersion = value;
-        }
+        public CloudEventsSpecVersion SpecVersion => attributes.SpecVersion;
+
+        // TODO: Consider exposing publicly.
+        internal CloudEvent WithSpecVersion(CloudEventsSpecVersion newSpecVersion) =>
+            new CloudEvent(attributes.WithSpecVersion(newSpecVersion), Extensions.Values);
 
         /// <summary>
         /// CloudEvents 'subject' attribute. This describes the subject of the event in the context

--- a/src/CloudNative.CloudEvents/Strings.Designer.cs
+++ b/src/CloudNative.CloudEvents/Strings.Designer.cs
@@ -160,11 +160,11 @@ namespace CloudNative.CloudEvents {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The &apos;specversion&apos; attribute cannot be cleared.
+        ///   Looks up a localized string similar to The &apos;specversion&apos; attribute cannot be modified.
         /// </summary>
-        internal static string ErrorSpecVersionCannotBeCleared {
+        internal static string ErrorSpecVersionCannotBeModified {
             get {
-                return ResourceManager.GetString("ErrorSpecVersionCannotBeCleared", resourceCulture);
+                return ResourceManager.GetString("ErrorSpecVersionCannotBeModified", resourceCulture);
             }
         }
         

--- a/src/CloudNative.CloudEvents/Strings.resx
+++ b/src/CloudNative.CloudEvents/Strings.resx
@@ -150,8 +150,8 @@
   <data name="ErrorSourceValueIsNotAUri" xml:space="preserve">
     <value>The 'source' attribute value must be a valid absolute or relative URI</value>
   </data>
-  <data name="ErrorSpecVersionCannotBeCleared" xml:space="preserve">
-    <value>The 'specversion' attribute cannot be cleared</value>
+  <data name="ErrorSpecVersionCannotBeModified" xml:space="preserve">
+    <value>The 'specversion' attribute cannot be modified</value>
   </data>
   <data name="ErrorSpecVersionValueIsNotAString" xml:space="preserve">
     <value>The 'specversion' attribute value must be a string</value>

--- a/test/CloudNative.CloudEvents.UnitTests/ConstructorTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/ConstructorTest.cs
@@ -118,7 +118,7 @@ namespace CloudNative.CloudEvents.UnitTests
             attrs["comexampleextension1"] = "value";
             attrs["comexampleextension2"] = new { othervalue = 5 };
 
-            cloudEvent.SpecVersion = CloudEventsSpecVersion.V0_2;
+            cloudEvent = cloudEvent.WithSpecVersion(CloudEventsSpecVersion.V0_2);
 
             Assert.Equal(CloudEventsSpecVersion.V0_2, cloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
@@ -149,7 +149,7 @@ namespace CloudNative.CloudEvents.UnitTests
             var attrs = cloudEvent.GetAttributes();
             attrs["comexampleextension1"] = "value";
 
-            cloudEvent.SpecVersion = CloudEventsSpecVersion.V1_0;
+            cloudEvent = cloudEvent.WithSpecVersion(CloudEventsSpecVersion.V1_0);
 
             Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", cloudEvent.Type);

--- a/test/CloudNative.CloudEvents.UnitTests/JsonTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/JsonTest.cs
@@ -78,7 +78,7 @@ namespace CloudNative.CloudEvents.UnitTests
         {
             var jsonFormatter = new JsonEventFormatter();
             var cloudEvent = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(jsonv02));
-            cloudEvent.SpecVersion = CloudEventsSpecVersion.V0_1;
+            cloudEvent = cloudEvent.WithSpecVersion(CloudEventsSpecVersion.V0_1);
             var jsonData = jsonFormatter.EncodeStructuredEvent(cloudEvent, out var contentType);
             var cloudEvent2 = jsonFormatter.DecodeStructuredEvent(jsonData);
 
@@ -96,7 +96,7 @@ namespace CloudNative.CloudEvents.UnitTests
         {
             var jsonFormatter = new JsonEventFormatter();
             var cloudEvent = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(jsonv10));
-            cloudEvent.SpecVersion = CloudEventsSpecVersion.V0_2;
+            cloudEvent = cloudEvent.WithSpecVersion(CloudEventsSpecVersion.V0_2);
             var jsonData = jsonFormatter.EncodeStructuredEvent(cloudEvent, out var contentType);
             var cloudEvent2 = jsonFormatter.DecodeStructuredEvent(jsonData);
 


### PR DESCRIPTION
This commit includes two WithSpecVersion methods, one in CloudEvent
and the other in CloudEventAttributes, which convert from one
version to another. These are currently internal, but we can expose
them later if we wish.

Fixes #65
Fixed #66

Creating this commit has raised more issues to discuss:

- CloudEventSpecVersion.Default is a public enum value; changing that
  later would be a breaking change in difficult-to-document ways.
- In general, CloudEventSpecVersion feels like it deserves to be a
  class with well-known specific instances, rather than an enum. That
  would make various things much simpler.
- Given that attributes other than data have a limited set of types,
  I suspect it's worth having a CloudEventAttribute type encapsulating
  that.

Signed-off-by: Jon Skeet <jonskeet@google.com>