### PR TITLE
Finish XML documentation

### DIFF
--- a/src/CloudNative.CloudEvents.Amqp/AmqpClientExtensions.cs
+++ b/src/CloudNative.CloudEvents.Amqp/AmqpClientExtensions.cs
@@ -22,8 +22,16 @@ namespace CloudNative.CloudEvents.Amqp
 
         internal const string SpecVersionAmqpHeader = AmqpHeaderPrefix + "specversion";
 
+        /// <summary>
+        /// Indicates whether this <see cref="Message"/> holds a single CloudEvent.
+        /// </summary>
+        /// <remarks>
+        /// This method returns false for batch requests, as they need to be parsed differently.
+        /// </remarks>
+        /// <param name="message">The message to check for the presence of a CloudEvent. Must not be null.</param>
+        /// <returns>true, if the request is a CloudEvent</returns>
         public static bool IsCloudEvent(this Message message) =>
-            HasCloudEventsContentType(message, out _) ||
+            HasCloudEventsContentType(Validation.CheckNotNull(message, nameof(message)), out _) ||
             message.ApplicationProperties.Map.ContainsKey(SpecVersionAmqpHeader);
 
         /// <summary>
@@ -42,7 +50,7 @@ namespace CloudNative.CloudEvents.Amqp
         /// <summary>
         /// Converts this AMQP message into a CloudEvent object.
         /// </summary>
-        /// <param name="httpResponseMessage">The AMQP message to convert. Must not be null.</param>
+        /// <param name="message">The AMQP message to convert. Must not be null.</param>
         /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
         /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
         /// <returns>A reference to a validated CloudEvent instance.</returns>

--- a/src/CloudNative.CloudEvents.AspNetCore/CloudEventJsonInputFormatter.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/CloudEventJsonInputFormatter.cs
@@ -15,13 +15,20 @@ namespace CloudNative.CloudEvents.AspNetCore
     // FIXME: This shouldn't really be tied to JSON. We need to work out how we actually want this to be used.
     // See 
 
+    /// <summary>
+    /// A <see cref="TextInputFormatter"/> that parses HTTP requests into CloudEvents.
+    /// </summary>
     public class CloudEventJsonInputFormatter : TextInputFormatter
     {
         private readonly CloudEventFormatter _formatter;
 
+        /// <summary>
+        /// Constructs a new instance that uses the given formatter for deserialization.
+        /// </summary>
+        /// <param name="formatter"></param>
         public CloudEventJsonInputFormatter(CloudEventFormatter formatter)
         {
-            _formatter = formatter;
+            _formatter = Validation.CheckNotNull(formatter, nameof(formatter));
             SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/json"));
             SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/cloudevents+json"));
 
@@ -29,6 +36,7 @@ namespace CloudNative.CloudEvents.AspNetCore
             SupportedEncodings.Add(Encoding.Unicode);
         }
 
+        /// <inheritdoc />
         public override async Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context, Encoding encoding)
         {
             Validation.CheckNotNull(context, nameof(context));
@@ -47,14 +55,8 @@ namespace CloudNative.CloudEvents.AspNetCore
             }
         }
 
+        /// <inheritdoc />
         protected override bool CanReadType(Type type)
-        {
-            if (type == typeof(CloudEvent))
-            {
-                return base.CanReadType(type);
-            }
-
-            return false;
-        }
+             => type == typeof(CloudEvent) && base.CanReadType(type);
     }
 }

--- a/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtensions.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtensions.cs
@@ -45,7 +45,7 @@ namespace CloudNative.CloudEvents.AspNetCore
         /// </summary>
         /// <param name="httpRequest">The HTTP request to decode. Must not be null.</param>
         /// <param name="formatter">The event formatter to use to process the request body. Must not be null.</param>
