### PR TITLE
Complete the HTTP batch support

### DIFF
--- a/src/CloudNative.CloudEvents.Amqp/AmqpClientExtensions.cs
+++ b/src/CloudNative.CloudEvents.Amqp/AmqpClientExtensions.cs
@@ -127,11 +127,10 @@ namespace CloudNative.CloudEvents.Amqp
             }
         }
 
-        // TODO: Check that it really is meant to be case-sensitive. (Original code was inconsistent.)
         private static bool HasCloudEventsContentType(Message message, out string contentType)
         {
-            contentType = (message.Properties.ContentType as Symbol)?.ToString();
-            return contentType?.StartsWith(CloudEvent.MediaType) == true;
+            contentType = message.Properties.ContentType?.ToString();
+            return MimeUtilities.IsCloudEventsContentType(contentType);
         }
 
         /// <summary>

--- a/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtensions.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtensions.cs
@@ -88,7 +88,6 @@ namespace CloudNative.CloudEvents
         }
 
         private static bool HasCloudEventsContentType(HttpRequest request) =>
-            request?.ContentType is var contentType &&
-            contentType.StartsWith(CloudEvent.MediaType, StringComparison.InvariantCultureIgnoreCase);
+            MimeUtilities.IsCloudEventsContentType(request?.ContentType);
     }
 }

--- a/src/CloudNative.CloudEvents.Kafka/KafkaClientExtensions.cs
+++ b/src/CloudNative.CloudEvents.Kafka/KafkaClientExtensions.cs
@@ -27,8 +27,7 @@ namespace CloudNative.CloudEvents.Kafka
 
         public static bool IsCloudEvent(this Message<string, byte[]> message) =>
             GetHeaderValue(message, SpecVersionKafkaHeader) is object ||
-            (ExtractContentType(message)?.StartsWith(CloudEvent.MediaType, StringComparison.InvariantCultureIgnoreCase) == true);
-
+            MimeUtilities.IsCloudEventsContentType(ExtractContentType(message));
 
         /// <summary>
         /// Converts this Kafka message into a CloudEvent object.
@@ -64,7 +63,7 @@ namespace CloudNative.CloudEvents.Kafka
             CloudEvent cloudEvent;
 
             // Structured mode
-            if (contentType?.StartsWith(CloudEvent.MediaType, StringComparison.InvariantCultureIgnoreCase) == true)
+            if (MimeUtilities.IsCloudEventsContentType(contentType))
             {
                 cloudEvent = formatter.DecodeStructuredModeMessage(message.Value, new ContentType(contentType), extensionAttributes);
             }

--- a/src/CloudNative.CloudEvents/Core/MimeUtilities.cs
+++ b/src/CloudNative.CloudEvents/Core/MimeUtilities.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
+using System;
 using System.Net.Http.Headers;
 using System.Net.Mime;
 using System.Text;
@@ -67,5 +68,23 @@ namespace CloudNative.CloudEvents.Core
         /// <returns>The converted content type, or null if <paramref name="contentType"/> is null.</returns>
         public static ContentType CreateContentTypeOrNull(string contentType) =>
             contentType is null ? null : new ContentType(contentType);
+
+        /// <summary>
+        /// Determines whether the given content type denotes a (non-batch) CloudEvent.
+        /// </summary>
+        /// <param name="contentType">The content type to check. May be null, in which case the result is false.</param>
+        /// <returns>true if the given content type denotes a (non-batch) CloudEvent; false otherwise</returns>
+        public static bool IsCloudEventsContentType(string contentType) =>
+            contentType is string &&
+            contentType.StartsWith(CloudEvent.MediaType, StringComparison.InvariantCultureIgnoreCase) &&
+            !contentType.StartsWith(BatchMediaType, StringComparison.InvariantCultureIgnoreCase);
+
+        /// <summary>
+        /// Determines whether the given content type denotes a CloudEvent batch.
+        /// </summary>
+        /// <param name="contentType">The content type to check. May be null, in which case the result is false.</param>
+        /// <returns>true if the given content type represents a CloudEvent batch; false otherwise</returns>
+        public static bool IsCloudEventsBatchContentType(string contentType) =>
+            contentType is string && contentType.StartsWith(BatchMediaType, StringComparison.InvariantCultureIgnoreCase);
     }
 }

--- a/src/CloudNative.CloudEvents/Core/Validation.cs
+++ b/src/CloudNative.CloudEvents/Core/Validation.cs
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace CloudNative.CloudEvents.Core
@@ -93,6 +94,22 @@ namespace CloudNative.CloudEvents.Core
             var missing = cloudEvent.SpecVersion.RequiredAttributes.Where(attr => cloudEvent[attr] is null).ToList();
             string joinedMissing = string.Join(", ", missing);
             throw new ArgumentException($"CloudEvent is missing required attributes: {joinedMissing}", paramName);
