### PR TITLE
fix: Don't use ValueTask where Task is fine

### DIFF
--- a/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtensions.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtensions.cs
@@ -28,7 +28,7 @@ namespace CloudNative.CloudEvents
         /// <param name="extensions">The extension attributes to use when populating the CloudEvent. May be null.</param>
         /// <returns>The decoded CloudEvent.</returns>
         /// <exception cref="ArgumentException">The request does not contain a CloudEvent.</exception>
-        public static ValueTask<CloudEvent> ToCloudEventAsync(
+        public static Task<CloudEvent> ToCloudEventAsync(
             this HttpRequest httpRequest,
             CloudEventFormatter formatter,
             params CloudEventAttribute[] extensionAttributes) =>
@@ -42,7 +42,7 @@ namespace CloudNative.CloudEvents
         /// <param name="extensions">The extension attributes to use when populating the CloudEvent. May be null.</param>
         /// <returns>The decoded CloudEvent.</returns>
         /// <exception cref="ArgumentException">The request does not contain a CloudEvent.</exception>
-        public static async ValueTask<CloudEvent> ToCloudEventAsync(
+        public static async Task<CloudEvent> ToCloudEventAsync(
             this HttpRequest httpRequest,
             CloudEventFormatter formatter,
             IEnumerable<CloudEventAttribute> extensionAttributes)
@@ -97,7 +97,7 @@ namespace CloudNative.CloudEvents
         /// <param name="extensions">The extension attributes to use when populating the CloudEvent. May be null.</param>
         /// <returns>The decoded CloudEvent.</returns>
         /// <exception cref="ArgumentException">The request does not contain a CloudEvent.</exception>
-        public static ValueTask<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
+        public static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
             this HttpRequest httpRequest,
             CloudEventFormatter formatter,
             params CloudEventAttribute[] extensionAttributes) =>
@@ -111,7 +111,7 @@ namespace CloudNative.CloudEvents
         /// <param name="extensions">The extension attributes to use when populating the CloudEvent. May be null.</param>
         /// <returns>The decoded CloudEvent.</returns>
         /// <exception cref="ArgumentException">The request does not contain a CloudEvent.</exception>
-        public static async ValueTask<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
+        public static async Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
             this HttpRequest httpRequest,
             CloudEventFormatter formatter,
             IEnumerable<CloudEventAttribute> extensionAttributes)

--- a/test/CloudNative.CloudEvents.UnitTests/AspNetCore/HttpRequestExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/AspNetCore/HttpRequestExtensionsTest.cs
@@ -37,8 +37,8 @@ namespace CloudNative.CloudEvents.AspNetCore.UnitTests
             var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
             var formatter = new JsonEventFormatter();
             var contentBytes = formatter.EncodeStructuredModeMessage(cloudEvent, out var contentType);
-            await Assert.ThrowsAsync<ArgumentException>(() => CreateRequest(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionArray).AsTask());
-            await Assert.ThrowsAsync<ArgumentException>(() => CreateRequest(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionSequence).AsTask());
+            await Assert.ThrowsAsync<ArgumentException>(() => CreateRequest(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionArray));
+            await Assert.ThrowsAsync<ArgumentException>(() => CreateRequest(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionSequence));
         }
 
         private static HttpRequest CreateRequest(byte[] content, ContentType contentType) =>


### PR DESCRIPTION
We should only use ValueTask when we're pretty convinced it will
make a difference, which probably doesn't include the ASP.NET Core
protocol bindings.

Fixes #124

Signed-off-by: Jon Skeet <jonskeet@google.com>