-        /// <param name="extensions">The extension attributes to use when populating the CloudEvent. May be null.</param>
+        /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
         /// <returns>The decoded CloudEvent.</returns>
         /// <exception cref="ArgumentException">The request does not contain a CloudEvent.</exception>
         public static Task<CloudEvent> ToCloudEventAsync(
@@ -59,7 +59,7 @@ namespace CloudNative.CloudEvents.AspNetCore
         /// </summary>
         /// <param name="httpRequest">The HTTP request to decode. Must not be null.</param>
         /// <param name="formatter">The event formatter to use to process the request body. Must not be null.</param>
-        /// <param name="extensions">The extension attributes to use when populating the CloudEvent. May be null.</param>
+        /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
         /// <returns>The decoded CloudEvent.</returns>
         /// <exception cref="ArgumentException">The request does not contain a CloudEvent.</exception>
         public static async Task<CloudEvent> ToCloudEventAsync(
@@ -114,7 +114,7 @@ namespace CloudNative.CloudEvents.AspNetCore
         /// </summary>
         /// <param name="httpRequest">The HTTP request to decode. Must not be null.</param>
         /// <param name="formatter">The event formatter to use to process the request body. Must not be null.</param>
-        /// <param name="extensions">The extension attributes to use when populating the CloudEvent. May be null.</param>
+        /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
         /// <returns>The decoded CloudEvent.</returns>
         /// <exception cref="ArgumentException">The request does not contain a CloudEvent.</exception>
         public static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
@@ -128,7 +128,7 @@ namespace CloudNative.CloudEvents.AspNetCore
         /// </summary>
         /// <param name="httpRequest">The HTTP request to decode. Must not be null.</param>
         /// <param name="formatter">The event formatter to use to process the request body. Must not be null.</param>
-        /// <param name="extensions">The extension attributes to use when populating the CloudEvent. May be null.</param>
+        /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
         /// <returns>The decoded CloudEvent.</returns>
         /// <exception cref="ArgumentException">The request does not contain a CloudEvent.</exception>
         public static async Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(

--- a/src/CloudNative.CloudEvents.Kafka/KafkaClientExtensions.cs
+++ b/src/CloudNative.CloudEvents.Kafka/KafkaClientExtensions.cs
@@ -146,7 +146,7 @@ namespace CloudNative.CloudEvents.Kafka
 
             // TODO: Is this appropriate? Why can't we transport a CloudEvent without data in Kafka?
             Validation.CheckArgument(cloudEvent.Data is object, nameof(cloudEvent), "Only CloudEvents with data can be converted to Kafka messages");
-            var headers = MapHeaders(cloudEvent, formatter);
+            var headers = MapHeaders(cloudEvent);
             string key = (string) cloudEvent[Partitioning.PartitionKeyAttribute];
             byte[] value;
             string contentTypeHeaderValue;
@@ -177,7 +177,7 @@ namespace CloudNative.CloudEvents.Kafka
             };
         }
 
-        private static Headers MapHeaders(CloudEvent cloudEvent, CloudEventFormatter formatter)
+        private static Headers MapHeaders(CloudEvent cloudEvent)
         {
             var headers = new Headers
             {

--- a/src/CloudNative.CloudEvents.Kafka/KafkaClientExtensions.cs
+++ b/src/CloudNative.CloudEvents.Kafka/KafkaClientExtensions.cs
@@ -25,6 +25,14 @@ namespace CloudNative.CloudEvents.Kafka
 
         // TODO: Avoid all the byte[] -> string conversions? If we didn't care about case-sensitivity, we could prepare byte arrays to perform comparisons with.
 
+        /// <summary>
+        /// Indicates whether this message holds a single CloudEvent.
+        /// </summary>
+        /// <remarks>
+        /// This method returns false for batch requests, as they need to be parsed differently.
+        /// </remarks>
+        /// <param name="message">The message to check for the presence of a CloudEvent. Must not be null.</param>
+        /// <returns>true, if the request is a CloudEvent</returns>
         public static bool IsCloudEvent(this Message<string, byte[]> message) =>
             GetHeaderValue(message, SpecVersionKafkaHeader) is object ||
             MimeUtilities.IsCloudEventsContentType(ExtractContentType(message));
@@ -126,7 +134,7 @@ namespace CloudNative.CloudEvents.Kafka
                 ?.GetValueBytes();
 
         /// <summary>
-        /// Converts a CloudEvent to <see cref="Message"/>.
+        /// Converts a CloudEvent to a Kafka message.
         /// </summary>
         /// <param name="cloudEvent">The CloudEvent to convert. Must not be null, and must be a valid CloudEvent.</param>
         /// <param name="contentMode">Content mode. Structured or binary.</param>

--- a/src/CloudNative.CloudEvents.NewtonsoftJson/JsonEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.NewtonsoftJson/JsonEventFormatter.cs
@@ -304,7 +304,6 @@ namespace CloudNative.CloudEvents.NewtonsoftJson
         /// Decodes the "data_base64" property provided within a structured-mode message,
         /// populating the <see cref="CloudEvent.Data"/> property accordingly.
         /// </summary>
-        /// <param name="cloudEvent"></param>
         /// <remarks>
         /// <para>
         /// This implementation converts JSON string tokens to byte arrays, and fails for any other token type.
@@ -437,8 +436,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson
         /// </remarks>
         /// <param name="cloudEvent">The CloudEvent being encoded, which will have a non-null value for
         /// its <see cref="CloudEvent.Data"/> property.
-        /// <paramref name="writer"/>The writer to serialize the data to. Will not be null.</param>
-        /// <see cref="CloudEvent.Data"/>.</param>
+        /// <param name="writer"/>The writer to serialize the data to. Will not be null.</param>
         protected virtual void EncodeStructuredModeData(CloudEvent cloudEvent, JsonWriter writer)
         {
             ContentType dataContentType = new ContentType(cloudEvent.DataContentType ?? JsonMediaType);

--- a/src/CloudNative.CloudEvents.SystemTextJson/JsonEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.SystemTextJson/JsonEventFormatter.cs
@@ -121,6 +121,7 @@ namespace CloudNative.CloudEvents.SystemTextJson
         public override CloudEvent DecodeStructuredModeMessage(Stream body, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes) =>
             DecodeStructuredModeMessageImpl(body, contentType, extensionAttributes, false).GetAwaiter().GetResult();
 
+        /// <inheritdoc />
         public override CloudEvent DecodeStructuredModeMessage(byte[] body, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes) =>
             DecodeStructuredModeMessageImpl(new MemoryStream(body), contentType, extensionAttributes, false).GetAwaiter().GetResult();
 
@@ -317,7 +318,6 @@ namespace CloudNative.CloudEvents.SystemTextJson
         /// Decodes the "data_base64" property provided within a structured-mode message,
         /// populating the <see cref="CloudEvent.Data"/> property accordingly.
         /// </summary>
-        /// <param name="cloudEvent"></param>
         /// <remarks>
         /// <para>
         /// This implementation converts JSON string tokens to byte arrays, and fails for any other token type.
@@ -438,7 +438,7 @@ namespace CloudNative.CloudEvents.SystemTextJson
         }
 
         /// <summary>
-        /// Encodes structured mode data within a CloudEvent, writing it to the specified <see cref="JsonWriter"/>.
+        /// Encodes structured mode data within a CloudEvent, writing it to the specified <see cref="Utf8JsonWriter"/>.
         /// </summary>
         /// <remarks>
         /// <para>
@@ -449,8 +449,7 @@ namespace CloudNative.CloudEvents.SystemTextJson
         /// </remarks>
         /// <param name="cloudEvent">The CloudEvent being encoded, which will have a non-null value for
         /// its <see cref="CloudEvent.Data"/> property.
-        /// <paramref name="writer"/>The writer to serialize the data to. Will not be null.</param>
-        /// <see cref="CloudEvent.Data"/>.</param>
+        /// <param name="writer"/>The writer to serialize the data to. Will not be null.</param>
         protected virtual void EncodeStructuredModeData(CloudEvent cloudEvent, Utf8JsonWriter writer)
         {
             ContentType dataContentType = new ContentType(cloudEvent.DataContentType ?? JsonMediaType);

--- a/src/CloudNative.CloudEvents/CloudEventAttributeType.cs
+++ b/src/CloudNative.CloudEvents/CloudEventAttributeType.cs
@@ -141,9 +141,11 @@ namespace CloudNative.CloudEvents
 
             protected override string FormatImpl(bool value) => value ? "true" : "false";
             protected override bool ParseImpl(string value) =>
+#pragma warning disable IDE0075 // Simplify conditional expression (the suggestion really isn't simpler)
                 value == "true" ? true
                 : value == "false" ? false
                 : throw new ArgumentException("Invalid Boolean attribute value");
+#pragma warning restore IDE0075 // Simplify conditional expression
         }
 
         private class StringType : GenericCloudEventsAttributeType<string>

--- a/src/CloudNative.CloudEvents/CloudNative.CloudEvents.csproj
+++ b/src/CloudNative.CloudEvents/CloudNative.CloudEvents.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>CNCF CloudEvents SDK</Description>
     <LangVersion>8.0</LangVersion>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,6 +14,7 @@
     <SignAssembly>True</SignAssembly>
     <Deterministic>True</Deterministic>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     
     <!-- Package properties -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>


### PR DESCRIPTION
(Also addresses a couple of messages in VS.)

The use of `inheritdoc` in the XML documentation may or may not be appropriate - I need to check how well supported that is in VS. I believe it's *not* well supported in docfx at the moment, so we may need to duplicate some comments in the future if we want to publish reference documentation.