### PR TITLE
Release of all CloudNative.CloudEvents packages version 2.0.0-beta.2

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
       - During beta, we use the same version number for all
       - packages. See PROCESSES.md for details.
       -->
-    <Version>2.0.0-beta.1</Version>
+    <Version>2.0.0-beta.2</Version>
     
     <!-- Make the repository root available for other properties -->
     <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))</RepoRoot>


### PR DESCRIPTION
This is the first release since the significant overhaul from 1.x.

See https://github.com/cloudevents/sdk-csharp/blob/master/docs/changes-since-1x.md for more details.

Signed-off-by: Jon Skeet <jonskeet@google.com>