### PR TITLE
feat: Extract the existing JSON event formatter from the main SDK

### DIFF
--- a/CloudEvents.sln
+++ b/CloudEvents.sln
@@ -31,6 +31,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CloudNative.CloudEvents.Int
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CloudNative.CloudEvents.Avro", "src\CloudNative.CloudEvents.Avro\CloudNative.CloudEvents.Avro.csproj", "{E4BE54BF-F4D7-495F-9278-07E5A8C79935}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CloudNative.CloudEvents.NewtonsoftJson", "src\CloudNative.CloudEvents.NewtonsoftJson\CloudNative.CloudEvents.NewtonsoftJson.csproj", "{9DC17081-21D8-4123-8650-D97C2153DB8C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -161,6 +163,18 @@ Global
 		{E4BE54BF-F4D7-495F-9278-07E5A8C79935}.Release|x64.Build.0 = Release|Any CPU
 		{E4BE54BF-F4D7-495F-9278-07E5A8C79935}.Release|x86.ActiveCfg = Release|Any CPU
 		{E4BE54BF-F4D7-495F-9278-07E5A8C79935}.Release|x86.Build.0 = Release|Any CPU
+		{9DC17081-21D8-4123-8650-D97C2153DB8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9DC17081-21D8-4123-8650-D97C2153DB8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9DC17081-21D8-4123-8650-D97C2153DB8C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9DC17081-21D8-4123-8650-D97C2153DB8C}.Debug|x64.Build.0 = Debug|Any CPU
+		{9DC17081-21D8-4123-8650-D97C2153DB8C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9DC17081-21D8-4123-8650-D97C2153DB8C}.Debug|x86.Build.0 = Debug|Any CPU
+		{9DC17081-21D8-4123-8650-D97C2153DB8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9DC17081-21D8-4123-8650-D97C2153DB8C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9DC17081-21D8-4123-8650-D97C2153DB8C}.Release|x64.ActiveCfg = Release|Any CPU
+		{9DC17081-21D8-4123-8650-D97C2153DB8C}.Release|x64.Build.0 = Release|Any CPU
+		{9DC17081-21D8-4123-8650-D97C2153DB8C}.Release|x86.ActiveCfg = Release|Any CPU
+		{9DC17081-21D8-4123-8650-D97C2153DB8C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/CloudNative.CloudEvents.AspNetCoreSample/CloudNative.CloudEvents.AspNetCoreSample.csproj
+++ b/samples/CloudNative.CloudEvents.AspNetCoreSample/CloudNative.CloudEvents.AspNetCoreSample.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\CloudNative.CloudEvents.AspNetCore\CloudNative.CloudEvents.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\CloudNative.CloudEvents\CloudNative.CloudEvents.csproj" />
+    <ProjectReference Include="..\..\src\CloudNative.CloudEvents.NewtonsoftJson\CloudNative.CloudEvents.NewtonsoftJson.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/CloudNative.CloudEvents.AspNetCoreSample/Startup.cs
+++ b/samples/CloudNative.CloudEvents.AspNetCoreSample/Startup.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
+using CloudNative.CloudEvents.NewtonsoftJson;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -24,7 +25,7 @@ namespace CloudNative.CloudEvents.AspNetCoreSample
         {
             services.AddControllers(opts =>
             {
-                opts.InputFormatters.Insert(0, new CloudEventJsonInputFormatter());
+                opts.InputFormatters.Insert(0, new CloudEventJsonInputFormatter(new JsonEventFormatter()));
             });
         }
 

--- a/samples/HttpSend/HttpSend.csproj
+++ b/samples/HttpSend/HttpSend.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\CloudNative.CloudEvents\CloudNative.CloudEvents.csproj" />
+    <ProjectReference Include="..\..\src\CloudNative.CloudEvents.NewtonsoftJson\CloudNative.CloudEvents.NewtonsoftJson.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/HttpSend/Program.cs
+++ b/samples/HttpSend/Program.cs
@@ -2,15 +2,16 @@
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
+using CloudNative.CloudEvents;
+using CloudNative.CloudEvents.Http;
+using CloudNative.CloudEvents.NewtonsoftJson;
+using McMaster.Extensions.CommandLineUtils;
+using Newtonsoft.Json;
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Net.Http;
 using System.Net.Mime;
 using System.Threading.Tasks;
-using CloudNative.CloudEvents;
-using CloudNative.CloudEvents.Http;
-using McMaster.Extensions.CommandLineUtils;
-using Newtonsoft.Json;
 
 namespace HttpSend
 {

--- a/src/CloudNative.CloudEvents.AspNetCore/CloudEventJsonInputFormatter.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/CloudEventJsonInputFormatter.cs
@@ -2,23 +2,25 @@
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.Net.Http.Headers;
 using System;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc.Formatters;
-using Microsoft.Net.Http.Headers;
 
 namespace CloudNative.CloudEvents
 {
     // FIXME: This doesn't get called for binary CloudEvents without content, or with a different data content type.
+    // FIXME: This shouldn't really be tied to JSON. We need to work out how we actually want this to be used.
+    // See 
 
     public class CloudEventJsonInputFormatter : TextInputFormatter
     {
         private readonly ICloudEventFormatter _formatter;
 
-        public CloudEventJsonInputFormatter()
+        public CloudEventJsonInputFormatter(ICloudEventFormatter formatter)
         {
-            _formatter = new JsonEventFormatter();
+            _formatter = formatter;
             SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/json"));
             SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/cloudevents+json"));
 

--- a/src/CloudNative.CloudEvents.NewtonsoftJson/CloudNative.CloudEvents.NewtonsoftJson.csproj
+++ b/src/CloudNative.CloudEvents.NewtonsoftJson/CloudNative.CloudEvents.NewtonsoftJson.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Description>JSON support for the CNCF CloudEvents SDK, based on Newtonsoft.Json.</Description>
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CloudNative.CloudEvents\CloudNative.CloudEvents.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/CloudNative.CloudEvents.NewtonsoftJson/JsonEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.NewtonsoftJson/JsonEventFormatter.cs
@@ -11,7 +11,7 @@ using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace CloudNative.CloudEvents
+namespace CloudNative.CloudEvents.NewtonsoftJson
 {
     /// <summary>
     /// Formatter that implements the JSON Event Format

--- a/src/CloudNative.CloudEvents/CloudNative.CloudEvents.csproj
+++ b/src/CloudNative.CloudEvents/CloudNative.CloudEvents.csproj
@@ -7,10 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Update="Strings.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/test/CloudNative.CloudEvents.IntegrationTests/AspNetCore/CloudEventControllerTests.cs
+++ b/test/CloudNative.CloudEvents.IntegrationTests/AspNetCore/CloudEventControllerTests.cs
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 
 using CloudNative.CloudEvents.AspNetCoreSample;
+using CloudNative.CloudEvents.NewtonsoftJson;
 using CloudNative.CloudEvents.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
 using System;

--- a/test/CloudNative.CloudEvents.UnitTests/Amqp/AmqpTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Amqp/AmqpTest.cs
@@ -6,6 +6,7 @@ using System;
 using System.Net.Mime;
 using Amqp;
 using Xunit;
+using CloudNative.CloudEvents.NewtonsoftJson;
 using static CloudNative.CloudEvents.UnitTests.TestHelpers;
 
 namespace CloudNative.CloudEvents.Amqp.UnitTests

--- a/test/CloudNative.CloudEvents.UnitTests/Avro/AvroEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Avro/AvroEventFormatterTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
+using CloudNative.CloudEvents.NewtonsoftJson;
 using System;
 using System.Net.Mime;
 using System.Text;

--- a/test/CloudNative.CloudEvents.UnitTests/CloudNative.CloudEvents.UnitTests.csproj
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudNative.CloudEvents.UnitTests.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\..\src\CloudNative.CloudEvents.Avro\CloudNative.CloudEvents.Avro.csproj" />
     <ProjectReference Include="..\..\src\CloudNative.CloudEvents.Kafka\CloudNative.CloudEvents.Kafka.csproj" />
     <ProjectReference Include="..\..\src\CloudNative.CloudEvents.Mqtt\CloudNative.CloudEvents.Mqtt.csproj" />
+    <ProjectReference Include="..\..\src\CloudNative.CloudEvents.NewtonsoftJson\CloudNative.CloudEvents.NewtonsoftJson.csproj" />
     <ProjectReference Include="..\..\src\CloudNative.CloudEvents\CloudNative.CloudEvents.csproj" />
   </ItemGroup>
 

--- a/test/CloudNative.CloudEvents.UnitTests/Extensions/DistributedTracingTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Extensions/DistributedTracingTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
+using CloudNative.CloudEvents.NewtonsoftJson;
 using System.Text;
 using Xunit;
 

--- a/test/CloudNative.CloudEvents.UnitTests/Extensions/PartitioningTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Extensions/PartitioningTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
+using CloudNative.CloudEvents.NewtonsoftJson;
 using System.Text;
 using Xunit;
 

--- a/test/CloudNative.CloudEvents.UnitTests/Extensions/SamplingTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Extensions/SamplingTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
+using CloudNative.CloudEvents.NewtonsoftJson;
 using System;
 using System.Text;
 using Xunit;

--- a/test/CloudNative.CloudEvents.UnitTests/Extensions/SequenceTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Extensions/SequenceTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
+using CloudNative.CloudEvents.NewtonsoftJson;
 using System;
 using System.Text;
 using Xunit;

--- a/test/CloudNative.CloudEvents.UnitTests/Http/CloudEventHttpContentTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Http/CloudEventHttpContentTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
+using CloudNative.CloudEvents.NewtonsoftJson;
 using System;
 using System.Net.Http.Headers;
 using Xunit;

--- a/test/CloudNative.CloudEvents.UnitTests/Http/HttpClientExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Http/HttpClientExtensionsTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
+using CloudNative.CloudEvents.NewtonsoftJson;
 using System;
 using System.IO;
 using System.Linq;

--- a/test/CloudNative.CloudEvents.UnitTests/Http/HttpWebExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Http/HttpWebExtensionsTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
+using CloudNative.CloudEvents.NewtonsoftJson;
 using System;
 using System.IO;
 using System.Linq;

--- a/test/CloudNative.CloudEvents.UnitTests/Kafka/KafkaTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Kafka/KafkaTest.cs
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 
 using CloudNative.CloudEvents.Extensions;
+using CloudNative.CloudEvents.NewtonsoftJson;
 using Confluent.Kafka;
 using Newtonsoft.Json;
 using System;

--- a/test/CloudNative.CloudEvents.UnitTests/Mqtt/MqttTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Mqtt/MqttTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
+using CloudNative.CloudEvents.NewtonsoftJson;
 using MQTTnet;
 using MQTTnet.Client;
 using MQTTnet.Server;

--- a/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/JsonEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/JsonEventFormatterTest.cs
@@ -8,7 +8,7 @@ using System.Text;
 using Xunit;
 using static CloudNative.CloudEvents.UnitTests.TestHelpers;
 
-namespace CloudNative.CloudEvents.UnitTests
+namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
 {
     public class JsonEventFormatterTest
     {


### PR DESCRIPTION
This allows us to remove the Newtonsoft.Json dependency from the
SDK, and implement another event formatter based on System.Text.Json
later on. That should probably wait until we've iterated on the
design of event formatters though.

This commit moves us closer towards (but doesn't fix) #42.

Signed-off-by: Jon Skeet <jonskeet@google.com>