+        }
+
+        /// <summary>
+        /// Validates that the specified batch is valid, by asserting that it is non-null,
+        /// and that it only contains non-null references to valid CloudEvents.
+        /// </summary>
+        /// <param name="cloudEvents">The event batch to validate.
+        /// <param name="paramName">The parameter name to use in the exception if <paramref name="cloudEvent"/> is null or invalid.
+        /// May be null.</param>
+        public static void CheckCloudEventBatchArgument(IReadOnlyList<CloudEvent> cloudEvents, string paramName)
+        {
+            CheckNotNull(cloudEvents, paramName);
+            foreach (var cloudEvent in cloudEvents)
+            {
+                CheckCloudEventArgument(cloudEvent, paramName);
+            }
         }
     }
 }

--- a/src/CloudNative.CloudEvents/Http/HttpClientExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpClientExtensions.cs
@@ -235,7 +235,7 @@ namespace CloudNative.CloudEvents.Http
             IEnumerable<CloudEventAttribute> extensionAttributes)
         {
             Validation.CheckNotNull(httpResponseMessage, nameof(httpResponseMessage));
-            return ToCloudEventBatchInternalAsync(httpResponseMessage.Headers, httpResponseMessage.Content, formatter, extensionAttributes, nameof(httpResponseMessage));
+            return ToCloudEventBatchInternalAsync(httpResponseMessage.Content, formatter, extensionAttributes, nameof(httpResponseMessage));
         }
 
         /// <summary>
@@ -264,10 +264,10 @@ namespace CloudNative.CloudEvents.Http
             IEnumerable<CloudEventAttribute> extensionAttributes)
         {
             Validation.CheckNotNull(httpRequestMessage, nameof(httpRequestMessage));
-            return ToCloudEventBatchInternalAsync(httpRequestMessage.Headers, httpRequestMessage.Content, formatter, extensionAttributes, nameof(httpRequestMessage));
+            return ToCloudEventBatchInternalAsync(httpRequestMessage.Content, formatter, extensionAttributes, nameof(httpRequestMessage));
         }
 
-        private static async Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchInternalAsync(HttpHeaders headers, HttpContent content,
+        private static async Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchInternalAsync(HttpContent content,
             CloudEventFormatter formatter, IEnumerable<CloudEventAttribute> extensionAttributes, string paramName)
         {
             Validation.CheckNotNull(formatter, nameof(formatter));

--- a/src/CloudNative.CloudEvents/Http/HttpClientExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpClientExtensions.cs
@@ -287,12 +287,9 @@ namespace CloudNative.CloudEvents.Http
 
         // TODO: This would include "application/cloudeventsarerubbish" for example...
         private static bool HasCloudEventsContentType(HttpContent content) =>
-            content?.Headers?.ContentType is var contentType &&
-            contentType.MediaType.StartsWith(CloudEvent.MediaType, StringComparison.InvariantCultureIgnoreCase) &&
-            !contentType.MediaType.StartsWith(MimeUtilities.BatchMediaType);
+            MimeUtilities.IsCloudEventsContentType(content?.Headers?.ContentType?.MediaType);
 
         private static bool HasCloudEventsBatchContentType(HttpContent content) =>
-            content?.Headers?.ContentType is var contentType &&
-            contentType.MediaType.StartsWith(MimeUtilities.BatchMediaType);
+            MimeUtilities.IsCloudEventsBatchContentType(content?.Headers?.ContentType?.MediaType);
     }
 }

--- a/src/CloudNative.CloudEvents/Http/HttpContentExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpContentExtensions.cs
@@ -82,11 +82,7 @@ namespace CloudNative.CloudEvents.Http
         /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
         public static HttpContent ToHttpContent(this IReadOnlyList<CloudEvent> cloudEvents, CloudEventFormatter formatter)
         {
-            Validation.CheckNotNull(cloudEvents, nameof(cloudEvents));
-            foreach (var cloudEvent in cloudEvents)
-            {
-                Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvents));
-            }
+            Validation.CheckCloudEventBatchArgument(cloudEvents, nameof(cloudEvents)); 
             Validation.CheckNotNull(formatter, nameof(formatter));
 
             // TODO: Validate that all events in the batch have the same version?

