### PR TITLE
All packages pre-release version 2.0.0-rc.1

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
       - During beta, we use the same version number for all
       - packages. See PROCESSES.md for details.
       -->
-    <Version>2.0.0-beta.3</Version>
+    <Version>2.0.0-rc.1</Version>
     
     <!-- Make the repository root available for other properties -->
     <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))</RepoRoot>


### PR DESCRIPTION
This is the first release candidate for version 2.0.0.

Most significant changes since 2.0.0-beta.3:

- Web hook code removed for the moment
  - See https://github.com/cloudevents/spec/issues/781 for background
- CloudEventJsonInputFormatter removed from ASP.NET Core package
  - More work is required before we want to commit to this; code is in the sample for now
- Distributed tracing extension attributes removed for the moment
  - See https://github.com/cloudevents/spec/pull/751 for background
- Use `ReadOnlyMemory<byte>` instead of `byte[]` in `CloudEventFormatter`

The last of these is the biggest change, and a breaking one.
`BinaryDataUtilities` has been modified to provide helper methods.

Signed-off-by: Jon Skeet <jonskeet@google.com>