### PR TITLE
Remove CloudEventJsonInputFormatter from the ASP.NET Core package

### DIFF
--- a/samples/CloudNative.CloudEvents.AspNetCoreSample/CloudEventJsonInputFormatter.cs
+++ b/samples/CloudNative.CloudEvents.AspNetCoreSample/CloudEventJsonInputFormatter.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
+using CloudNative.CloudEvents.AspNetCore;
 using CloudNative.CloudEvents.Core;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Net.Http.Headers;
@@ -9,7 +10,7 @@ using System;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace CloudNative.CloudEvents.AspNetCore
+namespace CloudNative.CloudEvents.AspNetCoreSample
 {
     // FIXME: This doesn't get called for binary CloudEvents without content, or with a different data content type.
     // FIXME: This shouldn't really be tied to JSON. We need to work out how we actually want this to be used.

--- a/samples/CloudNative.CloudEvents.AspNetCoreSample/Startup.cs
+++ b/samples/CloudNative.CloudEvents.AspNetCoreSample/Startup.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
-using CloudNative.CloudEvents.AspNetCore;
 using CloudNative.CloudEvents.NewtonsoftJson;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;


### PR DESCRIPTION
This commit moves it to the sample directory for now. There are
elements we'll want to look at more closely before including it
directly in the package, but anyone can easily look at the code and
include it themselves for now, if it suits their needs.

Means that #75 doesn't block the v2 release.

Signed-off-by: Jon Skeet <jonskeet@google.com>