--- a/src/CloudNative.CloudEvents/Http/HttpListenerExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpListenerExtensions.cs
@@ -86,11 +86,8 @@ namespace CloudNative.CloudEvents.Http
         public static async Task CopyToHttpListenerResponseAsync(this IReadOnlyList<CloudEvent> cloudEvents,
             HttpListenerResponse destination, CloudEventFormatter formatter)
         {
-            Validation.CheckNotNull(cloudEvents, nameof(cloudEvents));
-            foreach (var cloudEvent in cloudEvents)
-            {
-                Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvents));
-            }
+            Validation.CheckCloudEventBatchArgument(cloudEvents, nameof(cloudEvents));
+            Validation.CheckNotNull(destination, nameof(destination));
             Validation.CheckNotNull(formatter, nameof(formatter));
 
             // TODO: Validate that all events in the batch have the same version?

--- a/src/CloudNative.CloudEvents/Http/HttpListenerExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpListenerExtensions.cs
@@ -212,7 +212,6 @@ namespace CloudNative.CloudEvents.Http
         }
 
         private static bool HasCloudEventsContentType(HttpListenerRequest request) =>
-            request.ContentType is string contentType &&
-            contentType.StartsWith(CloudEvent.MediaType, StringComparison.InvariantCultureIgnoreCase);
+            MimeUtilities.IsCloudEventsContentType(request.ContentType);
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/AspNetCore/HttpRequestExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/AspNetCore/HttpRequestExtensionsTest.cs
@@ -1,0 +1,51 @@
+﻿// Copyright 2021 Cloud Native Foundation. 
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using CloudNative.CloudEvents.NewtonsoftJson;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Internal;
+using System;
+using System.IO;
+using System.Net.Mime;
+using System.Threading.Tasks;
+using Xunit;
+using static CloudNative.CloudEvents.UnitTests.TestHelpers;
+
+namespace CloudNative.CloudEvents.AspNetCore.UnitTests
+{
+    public class HttpRequestExtensionsTest
+    {
+        // TODO: Non-batch tests
+
+        [Fact]
+        public async Task ToCloudEventBatchAsync_Valid()
+        {
+            var batch = CreateSampleBatch();
+
+            var formatter = new JsonEventFormatter();
+            var contentBytes = formatter.EncodeBatchModeMessage(batch, out var contentType);
+
+            AssertBatchesEqual(batch, await CreateRequest(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionArray));
+            AssertBatchesEqual(batch, await CreateRequest(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionSequence));
+        }
+
+        [Fact]
+        public async Task ToCloudEventBatchAsync_Invalid()
+        {
+            // Most likely accident: calling ToCloudEventBatchAsync with a single event in structured mode.
+            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+            var formatter = new JsonEventFormatter();
+            var contentBytes = formatter.EncodeStructuredModeMessage(cloudEvent, out var contentType);
+            await Assert.ThrowsAsync<ArgumentException>(() => CreateRequest(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionArray).AsTask());
+            await Assert.ThrowsAsync<ArgumentException>(() => CreateRequest(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionSequence).AsTask());
+        }
+
+        private static HttpRequest CreateRequest(byte[] content, ContentType contentType) =>
+            new DefaultHttpRequest(new DefaultHttpContext())
+            {
+                ContentType = contentType.ToString(),
+                Body = new MemoryStream(content)
+            };
+    }
+}

--- a/test/CloudNative.CloudEvents.UnitTests/CloudNative.CloudEvents.UnitTests.csproj
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudNative.CloudEvents.UnitTests.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\CloudNative.CloudEvents.Amqp\CloudNative.CloudEvents.Amqp.csproj" />
+    <ProjectReference Include="..\..\src\CloudNative.CloudEvents.AspNetCore\CloudNative.CloudEvents.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\CloudNative.CloudEvents.Avro\CloudNative.CloudEvents.Avro.csproj" />
     <ProjectReference Include="..\..\src\CloudNative.CloudEvents.Kafka\CloudNative.CloudEvents.Kafka.csproj" />
     <ProjectReference Include="..\..\src\CloudNative.CloudEvents.Mqtt\CloudNative.CloudEvents.Mqtt.csproj" />

--- a/test/CloudNative.CloudEvents.UnitTests/Core/MimeUtilitiesTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Core/MimeUtilitiesTest.cs
@@ -78,5 +78,30 @@ namespace CloudNative.CloudEvents.Core.UnitTests
             ContentType ct = MimeUtilities.CreateContentTypeOrNull(text);
             Assert.Equal(text, ct?.ToString());
         }
