### PR TITLE
Event formatter batch handling

### DIFF
--- a/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
@@ -67,6 +67,12 @@ namespace CloudNative.CloudEvents
             return DecodeStructuredModeMessage(new MemoryStream(data), contentType, extensionAttributes);
         }
 
+        public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(byte[] data, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes) =>
+            throw new NotSupportedException("The Avro event formatter does not support batch content mode");
+
+        public override byte[] EncodeBatchModeMessage(IEnumerable<CloudEvent> cloudEvent, out ContentType contentType) =>
+            throw new NotSupportedException("The Avro event formatter does not support batch content mode");
+
         private CloudEvent DecodeGenericRecord(GenericRecord record, IEnumerable<CloudEventAttribute> extensionAttributes)
         {
             if (!record.TryGetValue(AttributeName, out var attrObj))

--- a/src/CloudNative.CloudEvents/CloudEventFormatter.cs
+++ b/src/CloudNative.CloudEvents/CloudEventFormatter.cs
@@ -110,5 +110,59 @@ namespace CloudNative.CloudEvents
         /// event formatter.</exception>
         /// <returns>The binary-mode representation of the CloudEvent.</returns>
         public abstract byte[] EncodeBinaryModeEventData(CloudEvent cloudEvent);
+
+        /// <summary>
+        /// Decodes a collection CloudEvents from a batch-mode message body, represented as a byte array.
+        /// </summary>
+        /// <param name="data">The data within the message body. Must not be null.</param>
+        /// <param name="contentType">The content type of the message, or null if no content type is known.
+        /// Typically this is a content type with a media type with a prefix of "application/cloudevents-batch"; the additional
+        /// information such as the charset parameter may be needed in order to decode the data.</param>
+        /// <param name="extensions">The extension attributes to use when populating the CloudEvent. May be null.</param>
+        /// <returns>The collection of CloudEvents derived from the batched data.</returns>
+        public abstract IReadOnlyList<CloudEvent> DecodeBatchModeMessage(byte[] data, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes);
+
+        /// <summary>
+        /// Decodes a collection CloudEvents from a batch-mode message body, represented as a stream. The default implementation copies the
+        /// content of the stream into a byte array before passing it to <see cref="DecodeBatchModeMessage(byte[], ContentType, IEnumerable{CloudEventAttribute})"/>
+        /// but this can be overridden by event formatters that can decode a stream more efficiently.
+        /// </summary>
+        /// <param name="data">The data within the message body. Must not be null.</param>
+        /// <param name="contentType">The content type of the message, or null if no content type is known.
+        /// Typically this is a content type with a media type with a prefix of "application/cloudevents"; the additional
+        /// information such as the charset parameter may be needed in order to decode the data.</param>
+        /// <param name="extensions">The extension attributes to use when populating the CloudEvent. May be null.</param>
+        /// <returns>The collection of CloudEvents derived from the batched data.</returns>
+        public virtual IReadOnlyList<CloudEvent> DecodeBatchModeMessage(Stream data, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes)
+        {
+            var bytes = BinaryDataUtilities.ToByteArray(data);
+            return DecodeBatchModeMessage(bytes, contentType, extensionAttributes);
+        }
+
+        /// <summary>
+        /// Asynchronously decodes a collection CloudEvents from a batch-mode message body, represented as a stream. The default implementation asynchronously copies the
+        /// content of the stream into a byte array before passing it to <see cref="DecodeBatchModeMessage(byte[], ContentType, IEnumerable{CloudEventAttribute})"/>
+        /// but this can be overridden by event formatters that can decode a stream more efficiently.
+        /// </summary>
+        /// <param name="data">The data within the message body. Must not be null.</param>
+        /// <param name="contentType">The content type of the message, or null if no content type is known.
+        /// Typically this is a content type with a media type with a prefix of "application/cloudevents"; the additional
+        /// information such as the charset parameter may be needed in order to decode the data.</param>
+        /// <param name="extensions">The extension attributes to use when populating the CloudEvent. May be null.</param>
+        /// <returns>The collection of CloudEvents derived from the batched data.</returns>
+        public virtual async Task<IReadOnlyList<CloudEvent>> DecodeBatchModeMessageAsync(Stream data, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes)
+        {
+            var bytes = await BinaryDataUtilities.ToByteArrayAsync(data).ConfigureAwait(false);
+            return DecodeBatchModeMessage(bytes, contentType, extensionAttributes);
+        }
+
+        /// <summary>
+        // Encodes a sequence of CloudEvents as the body of a message.
+        /// </summary>
+        /// <param name="cloudEvents">The CloudEvents to encode. Must not be null.</param>
+        /// <param name="contentType">On successful return, the content type of the structured-mode data.
+        /// Must not be null (on return).</param>
+        /// <returns>The batch representation of the CloudEvent.</returns>
+        public abstract byte[] EncodeBatchModeMessage(IEnumerable<CloudEvent> cloudEvents, out ContentType contentType);
     }
 }

--- a/src/CloudNative.CloudEvents/Core/MimeUtilities.cs
+++ b/src/CloudNative.CloudEvents/Core/MimeUtilities.cs
@@ -16,6 +16,12 @@ namespace CloudNative.CloudEvents.Core
     /// </summary>
     public static class MimeUtilities
     {
+        /// <summary>
+        /// The media type to use for batch mode. This is usually suffixed with a format-specific
+        /// type, e.g. "+json".
+        /// </summary>
+        public static string BatchMediaType { get; } = CloudEvent.MediaType + "-batch";
+
         // TODO: Should we return null, and force the caller to do the appropriate defaulting?
         /// <summary>
         /// Returns an encoding from a content type, defaulting to UTF-8.

--- a/test/CloudNative.CloudEvents.UnitTests/TestHelpers.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/TestHelpers.cs
@@ -84,7 +84,7 @@ namespace CloudNative.CloudEvents.UnitTests
         {
             cloudEvent.Id = "test-id";
             cloudEvent.Source = new Uri("//test", UriKind.RelativeOrAbsolute);
-            cloudEvent.Type = "test-id";
+            cloudEvent.Type = "test-type";
             return cloudEvent;
         }
 


### PR DESCRIPTION
(This comment is now out of date; see comment from 2021-04-08 for update.)

First two commits are from #110.

Obviously we'd need tests, and then probably protocol binding support (at least for HTTP). This is mostly to show what the CloudEventFormatter interface might look like for batch.

I'm nervous about it because it's not a separate content mode in the CloudEvents spec - but it would be really hard to express without putting it into CloudEventFormatter. It probably doesn't make sense to include it in the ContentMode enum, because the signatures for protocol bindings don't make sense (as they need to accept/return a collection instead of a single event). Basically it doesn't fit in terribly neatly...