### PR TITLE
Revisiting event formatter responsibilities

### DIFF
--- a/src/CloudNative.CloudEvents.Amqp/AmqpClientExtensions.cs
+++ b/src/CloudNative.CloudEvents.Amqp/AmqpClientExtensions.cs
@@ -20,7 +20,7 @@ namespace CloudNative.CloudEvents.Amqp
             message.ApplicationProperties.Map.ContainsKey(SpecVersionAmqpHeader);        
 
         public static CloudEvent ToCloudEvent(this Message message,
-            ICloudEventFormatter formatter,
+            CloudEventFormatter formatter,
             params CloudEventAttribute[] extensionAttributes)
         {
             if (HasCloudEventsContentType(message))

--- a/src/CloudNative.CloudEvents.Amqp/AmqpClientExtensions.cs
+++ b/src/CloudNative.CloudEvents.Amqp/AmqpClientExtensions.cs
@@ -30,10 +30,14 @@ namespace CloudNative.CloudEvents.Amqp
             else
             {
                 var propertyMap = message.ApplicationProperties.Map;
-                CloudEventsSpecVersion version = CloudEventsSpecVersion.Default;
-                if (propertyMap.TryGetValue(SpecVersionAmqpHeader, out var versionId) && versionId is string versionIdText)
+                if (!propertyMap.TryGetValue(SpecVersionAmqpHeader, out var versionId) || !(versionId is string versionIdText))
                 {
-                    version = CloudEventsSpecVersion.FromVersionId(versionIdText);
+                    throw new ArgumentException("Request is not a CloudEvent");
+                }
+                var version = CloudEventsSpecVersion.FromVersionId(versionIdText);
+                if (version is null)
+                {
+                    throw new ArgumentException($"Unsupported CloudEvents spec version '{versionIdText}'");
                 }
 
                 var cloudEvent = new CloudEvent(version, extensionAttributes)

--- a/src/CloudNative.CloudEvents.Amqp/AmqpCloudEventMessage.cs
+++ b/src/CloudNative.CloudEvents.Amqp/AmqpCloudEventMessage.cs
@@ -22,7 +22,7 @@ namespace CloudNative.CloudEvents.Amqp
             {
                 BodySection = new Data
                 {
-                    Binary = formatter.EncodeStructuredEvent(cloudEvent, out var contentType)
+                    Binary = formatter.EncodeStructuredModeMessage(cloudEvent, out var contentType)
                 };
                 Properties = new Properties { ContentType = contentType.MediaType };
                 ApplicationProperties = new ApplicationProperties();

--- a/src/CloudNative.CloudEvents.Amqp/AmqpCloudEventMessage.cs
+++ b/src/CloudNative.CloudEvents.Amqp/AmqpCloudEventMessage.cs
@@ -13,7 +13,7 @@ namespace CloudNative.CloudEvents.Amqp
 {
     public class AmqpCloudEventMessage : Message
     {
-        public AmqpCloudEventMessage(CloudEvent cloudEvent, ContentMode contentMode, ICloudEventFormatter formatter)
+        public AmqpCloudEventMessage(CloudEvent cloudEvent, ContentMode contentMode, CloudEventFormatter formatter)
         {
             ApplicationProperties = new ApplicationProperties();
             MapHeaders(cloudEvent);

--- a/src/CloudNative.CloudEvents.AspNetCore/CloudEventJsonInputFormatter.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/CloudEventJsonInputFormatter.cs
@@ -16,9 +16,9 @@ namespace CloudNative.CloudEvents
 
     public class CloudEventJsonInputFormatter : TextInputFormatter
     {
-        private readonly ICloudEventFormatter _formatter;
+        private readonly CloudEventFormatter _formatter;
 
-        public CloudEventJsonInputFormatter(ICloudEventFormatter formatter)
+        public CloudEventJsonInputFormatter(CloudEventFormatter formatter)
         {
             _formatter = formatter;
             SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/json"));

--- a/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtension.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtension.cs
@@ -33,11 +33,14 @@ namespace CloudNative.CloudEvents
             else
             {
                 var headers = httpRequest.Headers;
-                CloudEventsSpecVersion version = CloudEventsSpecVersion.Default;
-                if (headers.TryGetValue(HttpUtilities.SpecVersionHttpHeader, out var values))
+                if (!headers.TryGetValue(HttpUtilities.SpecVersionHttpHeader, out var versionId))
                 {
-                    string versionId = values.First();
-                    version = CloudEventsSpecVersion.FromVersionId(versionId);
+                    throw new ArgumentException("Request is not a CloudEvent");
+                }
+                var version = CloudEventsSpecVersion.FromVersionId(versionId.First());
+                if (version is null)
+                {
+                    throw new ArgumentException($"Unsupported CloudEvents spec version '{versionId.First()}'");
                 }
 
                 var cloudEvent = new CloudEvent(version, extensionAttributes);

--- a/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtension.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtension.cs
@@ -22,7 +22,7 @@ namespace CloudNative.CloudEvents
         /// <param name="extensions">List of extension instances</param>
         /// <returns>A CloudEvent instance or 'null' if the request message doesn't hold a CloudEvent</returns>
         public static async ValueTask<CloudEvent> ReadCloudEventAsync(this HttpRequest httpRequest,
-            ICloudEventFormatter formatter,
+            CloudEventFormatter formatter,
             params CloudEventAttribute[] extensionAttributes)
         {
             if (HasCloudEventsContentType(httpRequest))

--- a/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
@@ -40,10 +40,10 @@ namespace CloudNative.CloudEvents
             DecodeStructuredEvent(data, (IEnumerable<CloudEventAttribute>)extensionAttributes);
 
         // FIXME: We shouldn't use synchronous stream methods...
-        public Task<CloudEvent> DecodeStructuredEventAsync(Stream data, IEnumerable<CloudEventAttribute> extensionAttributes) =>
+        public override Task<CloudEvent> DecodeStructuredEventAsync(Stream data, IEnumerable<CloudEventAttribute> extensionAttributes) =>
             Task.FromResult(DecodeStructuredEvent(data, extensionAttributes));
 
-        public CloudEvent DecodeStructuredEvent(Stream data, IEnumerable<CloudEventAttribute> extensionAttributes)
+        public override CloudEvent DecodeStructuredEvent(Stream data, IEnumerable<CloudEventAttribute> extensionAttributes)
         {
             var decoder = new Avro.IO.BinaryDecoder(data);
             var rawEvent = avroReader.Read<GenericRecord>(null, decoder);
@@ -53,7 +53,7 @@ namespace CloudNative.CloudEvents
         public CloudEvent DecodeStructuredEvent(byte[] data, params CloudEventAttribute[] extensionAttributes) =>
             DecodeStructuredEvent(data, (IEnumerable<CloudEventAttribute>) extensionAttributes);
 
-        public CloudEvent DecodeStructuredEvent(byte[] data, IEnumerable<CloudEventAttribute> extensionAttributes) =>
+        public override CloudEvent DecodeStructuredEvent(byte[] data, IEnumerable<CloudEventAttribute> extensionAttributes) =>
             DecodeStructuredEvent(new MemoryStream(data), extensionAttributes);
 
         public CloudEvent DecodeGenericRecord(GenericRecord record, IEnumerable<CloudEventAttribute> extensionAttributes)
@@ -106,7 +106,7 @@ namespace CloudNative.CloudEvents
             return cloudEvent;
         }
 
-        public byte[] EncodeStructuredEvent(CloudEvent cloudEvent, out ContentType contentType)
+        public override byte[] EncodeStructuredEvent(CloudEvent cloudEvent, out ContentType contentType)
         {
             contentType = new ContentType(CloudEvent.MediaType+AvroEventFormatter.MediaTypeSuffix);
 
@@ -148,10 +148,10 @@ namespace CloudNative.CloudEvents
         }
 
         // TODO: Validate that this is correct...
-        public byte[] EncodeData(object value) =>
+        public override byte[] EncodeData(object value) =>
             throw new NotSupportedException("The Avro event formatter does not support binary content mode");
 
-        public object DecodeData(byte[] value, string contentType) =>
+        public override object DecodeData(byte[] value, string contentType) =>
             throw new NotSupportedException("The Avro event formatter does not support binary content mode");
     }
 }

--- a/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
@@ -45,7 +45,7 @@ namespace CloudNative.CloudEvents
         public override CloudEvent DecodeStructuredEvent(byte[] data, IEnumerable<CloudEventAttribute> extensionAttributes) =>
             DecodeStructuredEvent(new MemoryStream(data), extensionAttributes);
 
-        public CloudEvent DecodeGenericRecord(GenericRecord record, IEnumerable<CloudEventAttribute> extensionAttributes)
+        private CloudEvent DecodeGenericRecord(GenericRecord record, IEnumerable<CloudEventAttribute> extensionAttributes)
         {
             if (!record.TryGetValue("attribute", out var attrObj))
             {

--- a/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
@@ -36,9 +36,6 @@ namespace CloudNative.CloudEvents
         }
         public const string MediaTypeSuffix = "+avro";
 
-        public CloudEvent DecodeStructuredEvent(Stream data, params CloudEventAttribute[] extensionAttributes) =>
-            DecodeStructuredEvent(data, (IEnumerable<CloudEventAttribute>)extensionAttributes);
-
         // FIXME: We shouldn't use synchronous stream methods...
         public override Task<CloudEvent> DecodeStructuredEventAsync(Stream data, IEnumerable<CloudEventAttribute> extensionAttributes) =>
             Task.FromResult(DecodeStructuredEvent(data, extensionAttributes));
@@ -49,9 +46,6 @@ namespace CloudNative.CloudEvents
             var rawEvent = avroReader.Read<GenericRecord>(null, decoder);
             return DecodeGenericRecord(rawEvent, extensionAttributes);
         }
-
-        public CloudEvent DecodeStructuredEvent(byte[] data, params CloudEventAttribute[] extensionAttributes) =>
-            DecodeStructuredEvent(data, (IEnumerable<CloudEventAttribute>) extensionAttributes);
 
         public override CloudEvent DecodeStructuredEvent(byte[] data, IEnumerable<CloudEventAttribute> extensionAttributes) =>
             DecodeStructuredEvent(new MemoryStream(data), extensionAttributes);

--- a/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
@@ -9,7 +9,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Mime;
-using System.Threading.Tasks;
 
 namespace CloudNative.CloudEvents
 {
@@ -36,13 +35,9 @@ namespace CloudNative.CloudEvents
         }
         public const string MediaTypeSuffix = "+avro";
 
-        // FIXME: We shouldn't use synchronous stream methods...
-        public override Task<CloudEvent> DecodeStructuredEventAsync(Stream data, IEnumerable<CloudEventAttribute> extensionAttributes) =>
-            Task.FromResult(DecodeStructuredEvent(data, extensionAttributes));
-
         public override CloudEvent DecodeStructuredEvent(Stream data, IEnumerable<CloudEventAttribute> extensionAttributes)
         {
-            var decoder = new Avro.IO.BinaryDecoder(data);
+            var decoder = new BinaryDecoder(data);
             var rawEvent = avroReader.Read<GenericRecord>(null, decoder);
             return DecodeGenericRecord(rawEvent, extensionAttributes);
         }

--- a/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
@@ -16,7 +16,7 @@ namespace CloudNative.CloudEvents
     /// <summary>
     /// Formatter that implements the Avro Event Format
     /// </summary>
-    public class AvroEventFormatter : ICloudEventFormatter
+    public class AvroEventFormatter : CloudEventFormatter
     {
         private const string DataName = "data";
         private static readonly RecordSchema avroSchema;

--- a/src/CloudNative.CloudEvents.Kafka/KafkaClientExtensions.cs
+++ b/src/CloudNative.CloudEvents.Kafka/KafkaClientExtensions.cs
@@ -7,6 +7,7 @@ using Confluent.Kafka;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Mime;
 using System.Text;
 
 namespace CloudNative.CloudEvents.Kafka
@@ -38,7 +39,7 @@ namespace CloudNative.CloudEvents.Kafka
             // Structured mode
             if (contentType?.StartsWith(CloudEvent.MediaType, StringComparison.InvariantCultureIgnoreCase) == true)
             {
-                cloudEvent = eventFormatter.DecodeStructuredEvent(message.Value, extensionAttributes);
+                cloudEvent = eventFormatter.DecodeStructuredModeMessage(message.Value, new ContentType(contentType), extensionAttributes);
             }
             else
             {

--- a/src/CloudNative.CloudEvents.Kafka/KafkaClientExtensions.cs
+++ b/src/CloudNative.CloudEvents.Kafka/KafkaClientExtensions.cs
@@ -43,11 +43,15 @@ namespace CloudNative.CloudEvents.Kafka
             else
             {
                 // Binary mode
-                CloudEventsSpecVersion version = CloudEventsSpecVersion.Default;
-                if (GetHeaderValue(message, KafkaCloudEventMessage.SpecVersionKafkaHeader) is byte[] versionIdBytes)
+                if (!(GetHeaderValue(message, KafkaCloudEventMessage.SpecVersionKafkaHeader) is byte[] versionIdBytes))
                 {
-                    string versionId = Encoding.UTF8.GetString(versionIdBytes);
-                    version = CloudEventsSpecVersion.FromVersionId(versionId);
+                    throw new ArgumentException("Request is not a CloudEvent");
+                }
+                string versionId = Encoding.UTF8.GetString(versionIdBytes);
+                CloudEventsSpecVersion version = CloudEventsSpecVersion.FromVersionId(versionId);
+                if (version is null)
+                {
+                    throw new ArgumentException($"Unsupported CloudEvents spec version '{versionId}'");
                 }
 
                 cloudEvent = new CloudEvent(version, extensionAttributes)

--- a/src/CloudNative.CloudEvents.Kafka/KafkaClientExtensions.cs
+++ b/src/CloudNative.CloudEvents.Kafka/KafkaClientExtensions.cs
@@ -20,11 +20,11 @@ namespace CloudNative.CloudEvents.Kafka
             (ExtractContentType(message)?.StartsWith(CloudEvent.MediaType, StringComparison.InvariantCultureIgnoreCase) == true);
 
         public static CloudEvent ToCloudEvent(this Message<string, byte[]> message,
-            ICloudEventFormatter eventFormatter, params CloudEventAttribute[] extensionAttributes) =>
+            CloudEventFormatter eventFormatter, params CloudEventAttribute[] extensionAttributes) =>
             ToCloudEvent(message, eventFormatter, (IEnumerable<CloudEventAttribute>) extensionAttributes);
 
         public static CloudEvent ToCloudEvent(this Message<string, byte[]> message,
-            ICloudEventFormatter eventFormatter, IEnumerable<CloudEventAttribute> extensionAttributes)
+            CloudEventFormatter eventFormatter, IEnumerable<CloudEventAttribute> extensionAttributes)
         {
             if (!IsCloudEvent(message))
             {

--- a/src/CloudNative.CloudEvents.Kafka/KafkaCloudEventMessage.cs
+++ b/src/CloudNative.CloudEvents.Kafka/KafkaCloudEventMessage.cs
@@ -34,7 +34,7 @@ namespace CloudNative.CloudEvents.Kafka
 
             if (contentMode == ContentMode.Structured)
             {
-                Value = formatter.EncodeStructuredEvent(cloudEvent, out var contentType);
+                Value = formatter.EncodeStructuredModeMessage(cloudEvent, out var contentType);
                 Headers.Add(KafkaContentTypeAttributeName, Encoding.UTF8.GetBytes(contentType.MediaType));
             }
             else

--- a/src/CloudNative.CloudEvents.Kafka/KafkaCloudEventMessage.cs
+++ b/src/CloudNative.CloudEvents.Kafka/KafkaCloudEventMessage.cs
@@ -18,7 +18,7 @@ namespace CloudNative.CloudEvents.Kafka
         internal const string KafkaContentTypeAttributeName = "content-type";
         internal const string SpecVersionKafkaHeader = KafkaHeaderPrefix + "specversion";
 
-        public KafkaCloudEventMessage(CloudEvent cloudEvent, ContentMode contentMode, ICloudEventFormatter formatter)
+        public KafkaCloudEventMessage(CloudEvent cloudEvent, ContentMode contentMode, CloudEventFormatter formatter)
         {
             // TODO: Is this appropriate? Why can't we transport a CloudEvent without data in Kafka?
             if (cloudEvent.Data == null)
@@ -70,7 +70,7 @@ namespace CloudNative.CloudEvents.Kafka
             MapHeaders(cloudEvent, formatter);
         }
 
-        private void MapHeaders(CloudEvent cloudEvent, ICloudEventFormatter formatter)
+        private void MapHeaders(CloudEvent cloudEvent, CloudEventFormatter formatter)
         {
 
             foreach (var pair in cloudEvent.GetPopulatedAttributes())

--- a/src/CloudNative.CloudEvents.Mqtt/MqttClientExtensions.cs
+++ b/src/CloudNative.CloudEvents.Mqtt/MqttClientExtensions.cs
@@ -11,7 +11,8 @@ namespace CloudNative.CloudEvents.Mqtt
         public static CloudEvent ToCloudEvent(this MqttApplicationMessage message,
             CloudEventFormatter eventFormatter, params CloudEventAttribute[] extensionAttributes)
         {
-            return eventFormatter.DecodeStructuredEvent(message.Payload, extensionAttributes);
+            // TODO: Determine if there's a sensible content type we should apply.
+            return eventFormatter.DecodeStructuredModeMessage(message.Payload, contentType: null, extensionAttributes);
         }
     }
 }

--- a/src/CloudNative.CloudEvents.Mqtt/MqttClientExtensions.cs
+++ b/src/CloudNative.CloudEvents.Mqtt/MqttClientExtensions.cs
@@ -9,7 +9,7 @@ namespace CloudNative.CloudEvents.Mqtt
     public static class MqttClientExtensions
     {
         public static CloudEvent ToCloudEvent(this MqttApplicationMessage message,
-            ICloudEventFormatter eventFormatter, params CloudEventAttribute[] extensionAttributes)
+            CloudEventFormatter eventFormatter, params CloudEventAttribute[] extensionAttributes)
         {
             return eventFormatter.DecodeStructuredEvent(message.Payload, extensionAttributes);
         }

--- a/src/CloudNative.CloudEvents.Mqtt/MqttCloudEventMessage.cs
+++ b/src/CloudNative.CloudEvents.Mqtt/MqttCloudEventMessage.cs
@@ -9,7 +9,7 @@ namespace CloudNative.CloudEvents.Mqtt
     // TODO: Update to a newer version of MQTTNet and support both binary and structured mode?
     public class MqttCloudEventMessage : MqttApplicationMessage
     {
-        public MqttCloudEventMessage(CloudEvent cloudEvent, ICloudEventFormatter formatter)
+        public MqttCloudEventMessage(CloudEvent cloudEvent, CloudEventFormatter formatter)
         {
             this.Payload = formatter.EncodeStructuredEvent(cloudEvent, out var contentType);
         }

--- a/src/CloudNative.CloudEvents.Mqtt/MqttCloudEventMessage.cs
+++ b/src/CloudNative.CloudEvents.Mqtt/MqttCloudEventMessage.cs
@@ -11,7 +11,7 @@ namespace CloudNative.CloudEvents.Mqtt
     {
         public MqttCloudEventMessage(CloudEvent cloudEvent, CloudEventFormatter formatter)
         {
-            this.Payload = formatter.EncodeStructuredEvent(cloudEvent, out var contentType);
+            this.Payload = formatter.EncodeStructuredModeMessage(cloudEvent, out var contentType);
         }
     }
 }

--- a/src/CloudNative.CloudEvents.NewtonsoftJson/JsonEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.NewtonsoftJson/JsonEventFormatter.cs
@@ -22,9 +22,6 @@ namespace CloudNative.CloudEvents.NewtonsoftJson
         private const string Data = "data";
         public const string MediaTypeSuffix = "+json";
 
-        public CloudEvent DecodeStructuredEvent(Stream data, params CloudEventAttribute[] extensionAttributes) =>
-            DecodeStructuredEvent(data, (IEnumerable<CloudEventAttribute>) extensionAttributes);
-
         public override async Task<CloudEvent> DecodeStructuredEventAsync(Stream data, IEnumerable<CloudEventAttribute> extensionAttributes)
         {
             var jsonReader = new JsonTextReader(new StreamReader(data, Encoding.UTF8, true, 8192, true))
@@ -44,9 +41,6 @@ namespace CloudNative.CloudEvents.NewtonsoftJson
             var jObject = JObject.Load(jsonReader);
             return DecodeJObject(jObject, extensionAttributes);
         }
-
-        public CloudEvent DecodeStructuredEvent(byte[] data, params CloudEventAttribute[] extensionAttributes) =>
-            DecodeStructuredEvent(data, (IEnumerable<CloudEventAttribute>)extensionAttributes);
 
         public override CloudEvent DecodeStructuredEvent(byte[] data, IEnumerable<CloudEventAttribute> extensionAttributes = null) =>
             DecodeStructuredEvent(new MemoryStream(data), extensionAttributes);

--- a/src/CloudNative.CloudEvents.NewtonsoftJson/JsonEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.NewtonsoftJson/JsonEventFormatter.cs
@@ -16,7 +16,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson
     /// <summary>
     /// Formatter that implements the JSON Event Format
     /// </summary>
-    public class JsonEventFormatter : ICloudEventFormatter
+    public class JsonEventFormatter : CloudEventFormatter
     {
         private const string DataBase64 = "data_base64";
         private const string Data = "data";

--- a/src/CloudNative.CloudEvents.NewtonsoftJson/JsonEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.NewtonsoftJson/JsonEventFormatter.cs
@@ -25,7 +25,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson
         public CloudEvent DecodeStructuredEvent(Stream data, params CloudEventAttribute[] extensionAttributes) =>
             DecodeStructuredEvent(data, (IEnumerable<CloudEventAttribute>) extensionAttributes);
 
-        public async Task<CloudEvent> DecodeStructuredEventAsync(Stream data, IEnumerable<CloudEventAttribute> extensionAttributes)
+        public override async Task<CloudEvent> DecodeStructuredEventAsync(Stream data, IEnumerable<CloudEventAttribute> extensionAttributes)
         {
             var jsonReader = new JsonTextReader(new StreamReader(data, Encoding.UTF8, true, 8192, true))
             {
@@ -35,7 +35,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson
             return DecodeJObject(jObject, extensionAttributes);
         }
 
-        public CloudEvent DecodeStructuredEvent(Stream data, IEnumerable<CloudEventAttribute> extensionAttributes = null)
+        public override CloudEvent DecodeStructuredEvent(Stream data, IEnumerable<CloudEventAttribute> extensionAttributes = null)
         {
             var jsonReader = new JsonTextReader(new StreamReader(data, Encoding.UTF8, true, 8192, true))
             {
@@ -48,7 +48,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson
         public CloudEvent DecodeStructuredEvent(byte[] data, params CloudEventAttribute[] extensionAttributes) =>
             DecodeStructuredEvent(data, (IEnumerable<CloudEventAttribute>)extensionAttributes);
 
-        public CloudEvent DecodeStructuredEvent(byte[] data, IEnumerable<CloudEventAttribute> extensionAttributes = null) =>
+        public override CloudEvent DecodeStructuredEvent(byte[] data, IEnumerable<CloudEventAttribute> extensionAttributes = null) =>
             DecodeStructuredEvent(new MemoryStream(data), extensionAttributes);
 
         // TODO: If we make this private, we'll have significantly more control over what token types we see.
@@ -117,7 +117,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson
             return cloudEvent;
         }
 
-        public byte[] EncodeStructuredEvent(CloudEvent cloudEvent, out ContentType contentType)
+        public override byte[] EncodeStructuredEvent(CloudEvent cloudEvent, out ContentType contentType)
         {
             contentType = new ContentType("application/cloudevents+json")
             {
@@ -157,7 +157,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson
         }
 
         // TODO: How should the caller know whether the result is "raw" or should be stored in data_base64?
-        public byte[] EncodeData(object value)
+        public override byte[] EncodeData(object value)
         {
             // TODO: Check this is what we want.
             // In particular, if this is just other text or binary data, rather than JSON, what does it
@@ -173,7 +173,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson
             return json is null ? new byte[0] : Encoding.UTF8.GetBytes(json);
         }
 
-        public object DecodeData(byte[] value, string contentType)
+        public override object DecodeData(byte[] value, string contentType)
         {
             if (contentType == "application/json")
             {

--- a/src/CloudNative.CloudEvents/BinaryDataUtilities.cs
+++ b/src/CloudNative.CloudEvents/BinaryDataUtilities.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2021 Cloud Native Foundation.
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Threading.Tasks;
+
+namespace CloudNative.CloudEvents
+{
+    /// <summary>
+    /// Utilities methods for dealing with binary data, converting between
+    /// streams, arrays, Memory{T} etc.
+    /// </summary>
+    internal static class BinaryDataUtilities
+    {
+        internal async static Task<byte[]> ToByteArrayAsync(Stream stream)
+        {
+            // TODO: Optimize if it's already a MemoryStream?
+            var memory = new MemoryStream();
+            await stream.CopyToAsync(memory).ConfigureAwait(false);
+            return memory.ToArray();
+        }
+
+        internal static byte[] ToByteArray(Stream stream)
+        {
+            var memory = new MemoryStream();
+            stream.CopyTo(memory);
+            return memory.ToArray();
+        }
+    }
+}

--- a/src/CloudNative.CloudEvents/CloudEventFormatter.cs
+++ b/src/CloudNative.CloudEvents/CloudEventFormatter.cs
@@ -13,7 +13,7 @@ namespace CloudNative.CloudEvents
     /// <summary>
     /// Implemented by formatters
     /// </summary>
-    public abstract class ICloudEventFormatter
+    public abstract class CloudEventFormatter
     {
         /// <summary>
         /// Decode a structured event from a stream

--- a/src/CloudNative.CloudEvents/CloudEventFormatter.cs
+++ b/src/CloudNative.CloudEvents/CloudEventFormatter.cs
@@ -16,22 +16,32 @@ namespace CloudNative.CloudEvents
     public abstract class CloudEventFormatter
     {
         /// <summary>
-        /// Decode a structured event from a stream
+        /// Decode a structured event from a stream. The default implementation copies the
+        /// content of the stream into a byte array before passing it to <see cref="DecodeStructuredEvent(byte[], IEnumerable{CloudEventAttribute})"/>,
+        /// but this can be overridden by event formatters that can decode a stream more efficiently.
         /// </summary>
         /// <param name="data"></param>
         /// <param name="extensions"></param>
         /// <returns></returns>
-        public virtual CloudEvent DecodeStructuredEvent(Stream data, IEnumerable<CloudEventAttribute> extensionAttributes) =>
-            throw new NotImplementedException();
+        public virtual CloudEvent DecodeStructuredEvent(Stream data, IEnumerable<CloudEventAttribute> extensionAttributes)
+        {
+            var bytes = BinaryDataUtilities.ToByteArray(data);
+            return DecodeStructuredEvent(bytes, extensionAttributes);
+        }
 
         /// <summary>
-        /// Decode a structured event from a stream asynchonously
+        /// Decode a structured event from a stream. The default implementation asynchronously copies the
+        /// content of the stream into a byte array before passing it to <see cref="DecodeStructuredEvent(byte[], IEnumerable{CloudEventAttribute})"/>,
+        /// but this can be overridden by event formatters that can decode a stream more efficiently.
         /// </summary>
         /// <param name="data"></param>
         /// <param name="extensions"></param>
         /// <returns></returns>
-        public virtual Task<CloudEvent> DecodeStructuredEventAsync(Stream data, IEnumerable<CloudEventAttribute> extensionAttributes) =>
-            throw new NotImplementedException();
+        public virtual async Task<CloudEvent> DecodeStructuredEventAsync(Stream data, IEnumerable<CloudEventAttribute> extensionAttributes)
+        {
+            var bytes = await BinaryDataUtilities.ToByteArrayAsync(data).ConfigureAwait(false);
+            return DecodeStructuredEvent(bytes, extensionAttributes);
+        }
 
         // TODO: Remove either this one or the stream one? It seems unnecessary to have both.
 

--- a/src/CloudNative.CloudEvents/Http/CloudEventHttpContent.cs
+++ b/src/CloudNative.CloudEvents/Http/CloudEventHttpContent.cs
@@ -26,7 +26,7 @@ namespace CloudNative.CloudEvents.Http
         /// <param name="cloudEvent">CloudEvent</param>
         /// <param name="contentMode">Content mode. Structured or binary.</param>
         /// <param name="formatter">Event formatter</param>
-        public CloudEventHttpContent(CloudEvent cloudEvent, ContentMode contentMode, ICloudEventFormatter formatter)
+        public CloudEventHttpContent(CloudEvent cloudEvent, ContentMode contentMode, CloudEventFormatter formatter)
         {
             if (contentMode == ContentMode.Structured)
             {

--- a/src/CloudNative.CloudEvents/Http/CloudEventHttpContent.cs
+++ b/src/CloudNative.CloudEvents/Http/CloudEventHttpContent.cs
@@ -6,19 +6,20 @@ using System;
 using System.IO;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Net.Mime;
 using System.Threading.Tasks;
 
 namespace CloudNative.CloudEvents.Http
 {
+    // TODO: Do we really need to have a subclass here? How about a static factory method instead?
+
     /// <summary>
     /// This class is for use with `HttpClient` and constructs content and headers for
     /// a HTTP request from a CloudEvent.
     /// </summary>
     public class CloudEventHttpContent : HttpContent
     {
-        IInnerContent inner;                      
+        private readonly InnerByteArrayContent inner;                      
 
         /// <summary>
         /// Constructor
@@ -28,70 +29,44 @@ namespace CloudNative.CloudEvents.Http
         /// <param name="formatter">Event formatter</param>
         public CloudEventHttpContent(CloudEvent cloudEvent, ContentMode contentMode, CloudEventFormatter formatter)
         {
-            if (contentMode == ContentMode.Structured)
+            byte[] content;
+            ContentType contentType;
+            switch (contentMode)
             {
-                inner = new InnerByteArrayContent(formatter.EncodeStructuredEvent(cloudEvent, out var contentType));
-                // This is optional in the specification, but can be useful.
-                MapHeaders(cloudEvent, includeDataContentType: true);
-                Headers.ContentType = new MediaTypeHeaderValue(contentType.MediaType);
-                return;
-            }
+                case ContentMode.Structured:
+                    content = formatter.EncodeStructuredModeMessage(cloudEvent, out contentType);
+                    // This is optional in the specification, but can be useful.
+                    MapHeaders(cloudEvent, includeDataContentType: true);
+                    break;
+                case ContentMode.Binary:
+                    content = formatter.EncodeBinaryModeEventData(cloudEvent);
+                    contentType = MimeUtilities.CreateContentTypeOrNull(cloudEvent.DataContentType);
+                    MapHeaders(cloudEvent, includeDataContentType: false);
+                    break;
+                default:
+                    throw new ArgumentException($"Unsupported content mode: {contentMode}");
 
-            // TODO: Shouldn't we use the formatter in all cases? If I have a JSON formatter and
-            // If we specify that the the data is a byte array, I'd expect to end up with a base64-encoded representation...
-            if (cloudEvent.Data is byte[])
-            {
-                inner = new InnerByteArrayContent((byte[])cloudEvent.Data);
             }
-            else if (cloudEvent.Data is string)
+            inner = new InnerByteArrayContent(content);
+            if (contentType is object)
             {
-                inner = new InnerStringContent((string)cloudEvent.Data);
+                Headers.ContentType = contentType.ToMediaTypeHeaderValue();
             }
-            else if (cloudEvent.Data is Stream)
-            {
-                inner = new InnerStreamContent((Stream)cloudEvent.Data);
-            }
-            else
-            {
-                inner = new InnerByteArrayContent(formatter.EncodeData(cloudEvent.Data));
-            }
-
-            // We don't require a data content type if there isn't any data.
-            // We may not be able to tell whether the data is empty or not, but we're lenient
-            // in that case.
-            var dataContentType = cloudEvent.DataContentType;
-            if (dataContentType is object)
-            {
-                var mediaType = new ContentType(dataContentType).MediaType;
-                Headers.ContentType = new MediaTypeHeaderValue(mediaType);
-            }
-            else if (TryComputeLength(out var length) && length != 0L)
+            else if (content.Length != 0)
             {
                 throw new ArgumentException(Strings.ErrorContentTypeUnspecified, nameof(cloudEvent));
             }
-            MapHeaders(cloudEvent, includeDataContentType: false);
         }
 
-        private interface IInnerContent
-        {
-            Task InnerSerializeToStreamAsync(Stream stream, TransportContext context);
-            bool InnerTryComputeLength(out long length);
-        }
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context) =>
+            inner.InnerSerializeToStreamAsync(stream, context);
 
-        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
-        {
-            return inner.InnerSerializeToStreamAsync(stream, context);
-        }
-
-        protected override bool TryComputeLength(out long length)
-        {
-            return inner.InnerTryComputeLength(out length);
-        }
+        protected override bool TryComputeLength(out long length) =>
+            inner.InnerTryComputeLength(out length);
 
         private void MapHeaders(CloudEvent cloudEvent, bool includeDataContentType)
         {
-            Headers.Add(HttpUtilities.HttpHeaderPrefix + CloudEventsSpecVersion.SpecVersionAttribute.Name,
-                HttpUtilities.EncodeHeaderValue(cloudEvent.SpecVersion.VersionId));
+            Headers.Add(HttpUtilities.SpecVersionHttpHeader, HttpUtilities.EncodeHeaderValue(cloudEvent.SpecVersion.VersionId));
             foreach (var attributeAndValue in cloudEvent.GetPopulatedAttributes())
             {
                 CloudEventAttribute attribute = attributeAndValue.Key;
@@ -115,51 +90,9 @@ namespace CloudNative.CloudEvents.Http
         /// This inner class is required to get around the 'protected'-ness of the
         /// override functions of HttpContent for enabling containment/delegation
         /// </summary>
-        class InnerByteArrayContent : ByteArrayContent, IInnerContent
+        class InnerByteArrayContent : ByteArrayContent
         {
             public InnerByteArrayContent(byte[] content) : base(content)
-            {
-            }
-
-            public Task InnerSerializeToStreamAsync(Stream stream, TransportContext context)
-            {
-                return base.SerializeToStreamAsync(stream, context);
-            }
-
-            public bool InnerTryComputeLength(out long length)
-            {
-                return base.TryComputeLength(out length);
-            }
-        }
-
-        /// <summary>
-        /// This inner class is required to get around the 'protected'-ness of the
-        /// override functions of HttpContent for enabling containment/delegation
-        /// </summary>
-        class InnerStreamContent : StreamContent, IInnerContent
-        {
-            public InnerStreamContent(Stream content) : base(content)
-            {
-            }
-
-            public Task InnerSerializeToStreamAsync(Stream stream, TransportContext context)
-            {
-                return base.SerializeToStreamAsync(stream, context);
-            }
-
-            public bool InnerTryComputeLength(out long length)
-            {
-                return base.TryComputeLength(out length);
-            }
-        }
-
-        /// <summary>
-        /// This inner class is required to get around the 'protected'-ness of the
-        /// override functions of HttpContent for enabling containment/delegation
-        /// </summary>
-        class InnerStringContent : StringContent, IInnerContent
-        {
-            public InnerStringContent(string content) : base(content)
             {
             }
 

--- a/src/CloudNative.CloudEvents/Http/HttpClientExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpClientExtensions.cs
@@ -80,7 +80,7 @@ namespace CloudNative.CloudEvents.Http
         /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent.</param>
         /// <returns>A CloudEvent instance or 'null' if the response message doesn't hold a CloudEvent</returns>
         public static Task<CloudEvent> ToCloudEventAsync(this HttpResponseMessage httpResponseMessage,
-            ICloudEventFormatter formatter, params CloudEventAttribute[] extensionAttributes) =>
+            CloudEventFormatter formatter, params CloudEventAttribute[] extensionAttributes) =>
             ToCloudEventInternalAsync(httpResponseMessage.Headers, httpResponseMessage.Content, formatter, extensionAttributes);
 
         /// <summary>
@@ -91,12 +91,12 @@ namespace CloudNative.CloudEvents.Http
         /// <param name="extensionAttributes">List of extension instances</param>
         /// <returns>A CloudEvent instance or 'null' if the request message doesn't hold a CloudEvent</returns>
         public static Task<CloudEvent> ToCloudEventAsync(this HttpRequestMessage httpRequestMessage,
-            ICloudEventFormatter formatter,
+            CloudEventFormatter formatter,
             params CloudEventAttribute[] extensionAttributes) =>
             ToCloudEventInternalAsync(httpRequestMessage.Headers, httpRequestMessage.Content, formatter, extensionAttributes);
 
         private static async Task<CloudEvent> ToCloudEventInternalAsync(HttpHeaders headers, HttpContent content,
-            ICloudEventFormatter formatter, IEnumerable<CloudEventAttribute> extensionAttributes)
+            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute> extensionAttributes)
         {
             if (HasCloudEventsContentType(content))
             {

--- a/src/CloudNative.CloudEvents/Http/HttpClientExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpClientExtensions.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Mime;
 using System.Threading.Tasks;
 
 namespace CloudNative.CloudEvents.Http
@@ -102,7 +103,7 @@ namespace CloudNative.CloudEvents.Http
             {
                 // FIXME: Handle no formatter being specified.
                 var stream = await content.ReadAsStreamAsync().ConfigureAwait(false);
-                return await formatter.DecodeStructuredEventAsync(stream, extensionAttributes).ConfigureAwait(false);
+                return await formatter.DecodeStructuredModeMessageAsync(stream, content.Headers.ContentType.ToContentType(), extensionAttributes).ConfigureAwait(false);
             }
             else
             {
@@ -136,7 +137,7 @@ namespace CloudNative.CloudEvents.Http
                     // TODO: Should this just be the media type? We probably need to take a full audit of this...
                     cloudEvent.DataContentType = content.Headers?.ContentType?.ToString();
                     var data = await content.ReadAsByteArrayAsync().ConfigureAwait(false);
-                    cloudEvent.Data = formatter.DecodeData(data, cloudEvent.DataContentType);
+                    formatter.DecodeBinaryModeEventData(data, cloudEvent);
                 }
                 return cloudEvent;
             }

--- a/src/CloudNative.CloudEvents/Http/HttpClientExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpClientExtensions.cs
@@ -106,11 +106,17 @@ namespace CloudNative.CloudEvents.Http
             }
             else
             {
-                CloudEventsSpecVersion version = CloudEventsSpecVersion.Default;
-                if (headers.Contains(HttpUtilities.SpecVersionHttpHeader))
+                string versionId = headers.Contains(HttpUtilities.SpecVersionHttpHeader)
+                    ? headers.GetValues(HttpUtilities.SpecVersionHttpHeader).First()
+                    : null;
+                if (versionId is null)
                 {
-                    string versionId = headers.GetValues(HttpUtilities.SpecVersionHttpHeader).First();
-                    version = CloudEventsSpecVersion.FromVersionId(versionId);
+                    throw new ArgumentException("Request is not a CloudEvent");
+                }
+                var version = CloudEventsSpecVersion.FromVersionId(versionId);
+                if (version is null)
+                {
+                    throw new ArgumentException($"Unsupported CloudEvents spec version '{versionId}'");
                 }
 
                 var cloudEvent = new CloudEvent(version, extensionAttributes);

--- a/src/CloudNative.CloudEvents/Http/HttpListenerExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpListenerExtensions.cs
@@ -26,7 +26,7 @@ namespace CloudNative.CloudEvents.Http
         /// <param name="formatter">Formatter</param>
         /// <returns>Task</returns>
         public static Task CopyFromAsync(this HttpListenerResponse httpListenerResponse, CloudEvent cloudEvent,
-            ContentMode contentMode, ICloudEventFormatter formatter)
+            ContentMode contentMode, CloudEventFormatter formatter)
         {
             if (contentMode == ContentMode.Structured)
             {
@@ -99,7 +99,7 @@ namespace CloudNative.CloudEvents.Http
         /// <param name="extensions">List of extension instances</param>
         /// <returns>A CloudEvent instance or 'null' if the request message doesn't hold a CloudEvent</returns>
         public static CloudEvent ToCloudEvent(this HttpListenerRequest httpListenerRequest,
-            ICloudEventFormatter formatter, params CloudEventAttribute[] extensionAttributes)
+            CloudEventFormatter formatter, params CloudEventAttribute[] extensionAttributes)
         {
             if (HasCloudEventsContentType(httpListenerRequest))
             {

--- a/src/CloudNative.CloudEvents/Http/HttpUtilities.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpUtilities.cs
@@ -21,7 +21,7 @@ namespace CloudNative.CloudEvents.Http
 
         public const string SpecVersionHttpHeader = HttpHeaderPrefix + "specversion";
 
-        internal static Stream MapDataAttributeToStream(CloudEvent cloudEvent, ICloudEventFormatter formatter) =>
+        internal static Stream MapDataAttributeToStream(CloudEvent cloudEvent, CloudEventFormatter formatter) =>
             cloudEvent.Data switch
             {
                 byte[] bytes => new MemoryStream(bytes),

--- a/src/CloudNative.CloudEvents/Http/HttpUtilities.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpUtilities.cs
@@ -6,6 +6,8 @@ using System;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -20,15 +22,6 @@ namespace CloudNative.CloudEvents.Http
         public const string HttpHeaderPrefix = "ce-";
 
         public const string SpecVersionHttpHeader = HttpHeaderPrefix + "specversion";
-
-        internal static Stream MapDataAttributeToStream(CloudEvent cloudEvent, CloudEventFormatter formatter) =>
-            cloudEvent.Data switch
-            {
-                byte[] bytes => new MemoryStream(bytes),
-                string text => new MemoryStream(Encoding.UTF8.GetBytes(text)),
-                Stream stream => stream,
-                object other => new MemoryStream(formatter.EncodeData(other))
-            };
 
         /// <summary>
         /// Checks whether the given HTTP header name starts with "ce-", and if so, converts it into

--- a/src/CloudNative.CloudEvents/Http/HttpWebExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpWebExtensions.cs
@@ -43,6 +43,7 @@ namespace CloudNative.CloudEvents.Http
 
         static void MapAttributesToWebRequest(CloudEvent cloudEvent, HttpWebRequest httpWebRequest)
         {
+            httpWebRequest.Headers.Add(HttpUtilities.SpecVersionHttpHeader, HttpUtilities.EncodeHeaderValue(cloudEvent.SpecVersion.VersionId));
             foreach (var attributeAndValue in cloudEvent.GetPopulatedAttributes())
             {
                 var attribute = attributeAndValue.Key;

--- a/src/CloudNative.CloudEvents/Http/HttpWebExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpWebExtensions.cs
@@ -29,16 +29,16 @@ namespace CloudNative.CloudEvents.Http
         {
             if (contentMode == ContentMode.Structured)
             {
-                var buffer = formatter.EncodeStructuredEvent(cloudEvent, out var contentType);
+                var buffer = formatter.EncodeStructuredModeMessage(cloudEvent, out var contentType);
                 httpWebRequest.ContentType = contentType.ToString();
                 await httpWebRequest.GetRequestStream().WriteAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
                 return;
             }
 
-            Stream stream = HttpUtilities.MapDataAttributeToStream(cloudEvent, formatter);
             httpWebRequest.ContentType = cloudEvent.DataContentType?.ToString() ?? "application/json";
             MapAttributesToWebRequest(cloudEvent, httpWebRequest);
-            await stream.CopyToAsync(httpWebRequest.GetRequestStream());
+            byte[] content = formatter.EncodeBinaryModeEventData(cloudEvent);
+            await httpWebRequest.GetRequestStream().WriteAsync(content, 0, content.Length).ConfigureAwait(false);
         }
 
         static void MapAttributesToWebRequest(CloudEvent cloudEvent, HttpWebRequest httpWebRequest)

--- a/src/CloudNative.CloudEvents/Http/HttpWebExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpWebExtensions.cs
@@ -25,7 +25,7 @@ namespace CloudNative.CloudEvents.Http
         /// <param name="formatter">Formatter</param>
         /// <returns>Task</returns>
         public static async Task CopyFromAsync(this HttpWebRequest httpWebRequest, CloudEvent cloudEvent,
-            ContentMode contentMode, ICloudEventFormatter formatter)
+            ContentMode contentMode, CloudEventFormatter formatter)
         {
             if (contentMode == ContentMode.Structured)
             {

--- a/src/CloudNative.CloudEvents/ICloudEventFormatter.cs
+++ b/src/CloudNative.CloudEvents/ICloudEventFormatter.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Mime;
@@ -12,7 +13,7 @@ namespace CloudNative.CloudEvents
     /// <summary>
     /// Implemented by formatters
     /// </summary>
-    public interface ICloudEventFormatter
+    public abstract class ICloudEventFormatter
     {
         /// <summary>
         /// Decode a structured event from a stream
@@ -20,7 +21,8 @@ namespace CloudNative.CloudEvents
         /// <param name="data"></param>
         /// <param name="extensions"></param>
         /// <returns></returns>
-        CloudEvent DecodeStructuredEvent(Stream data, IEnumerable<CloudEventAttribute> extensionAttributes);
+        public virtual CloudEvent DecodeStructuredEvent(Stream data, IEnumerable<CloudEventAttribute> extensionAttributes) =>
+            throw new NotImplementedException();
 
         /// <summary>
         /// Decode a structured event from a stream asynchonously
@@ -28,7 +30,8 @@ namespace CloudNative.CloudEvents
         /// <param name="data"></param>
         /// <param name="extensions"></param>
         /// <returns></returns>
-        Task<CloudEvent> DecodeStructuredEventAsync(Stream data, IEnumerable<CloudEventAttribute> extensionAttributes);
+        public virtual Task<CloudEvent> DecodeStructuredEventAsync(Stream data, IEnumerable<CloudEventAttribute> extensionAttributes) =>
+            throw new NotImplementedException();
 
         // TODO: Remove either this one or the stream one? It seems unnecessary to have both.
 
@@ -38,7 +41,8 @@ namespace CloudNative.CloudEvents
         /// <param name="data"></param>
         /// <param name="extensions"></param>
         /// <returns></returns>
-        CloudEvent DecodeStructuredEvent(byte[] data, IEnumerable<CloudEventAttribute> extensionAttributes);
+        public virtual CloudEvent DecodeStructuredEvent(byte[] data, IEnumerable<CloudEventAttribute> extensionAttributes) =>
+            throw new NotImplementedException();
 
         /// <summary>
         /// Encode an structured event into a byte array
@@ -46,11 +50,12 @@ namespace CloudNative.CloudEvents
         /// <param name="cloudEvent"></param>
         /// <param name="contentType"></param>
         /// <returns></returns>
-        byte[] EncodeStructuredEvent(CloudEvent cloudEvent, out ContentType contentType);
-      
+        public virtual byte[] EncodeStructuredEvent(CloudEvent cloudEvent, out ContentType contentType) =>
+            throw new NotImplementedException();
+
         // TODO: Work out whether this is what we want, and whether to potentially
         // separate it into a separate interface.
-        byte[] EncodeData(object value);
-        object DecodeData(byte[] value, string contentType);
+        public virtual byte[] EncodeData(object value) => throw new NotImplementedException();
+        public virtual object DecodeData(byte[] value, string contentType) => throw new NotImplementedException();
     }
 }

--- a/src/CloudNative.CloudEvents/MimeUtilities.cs
+++ b/src/CloudNative.CloudEvents/MimeUtilities.cs
@@ -1,0 +1,65 @@
+﻿// Copyright 2021 Cloud Native Foundation.
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using System.Net.Http.Headers;
+using System.Net.Mime;
+using System.Text;
+
+namespace CloudNative.CloudEvents
+{
+    // TODO: Consider this name and namespace carefully. It really does need to be public, as all the event formatters are elsewhere.
+    // But it's not ideal...
+
+    /// <summary>
+    /// Utility and extension methods around MIME.
+    /// </summary>
+    public static class MimeUtilities
+    {
+        // TODO: Should we return null, and force the caller to do the appropriate defaulting?
+        /// <summary>
+        /// Returns an encoding from a content type, defaulting to UTF-8.
+        /// </summary>
+        /// <param name="contentType">The content type, or null if no content type is known.</param>
+        /// <returns>An encoding suitable for the charset specified in <paramref name="contentType"/>,
+        /// or UTF-8 if no charset has been specified.</returns>
+        public static Encoding GetEncoding(this ContentType contentType) =>
+            contentType?.CharSet is string charSet ? Encoding.GetEncoding(charSet) : Encoding.UTF8;
+
+        /// <summary>
+        /// Converts a <see cref="MediaTypeHeaderValue"/> into a <see cref="ContentType"/>.
+        /// </summary>
+        /// <param name="headerValue">The header value to convert. May be null.</param>
+        /// <returns>The converted content type, or null if <paramref name="headerValue"/> is null.</returns>
+        public static ContentType ToContentType(this MediaTypeHeaderValue headerValue) =>
+            headerValue is null ? null : new ContentType(headerValue.ToString());
+
+        /// <summary>
+        /// Converts a <see cref="ContentType"/> into a <see cref="MediaTypeHeaderValue"/>.
+        /// </summary>
+        /// <param name="contentType">The content type to convert. May be null.</param>
+        /// <returns>The converted media type header value, or null if <paramref name="contentType"/> is null.</returns>
+        public static MediaTypeHeaderValue ToMediaTypeHeaderValue(this ContentType contentType)
+        {
+            if (contentType is null)
+            {
+                return null;
+            }
+            var header = new MediaTypeHeaderValue(contentType.MediaType);
+            foreach (string parameterName in contentType.Parameters.Keys)
+            {
+                header.Parameters.Add(new NameValueHeaderValue(parameterName, contentType.Parameters[parameterName].ToString()));
+            }
+            return header;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ContentType"/> from the given value, or returns null
+        /// if the input is null.
+        /// </summary>
+        /// <param name="contentType">The content type textual value. May be null.</param>
+        /// <returns>The converted content type, or null if <paramref name="contentType"/> is null.</returns>
+        public static ContentType CreateContentTypeOrNull(string contentType) =>
+            contentType is null ? null : new ContentType(contentType);
+    }
+}

--- a/test/CloudNative.CloudEvents.UnitTests/Avro/AvroEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Avro/AvroEventFormatterTest.cs
@@ -32,7 +32,7 @@ namespace CloudNative.CloudEvents.Avro.UnitTests
             var avroFormatter = new AvroEventFormatter();
             var cloudEvent = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(jsonv10));
             var avroData = avroFormatter.EncodeStructuredEvent(cloudEvent, out var contentType);
-            var cloudEvent2 = avroFormatter.DecodeStructuredEvent(avroData);
+            var cloudEvent2 = avroFormatter.DecodeStructuredEvent(avroData, new CloudEventAttribute[0]);
 
             Assert.Equal(cloudEvent2.SpecVersion, cloudEvent.SpecVersion);
             Assert.Equal(cloudEvent2.Type, cloudEvent.Type);
@@ -50,7 +50,7 @@ namespace CloudNative.CloudEvents.Avro.UnitTests
             var avroFormatter = new AvroEventFormatter();
             var cloudEventJ = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(jsonv10));
             var avroData = avroFormatter.EncodeStructuredEvent(cloudEventJ, out var contentType);
-            var cloudEvent = avroFormatter.DecodeStructuredEvent(avroData);
+            var cloudEvent = avroFormatter.DecodeStructuredEvent(avroData, new CloudEventAttribute[0]);
 
             Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
@@ -69,9 +69,9 @@ namespace CloudNative.CloudEvents.Avro.UnitTests
             var jsonFormatter = new JsonEventFormatter();
             var avroFormatter = new AvroEventFormatter();
             var extensionAttribute = CloudEventAttribute.CreateExtension("comexampleextension1", CloudEventAttributeType.String);
-            var cloudEventJ = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(jsonv10), extensionAttribute);
+            var cloudEventJ = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(jsonv10), new[] { extensionAttribute });
             var avroData = avroFormatter.EncodeStructuredEvent(cloudEventJ, out var contentType);
-            var cloudEvent = avroFormatter.DecodeStructuredEvent(avroData, extensionAttribute);
+            var cloudEvent = avroFormatter.DecodeStructuredEvent(avroData, new[] { extensionAttribute });
 
             Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", cloudEvent.Type);

--- a/test/CloudNative.CloudEvents.UnitTests/Avro/AvroEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Avro/AvroEventFormatterTest.cs
@@ -5,8 +5,8 @@
 using CloudNative.CloudEvents.NewtonsoftJson;
 using System;
 using System.Net.Mime;
-using System.Text;
 using Xunit;
+using static CloudNative.CloudEvents.UnitTests.CloudEventFormatterExtensions;
 using static CloudNative.CloudEvents.UnitTests.TestHelpers;
 
 namespace CloudNative.CloudEvents.Avro.UnitTests
@@ -30,9 +30,9 @@ namespace CloudNative.CloudEvents.Avro.UnitTests
         {
             var jsonFormatter = new JsonEventFormatter();
             var avroFormatter = new AvroEventFormatter();
-            var cloudEvent = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(jsonv10));
-            var avroData = avroFormatter.EncodeStructuredEvent(cloudEvent, out var contentType);
-            var cloudEvent2 = avroFormatter.DecodeStructuredEvent(avroData, new CloudEventAttribute[0]);
+            var cloudEvent = jsonFormatter.DecodeStructuredModeText(jsonv10);
+            var avroData = avroFormatter.EncodeStructuredModeMessage(cloudEvent, out var contentType);
+            var cloudEvent2 = avroFormatter.DecodeStructuredModeMessage(avroData, contentType, extensionAttributes: null);
 
             Assert.Equal(cloudEvent2.SpecVersion, cloudEvent.SpecVersion);
             Assert.Equal(cloudEvent2.Type, cloudEvent.Type);
@@ -48,9 +48,9 @@ namespace CloudNative.CloudEvents.Avro.UnitTests
         {
             var jsonFormatter = new JsonEventFormatter();
             var avroFormatter = new AvroEventFormatter();
-            var cloudEventJ = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(jsonv10));
-            var avroData = avroFormatter.EncodeStructuredEvent(cloudEventJ, out var contentType);
-            var cloudEvent = avroFormatter.DecodeStructuredEvent(avroData, new CloudEventAttribute[0]);
+            var cloudEventJ = jsonFormatter.DecodeStructuredModeText(jsonv10);
+            var avroData = avroFormatter.EncodeStructuredModeMessage(cloudEventJ, out var contentType);
+            var cloudEvent = avroFormatter.DecodeStructuredModeMessage(avroData, contentType, extensionAttributes: null);
 
             Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
@@ -69,9 +69,9 @@ namespace CloudNative.CloudEvents.Avro.UnitTests
             var jsonFormatter = new JsonEventFormatter();
             var avroFormatter = new AvroEventFormatter();
             var extensionAttribute = CloudEventAttribute.CreateExtension("comexampleextension1", CloudEventAttributeType.String);
-            var cloudEventJ = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(jsonv10), new[] { extensionAttribute });
-            var avroData = avroFormatter.EncodeStructuredEvent(cloudEventJ, out var contentType);
-            var cloudEvent = avroFormatter.DecodeStructuredEvent(avroData, new[] { extensionAttribute });
+            var cloudEventJ = jsonFormatter.DecodeStructuredModeText(jsonv10, new[] { extensionAttribute });
+            var avroData = avroFormatter.EncodeStructuredModeMessage(cloudEventJ, out var contentType);
+            var cloudEvent = avroFormatter.DecodeStructuredModeMessage(avroData, contentType, new[] { extensionAttribute });
 
             Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", cloudEvent.Type);

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventFormatterExtensions.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventFormatterExtensions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2021 Cloud Native Foundation. 
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Text;
+
+namespace CloudNative.CloudEvents.UnitTests
+{
+    /// <summary>
+    /// Extension methods for CloudEventFormatters to simplify testing.
+    /// Often in tests we have structured mode data as strings, and usually the content type isn't important,
+    /// so it's useful to be able to just decode that string directly.
+    /// </summary>
+    internal static class CloudEventFormatterExtensions
+    {
+        internal static CloudEvent DecodeStructuredModeText(this CloudEventFormatter eventFormatter, string text) =>
+            eventFormatter.DecodeStructuredModeMessage(Encoding.UTF8.GetBytes(text), contentType: null, extensionAttributes: null);
+
+        internal static CloudEvent DecodeStructuredModeText(this CloudEventFormatter eventFormatter, string text, IEnumerable<CloudEventAttribute> extensionAttributes) =>
+            eventFormatter.DecodeStructuredModeMessage(Encoding.UTF8.GetBytes(text), contentType: null, extensionAttributes);
+    }
+}

--- a/test/CloudNative.CloudEvents.UnitTests/Extensions/DistributedTracingTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Extensions/DistributedTracingTest.cs
@@ -5,6 +5,7 @@
 using CloudNative.CloudEvents.NewtonsoftJson;
 using System.Text;
 using Xunit;
+using static CloudNative.CloudEvents.UnitTests.CloudEventFormatterExtensions;
 
 namespace CloudNative.CloudEvents.Extensions.UnitTests
 {
@@ -27,7 +28,7 @@ namespace CloudNative.CloudEvents.Extensions.UnitTests
         public void ParseJson()
         {
             var jsonFormatter = new JsonEventFormatter();
-            var cloudEvent = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(sampleJson), DistributedTracing.AllAttributes);
+            var cloudEvent = jsonFormatter.DecodeStructuredModeText(sampleJson, DistributedTracing.AllAttributes);
 
             Assert.Equal(SampleParent, cloudEvent[DistributedTracing.TraceParentAttribute]);
             Assert.Equal(SampleParent, cloudEvent.GetTraceParent());
@@ -39,9 +40,9 @@ namespace CloudNative.CloudEvents.Extensions.UnitTests
         public void Transcode()
         {
             var jsonFormatter = new JsonEventFormatter();
-            var cloudEvent1 = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(sampleJson));
-            var jsonData = jsonFormatter.EncodeStructuredEvent(cloudEvent1, out _);
-            var cloudEvent = jsonFormatter.DecodeStructuredEvent(jsonData, DistributedTracing.AllAttributes);
+            var cloudEvent1 = jsonFormatter.DecodeStructuredModeText(sampleJson);
+            var jsonData = jsonFormatter.EncodeStructuredModeMessage(cloudEvent1, out var contentType);
+            var cloudEvent = jsonFormatter.DecodeStructuredModeMessage(jsonData, contentType, DistributedTracing.AllAttributes);
 
             Assert.Equal(SampleParent, cloudEvent[DistributedTracing.TraceParentAttribute]);
             Assert.Equal(SampleParent, cloudEvent.GetTraceParent());

--- a/test/CloudNative.CloudEvents.UnitTests/Extensions/PartitioningTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Extensions/PartitioningTest.cs
@@ -5,6 +5,7 @@
 using CloudNative.CloudEvents.NewtonsoftJson;
 using System.Text;
 using Xunit;
+using static CloudNative.CloudEvents.UnitTests.CloudEventFormatterExtensions;
 
 namespace CloudNative.CloudEvents.Extensions.UnitTests
 {
@@ -24,7 +25,7 @@ namespace CloudNative.CloudEvents.Extensions.UnitTests
         public void ParseJson()
         {
             var jsonFormatter = new JsonEventFormatter();
-            var cloudEvent = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(sampleJson));
+            var cloudEvent = jsonFormatter.DecodeStructuredModeText(sampleJson);
             Assert.Equal("abc", cloudEvent["partitionkey"]);
             Assert.Equal("abc", cloudEvent[Partitioning.PartitionKeyAttribute]);
             Assert.Equal("abc", cloudEvent.GetPartitionKey());
@@ -34,9 +35,9 @@ namespace CloudNative.CloudEvents.Extensions.UnitTests
         public void Transcode()
         {
             var jsonFormatter = new JsonEventFormatter();
-            var cloudEvent1 = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(sampleJson));
-            var jsonData = jsonFormatter.EncodeStructuredEvent(cloudEvent1, out _);
-            var cloudEvent = jsonFormatter.DecodeStructuredEvent(jsonData);
+            var cloudEvent1 = jsonFormatter.DecodeStructuredModeText(sampleJson);
+            var jsonData = jsonFormatter.EncodeStructuredModeMessage(cloudEvent1, out var contentType);
+            var cloudEvent = jsonFormatter.DecodeStructuredModeMessage(jsonData, contentType, null);
 
             Assert.Equal("abc", cloudEvent["partitionkey"]);
             Assert.Equal("abc", cloudEvent[Partitioning.PartitionKeyAttribute]);

--- a/test/CloudNative.CloudEvents.UnitTests/Extensions/SamplingTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Extensions/SamplingTest.cs
@@ -6,6 +6,7 @@ using CloudNative.CloudEvents.NewtonsoftJson;
 using System;
 using System.Text;
 using Xunit;
+using static CloudNative.CloudEvents.UnitTests.CloudEventFormatterExtensions;
 
 namespace CloudNative.CloudEvents.Extensions.UnitTests
 {
@@ -24,7 +25,7 @@ namespace CloudNative.CloudEvents.Extensions.UnitTests
         public void SamplingParse()
         {
             var jsonFormatter = new JsonEventFormatter();
-            var cloudEvent = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(sampleJson), Sampling.AllAttributes);
+            var cloudEvent = jsonFormatter.DecodeStructuredModeText(sampleJson, Sampling.AllAttributes);
 
             Assert.Equal(1, cloudEvent["sampledrate"]);
             Assert.Equal(1, cloudEvent.GetSampledRate());
@@ -34,12 +35,12 @@ namespace CloudNative.CloudEvents.Extensions.UnitTests
         public void SamplingJsonTranscode()
         {
             var jsonFormatter = new JsonEventFormatter();
-            var cloudEvent1 = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(sampleJson));
+            var cloudEvent1 = jsonFormatter.DecodeStructuredModeText(sampleJson);
             // Note that the value is just a string here, as we don't know the attribute type.
             Assert.Equal("1", cloudEvent1["sampledrate"]);
 
-            var jsonData = jsonFormatter.EncodeStructuredEvent(cloudEvent1, out _);
-            var cloudEvent = jsonFormatter.DecodeStructuredEvent(jsonData, Sampling.AllAttributes);
+            var jsonData = jsonFormatter.EncodeStructuredModeMessage(cloudEvent1, out var contentType);
+            var cloudEvent = jsonFormatter.DecodeStructuredModeMessage(jsonData, contentType, Sampling.AllAttributes);
 
             // When parsing with the attributes in place, the value is propagated as an integer.
             Assert.Equal(1, cloudEvent["sampledrate"]);

--- a/test/CloudNative.CloudEvents.UnitTests/Extensions/SequenceTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Extensions/SequenceTest.cs
@@ -6,6 +6,7 @@ using CloudNative.CloudEvents.NewtonsoftJson;
 using System;
 using System.Text;
 using Xunit;
+using static CloudNative.CloudEvents.UnitTests.CloudEventFormatterExtensions;
 
 namespace CloudNative.CloudEvents.Extensions.UnitTests
 {
@@ -25,7 +26,7 @@ namespace CloudNative.CloudEvents.Extensions.UnitTests
         public void Parse()
         {
             var jsonFormatter = new JsonEventFormatter();
-            var cloudEvent = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(sampleJson), Sequence.AllAttributes);
+            var cloudEvent = jsonFormatter.DecodeStructuredModeText(sampleJson, Sequence.AllAttributes);
 
             Assert.Equal("Integer", cloudEvent[Sequence.SequenceTypeAttribute]);
             Assert.Equal("25", cloudEvent[Sequence.SequenceAttribute]);
@@ -35,9 +36,9 @@ namespace CloudNative.CloudEvents.Extensions.UnitTests
         public void Transcode()
         {
             var jsonFormatter = new JsonEventFormatter();
-            var cloudEvent1 = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(sampleJson));
-            var jsonData = jsonFormatter.EncodeStructuredEvent(cloudEvent1, out var contentType);
-            var cloudEvent = jsonFormatter.DecodeStructuredEvent(jsonData, Sequence.AllAttributes);
+            var cloudEvent1 = jsonFormatter.DecodeStructuredModeText(sampleJson);
+            var jsonData = jsonFormatter.EncodeStructuredModeMessage(cloudEvent1, out var contentType);
+            var cloudEvent = jsonFormatter.DecodeStructuredModeMessage(jsonData, contentType, Sequence.AllAttributes);
 
             Assert.Equal("Integer", cloudEvent[Sequence.SequenceTypeAttribute]);
             Assert.Equal("25", cloudEvent[Sequence.SequenceAttribute]);

--- a/test/CloudNative.CloudEvents.UnitTests/Http/HttpClientExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Http/HttpClientExtensionsTest.cs
@@ -145,7 +145,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
         }
 
         [Fact]
-        async Task HttpStructuredClientReceiveTest()
+        public async Task HttpStructuredClientReceiveTest()
         {
             string ctx = Guid.NewGuid().ToString();
             PendingRequests.TryAdd(ctx, async context =>
@@ -200,7 +200,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
         }
 
         [Fact]
-        async Task HttpStructuredClientSendTest()
+        public async Task HttpStructuredClientSendTest()
         {
             var cloudEvent = new CloudEvent
             {                
@@ -231,7 +231,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
                     Assert.Equal("2018-04-05T17:31:00Z", headers["ce-time"]);
                     // Note that datacontenttype is mapped in this case, but would not be included in binary mode.
                     Assert.Equal("text/xml", headers["ce-datacontenttype"]);
-                    Assert.Equal("application/cloudevents+json", context.Request.ContentType);
+                    Assert.Equal("application/cloudevents+json; charset=utf-8", context.Request.ContentType);
                     Assert.Equal("value", headers["ce-comexampleextension1"]);
                     // The non-ASCII attribute value should have been URL-encoded using UTF-8 for the header.
                     Assert.Equal("%C3%A6%C3%B8%C3%A5", headers["ce-utf8examplevalue"]);

--- a/test/CloudNative.CloudEvents.UnitTests/MimeUtilitiesTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/MimeUtilitiesTest.cs
@@ -1,0 +1,82 @@
+﻿// Copyright 2021 Cloud Native Foundation. 
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Net.Mime;
+using System.Text;
+using Xunit;
+
+namespace CloudNative.CloudEvents.UnitTests.Http
+{
+    public class MimeUtilitiesTest
+    {
+        [Theory]
+        [InlineData("application/json")]
+        [InlineData("application/json; charset=iso-8859-1")]
+        [InlineData("application/json; charset=iso-8859-1; name=some-name")]
+        [InlineData("application/json; charset=iso-8859-1; name=some-name; x=y; a=b")]
+        [InlineData("application/json; charset=iso-8859-1; name=some-name; boundary=xyzzy; x=y")]
+        public void ContentTypeConversions(string text)
+        {
+            var originalContentType = new ContentType(text);
+            var header = originalContentType.ToMediaTypeHeaderValue();
+            AssertEqualParts(text, header.ToString());
+            var convertedContentType = header.ToContentType();
+            AssertEqualParts(originalContentType.ToString(), convertedContentType.ToString());
+
+            // Conversions can end up reordering the parameters. In reality we're only
+            // likely to end up with a media type and charset, but our tests use more parameters.
+            // This just makes them deterministic.
+            void AssertEqualParts(string expected, string actual)
+            {
+                expected = string.Join(";", expected.Split(";").OrderBy(x => x));
+                actual = string.Join(";", actual.Split(";").OrderBy(x => x));
+                Assert.Equal(expected, actual);
+            }
+        }
+
+        [Fact]
+        public void ContentTypeConversions_Null()
+        {
+            Assert.Null(default(ContentType).ToMediaTypeHeaderValue());
+            Assert.Null(default(MediaTypeHeaderValue).ToContentType());
+        }
+
+        [Theory]
+        [InlineData("iso-8859-1")]
+        [InlineData("utf-8")]
+        public void ContentTypeGetEncoding(string charSet)
+        {
+            var contentType = new ContentType($"text/plain; charset={charSet}");
+            Encoding encoding = contentType.GetEncoding();
+            Assert.Equal(charSet, encoding.WebName);
+        }
+
+        [Fact]
+        public void ContentTypeGetEncoding_NoContentType()
+        {
+            ContentType contentType = null;
+            Encoding encoding = contentType.GetEncoding();
+            Assert.Equal(Encoding.UTF8, encoding);
+        }
+
+        [Fact]
+        public void ContentTypeGetEncoding_NoCharSet()
+        {
+            ContentType contentType = new ContentType("text/plain");
+            Encoding encoding = contentType.GetEncoding();
+            Assert.Equal(Encoding.UTF8, encoding);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("text/plain")]
+        public void CreateContentTypeOrNull_WithContentType(string text)
+        {
+            ContentType ct = MimeUtilities.CreateContentTypeOrNull(text);
+            Assert.Equal(text, ct?.ToString());
+        }
+    }
+}

--- a/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/JsonEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/JsonEventFormatterTest.cs
@@ -6,6 +6,7 @@ using System;
 using System.Net.Mime;
 using System.Text;
 using Xunit;
+using static CloudNative.CloudEvents.UnitTests.CloudEventFormatterExtensions;
 using static CloudNative.CloudEvents.UnitTests.TestHelpers;
 
 namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
@@ -30,11 +31,11 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
         public void ReserializeTest10()
         {
             var jsonFormatter = new JsonEventFormatter();
-            var cloudEvent = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(jsonv10));
-            var jsonData = jsonFormatter.EncodeStructuredEvent(cloudEvent, out var contentType);
+            var cloudEvent = jsonFormatter.DecodeStructuredModeText(jsonv10);
+            var jsonData = jsonFormatter.EncodeStructuredModeMessage(cloudEvent, out var contentType);
             Assert.Equal("application/cloudevents+json", contentType.MediaType);
 
-            var cloudEvent2 = jsonFormatter.DecodeStructuredEvent(jsonData);
+            var cloudEvent2 = jsonFormatter.DecodeStructuredModeMessage(jsonData, contentType: null, Array.Empty<CloudEventAttribute>());
 
             Assert.Equal(cloudEvent2.SpecVersion, cloudEvent.SpecVersion);
             Assert.Equal(cloudEvent2.Type, cloudEvent.Type);
@@ -49,7 +50,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
         public void StructuredParseSuccess10()
         {
             var jsonFormatter = new JsonEventFormatter();
-            var cloudEvent = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(jsonv10));
+            var cloudEvent = jsonFormatter.DecodeStructuredModeMessage(Encoding.UTF8.GetBytes(jsonv10), contentType: null, extensionAttributes: null);
             Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
@@ -68,7 +69,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
             var extension = CloudEventAttribute.CreateExtension("comexampleextension2", CloudEventAttributeType.Integer);
 
             var jsonFormatter = new JsonEventFormatter();
-            var cloudEvent = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(jsonv10), new[] { extension });
+            var cloudEvent = jsonFormatter.DecodeStructuredModeMessage(Encoding.UTF8.GetBytes(jsonv10), contentType: null, new[] { extension });
             // Instead of getting it as a string (as before), we now have it as an integer.
             Assert.Equal(10, cloudEvent["comexampleextension2"]);
         }

--- a/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/JsonEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/JsonEventFormatterTest.cs
@@ -68,7 +68,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
             var extension = CloudEventAttribute.CreateExtension("comexampleextension2", CloudEventAttributeType.Integer);
 
             var jsonFormatter = new JsonEventFormatter();
-            var cloudEvent = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(jsonv10), extension);
+            var cloudEvent = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(jsonv10), new[] { extension });
             // Instead of getting it as a string (as before), we now have it as an integer.
             Assert.Equal(10, cloudEvent["comexampleextension2"]);
         }


### PR DESCRIPTION
Towards #55.

It's worth reviewing this one commit at a time - I'm afraid the last one is unavoidably large :(
Once this is merged, I want to add a *lot* more tests for the JsonEventFormatter, to validate everything it now documents. We could potentially do that in this PR, but I suspect it'll simplify reviewing if we focus on what the responsibilities should be for now, and then focus on the implementation and tests in another PR. (I've tried to make the implementation follow the docs, of course, but I definitely need tests...)