+
+        [Theory]
+        [InlineData("text/plain", false)]
+        [InlineData(null, false)]
+        [InlineData("application/cloudevents", true)]
+        [InlineData("application/cloudevents+json", true)]
+        // It's not entirely clear that this *should* be true...
+        [InlineData("application/cloudeventstrailing", true)]
+        [InlineData("application/cloudevents-batch", false)]
+        [InlineData("application/cloudevents-batch+json", false)]
+        public void IsCloudEventsContentType(string contentType, bool expectedResult) =>
+            Assert.Equal(expectedResult, MimeUtilities.IsCloudEventsContentType(contentType));
+
+        [Theory]
+        [InlineData("text/plain", false)]
+        [InlineData(null, false)]
+        [InlineData("application/cloudevents", false)]
+        [InlineData("application/cloudevents+json", false)]
+        [InlineData("application/cloudeventstrailing", false)]
+        [InlineData("application/cloudevents-batch", true)]
+        // It's not entirely clear that this *should* be true...
+        [InlineData("application/cloudevents-batchtrailing", true)]
+        [InlineData("application/cloudevents-batch+json", true)]
+        public void IsCloudEventsBatchContentType(string contentType, bool expectedResult) =>
+            Assert.Equal(expectedResult, MimeUtilities.IsCloudEventsBatchContentType(contentType));
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/Http/HttpClientExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Http/HttpClientExtensionsTest.cs
@@ -20,9 +20,6 @@ namespace CloudNative.CloudEvents.Http.UnitTests
 {
     public class HttpClientExtensionsTest : HttpTestBase
     {
-        private static readonly CloudEventAttribute[] EmptyExtensionArray = new CloudEventAttribute[0];
-        private static readonly IEnumerable<CloudEventAttribute> EmptyExtensionSequence = new List<CloudEventAttribute>();
-
         public static TheoryData<string, HttpContent, IDictionary<string, string>> SingleCloudEventMessages = new TheoryData<string, HttpContent, IDictionary<string, string>>
         {
             {

--- a/test/CloudNative.CloudEvents.UnitTests/Http/HttpClientExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Http/HttpClientExtensionsTest.cs
@@ -130,15 +130,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
         [Fact]
         public async Task ToCloudEventBatchAsync_Valid()
         {
-            var event1 = new CloudEvent().PopulateRequiredAttributes();
-            event1.Id = "event1";
-            event1.Data = "simple text";
-            event1.DataContentType = "text/plain";
-
-            var event2 = new CloudEvent().PopulateRequiredAttributes();
-            event2.Id = "event2";
-
-            var batch = new[] { event1, event2 };
+            var batch = CreateSampleBatch();
 
             var formatter = new JsonEventFormatter();
             var contentBytes = formatter.EncodeBatchModeMessage(batch, out var contentType);

--- a/test/CloudNative.CloudEvents.UnitTests/Http/HttpContentExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Http/HttpContentExtensionsTest.cs
@@ -47,15 +47,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
         [Fact]
         public async Task ToHttpContent_Batch()
         {
-            var event1 = new CloudEvent().PopulateRequiredAttributes();
-            event1.Id = "event1";
-            event1.Data = "simple text";
-            event1.DataContentType = "text/plain";
-
-            var event2 = new CloudEvent().PopulateRequiredAttributes();
-            event2.Id = "event2";
-
-            var batch = new[] { event1, event2 };
+            var batch = CreateSampleBatch();
 
             var formatter = new JsonEventFormatter();
             var content = batch.ToHttpContent(formatter);

--- a/test/CloudNative.CloudEvents.UnitTests/TestHelpers.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/TestHelpers.cs
@@ -15,6 +15,9 @@ namespace CloudNative.CloudEvents.UnitTests
     /// </summary>
     internal static class TestHelpers
     {
+        internal static CloudEventAttribute[] EmptyExtensionArray { get; } = new CloudEventAttribute[0];
+        internal static IEnumerable<CloudEventAttribute> EmptyExtensionSequence { get; } = new List<CloudEventAttribute>().AsReadOnly();
+
         /// <summary>
         /// A set of extension attributes covering all attributes types.
         /// The name of each attribute is the lower-cased form of the attribute type

--- a/test/CloudNative.CloudEvents.UnitTests/TestHelpers.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/TestHelpers.cs
@@ -90,6 +90,22 @@ namespace CloudNative.CloudEvents.UnitTests
         }
 
         /// <summary>
+        /// Creates a batch of two CloudEvents, one of which has (plain text) content.
+        /// </summary>
+        internal static List<CloudEvent> CreateSampleBatch()
+        {
+            var event1 = new CloudEvent().PopulateRequiredAttributes();
+            event1.Id = "event1";
+            event1.Data = "simple text";
+            event1.DataContentType = "text/plain";
+
+            var event2 = new CloudEvent().PopulateRequiredAttributes();
+            event2.Id = "event2";
+
+            return new List<CloudEvent> { event1, event2 };
+        }
+
+        /// <summary>
         /// Asserts that two timestamp values are equal, expressing the expected value as a
         /// string for compact testing.
         /// </summary>


### PR DESCRIPTION
Fixes #44

Note that the other protocol bindings we have at the moment don't include batch mode. The first change prepares them to though, by rejecting application/cloudevents-batch as a content type to parse as if it represented a single CloudEvent.