### PR TITLE
DO NOT MERGE: Expose an Ordinal enum for CloudEventAttributeType

### DIFF
--- a/src/CloudNative.CloudEvents/CloudEventAttributeType.cs
+++ b/src/CloudNative.CloudEvents/CloudEventAttributeType.cs
@@ -52,6 +52,52 @@ namespace CloudNative.CloudEvents
         public static CloudEventAttributeType Timestamp { get; } = new TimestampType();
 
         /// <summary>
+        /// Enum of event types, to allow efficient switching over CloudEventAttributeType.
+        /// Each attribute type has a unique value, returned by <see cref="OrdinalType"/>.
+        /// </summary>
+        /// <remarks>
+        /// This type is nested as relatively few consumers will need to use it.
+        /// </remarks>
+        public enum Ordinal
+        {
+            // Note: changing the values here is a breaking change.
+
+            /// <summary>
+            /// Ordinal for <see cref="CloudEventAttributeType.Binary"/>
+            /// </summary>
+            Binary = 0,
+            /// <summary>
+            /// Ordinal for <see cref="CloudEventAttributeType.Boolean"/>
+            /// </summary>
+            Boolean = 1,
+            /// <summary>
+            /// Ordinal for <see cref="CloudEventAttributeType.Integer"/>
+            /// </summary>
+            Integer = 2,
+            /// <summary>
+            /// Ordinal for <see cref="CloudEventAttributeType.String"/>
+            /// </summary>
+            String = 3,
+            /// <summary>
+            /// Ordinal for <see cref="CloudEventAttributeType.Uri"/>
+            /// </summary>
+            Uri = 4,
+            /// <summary>
+            /// Ordinal for <see cref="CloudEventAttributeType.UriReference"/>
+            /// </summary>
+            UriReference = 5,
+            /// <summary>
+            /// Ordinal for <see cref="CloudEventAttributeType.Timestamp"/>
+            /// </summary>
+            Timestamp = 6
+        }
+
+        /// <summary>
+        /// The <see cref="Ordinal"/> value for this type.
+        /// </summary>
+        public Ordinal OrdinalType { get; }
+
+        /// <summary>
         /// The name of the type, as it is written in the CloudEvents specification.
         /// </summary>
         public string Name { get; }
@@ -86,15 +132,16 @@ namespace CloudNative.CloudEvents
         /// <param name="value">The value to validate. Must be non-null, and suitable for this attribute type.</param>
         public abstract void Validate(object value);
 
-        private CloudEventAttributeType(string name, Type clrType)
+        private CloudEventAttributeType(string name, Ordinal ordinal, Type clrType)
         {
             Name = name;
+            OrdinalType = ordinal;
             ClrType = clrType;
         }
 
         private abstract class GenericCloudEventsAttributeType<T> : CloudEventAttributeType
         {
-            protected GenericCloudEventsAttributeType(string name) : base(name, typeof(T))
+            protected GenericCloudEventsAttributeType(string name, Ordinal ordinal) : base(name, ordinal, typeof(T))
             {
             }
 
@@ -128,7 +175,7 @@ namespace CloudNative.CloudEvents
 
         private class BooleanType : GenericCloudEventsAttributeType<bool>
         {
-            public BooleanType() : base("Boolean")
+            public BooleanType() : base("Boolean", Ordinal.Boolean)
             {
             }
 
@@ -141,7 +188,7 @@ namespace CloudNative.CloudEvents
 
         private class StringType : GenericCloudEventsAttributeType<string>
         {
-            public StringType() : base("String")
+            public StringType() : base("String", Ordinal.String)
             {
             }
 
@@ -211,7 +258,7 @@ namespace CloudNative.CloudEvents
 
         private class TimestampType : GenericCloudEventsAttributeType<DateTimeOffset>
         {
-            public TimestampType() : base("Timestamp")
+            public TimestampType() : base("Timestamp", Ordinal.Timestamp)
             {
             }
 
@@ -232,7 +279,7 @@ namespace CloudNative.CloudEvents
         // differences to make it not worthwhile.
         private class UriType : GenericCloudEventsAttributeType<Uri>
         {
-            public UriType() : base("URI")
+            public UriType() : base("URI", Ordinal.Uri)
             {
             }
 
@@ -261,7 +308,7 @@ namespace CloudNative.CloudEvents
 
         private class UriReferenceType : GenericCloudEventsAttributeType<Uri>
         {
-            public UriReferenceType() : base("URI-Reference")
+            public UriReferenceType() : base("URI-Reference", Ordinal.UriReference)
             {
             }
 
@@ -272,7 +319,7 @@ namespace CloudNative.CloudEvents
 
         private class BinaryType : GenericCloudEventsAttributeType<byte[]>
         {
-            public BinaryType() : base("Binary")
+            public BinaryType() : base("Binary", Ordinal.Binary)
             {
             }
 
@@ -282,7 +329,7 @@ namespace CloudNative.CloudEvents
 
         private class IntegerType : GenericCloudEventsAttributeType<int>
         {
-            public IntegerType() : base("Integer")
+            public IntegerType() : base("Integer", Ordinal.Integer)
             {
             }
 

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventAttributeTypeTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventAttributeTypeTest.cs
@@ -3,6 +3,8 @@
 // See LICENSE file in the project root for full license information.
 
 using System;
+using System.Linq;
+using System.Reflection;
 using System.Text;
 using Xunit;
 
@@ -31,6 +33,19 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("Timestamp", CloudEventAttributeType.Timestamp.Name);
             Assert.Equal("URI", CloudEventAttributeType.Uri.Name);
             Assert.Equal("URI-Reference", CloudEventAttributeType.UriReference.Name);
+        }
+
+        [Fact]
+        public void OrdinalTypeNameMatchesPropertyName()
+        {
+            var properties = typeof(CloudEventAttributeType)
+                .GetProperties(BindingFlags.Public | BindingFlags.Static)
+                .Where(prop => prop.PropertyType == typeof(CloudEventAttributeType));
+            foreach (var property in properties)
+            {
+                var type = (CloudEventAttributeType) property.GetValue(null);
+                Assert.Equal(property.Name, type.OrdinalType.ToString());
+            }
         }
 
         [Theory]


### PR DESCRIPTION
This is nested as most code won't need it, but it allows code to
use switch statements to react to different attribute types.

I'm interested in the following aspects for review:

- Whether we think this is sufficiently useful to be worth it at all
- The design of using a nested enum

(Another option would be to have an enum in a namespace which is
designed primarily for protocol/formatter implementers - we've
already discussed the possibility of having that namespace, and
maybe this could belong there?)