### PR TITLE
Improve the ASP.NET Core sample

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,17 +17,22 @@ jobs:
     - name: Check out our repo
       uses: actions/checkout@v2
 
-    # We need just the .NET Core 2.1 runtime for testing    
+    # We need the .NET Core 2.1 and .NET Core 3.1 runtimes for testing
     - name: Setup .NET Core 2.1
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 2.1.x
 
-    # Build with .NET Core 3.1 SDK
     - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x
+
+    # Build with .NET Core 5.0 SDK
+    - name: Setup .NET Core 5.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
 
     - name: Build
       run: |

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -15,17 +15,22 @@ jobs:
     - name: Check out our repo
       uses: actions/checkout@v2
 
-    # We need just the .NET Core 2.1 runtime for testing    
+    # We need the .NET Core 2.1 and .NET Core 3.1 runtimes for testing
     - name: Setup .NET Core 2.1
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 2.1.x
 
-    # Build with .NET Core 3.1 SDK
     - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x
+
+    # Build with .NET Core 5.0 SDK
+    - name: Setup .NET Core 5.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
 
     - name: Build
       run: |

--- a/samples/CloudNative.CloudEvents.AspNetCoreSample/CloudNative.CloudEvents.AspNetCoreSample.csproj
+++ b/samples/CloudNative.CloudEvents.AspNetCoreSample/CloudNative.CloudEvents.AspNetCoreSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/CloudNative.CloudEvents.AspNetCoreSample/Properties/launchSettings.json
+++ b/samples/CloudNative.CloudEvents.AspNetCoreSample/Properties/launchSettings.json
@@ -1,16 +1,11 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:64908",
-      "sslPort": 0
-    }
-  },
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
+    "WebApplication": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "api/events/generate",
+      "applicationUrl": "https://localhost:5001",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
- Test with both ASP.NET Core 3.1 and 5.0
- Add an API method to generate an event
- Change the launch settings to launch directly instead of with IIS Express

If #153 is merged before this, we'll need to modify it very slightly
as the encoding method will return `ReadOnlyMemory<byte>` instead of
`byte[]`, but that's easy enough to do.

Signed-off-by: Jon Skeet <jonskeet@google.com>