### PR TITLE
Provide an informative error message for non-CE HTTP requests

### DIFF
--- a/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtensions.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtensions.cs
@@ -78,6 +78,10 @@ namespace CloudNative.CloudEvents.AspNetCore
             {
                 var headers = httpRequest.Headers;
                 headers.TryGetValue(HttpUtilities.SpecVersionHttpHeader, out var versionId);
+                if (versionId.Count == 0)
+                {
+                    throw new ArgumentException($"Request does not represent a CloudEvent. It has neither a {HttpUtilities.SpecVersionHttpHeader} header, nor a suitable content type.", nameof(httpRequest));
+                }
                 var version = CloudEventsSpecVersion.FromVersionId(versionId.FirstOrDefault())
                     ?? throw new ArgumentException($"Unknown CloudEvents spec version '{versionId}'", nameof(httpRequest));
 

--- a/src/CloudNative.CloudEvents/Http/HttpClientExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpClientExtensions.cs
@@ -146,6 +146,10 @@ namespace CloudNative.CloudEvents.Http
                 string versionId = headers.Contains(HttpUtilities.SpecVersionHttpHeader)
                     ? headers.GetValues(HttpUtilities.SpecVersionHttpHeader).First()
                     : null;
+                if (versionId is null)
+                {
+                    throw new ArgumentException($"Request does not represent a CloudEvent. It has neither a {HttpUtilities.SpecVersionHttpHeader} header, nor a suitable content type.", nameof(paramName));
+                }
                 var version = CloudEventsSpecVersion.FromVersionId(versionId)
                     ?? throw new ArgumentException($"Unknown CloudEvents spec version '{versionId}'", paramName);
 

--- a/src/CloudNative.CloudEvents/Http/HttpListenerExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpListenerExtensions.cs
@@ -166,6 +166,10 @@ namespace CloudNative.CloudEvents.Http
             else
             {
                 string versionId = httpListenerRequest.Headers[HttpUtilities.SpecVersionHttpHeader];
+                if (versionId is null)
+                {
+                    throw new ArgumentException($"Request does not represent a CloudEvent. It has neither a {HttpUtilities.SpecVersionHttpHeader} header, nor a suitable content type.", nameof(httpListenerRequest));
+                }
                 var version = CloudEventsSpecVersion.FromVersionId(versionId)
                     ?? throw new ArgumentException($"Unknown CloudEvents spec version '{versionId}'", nameof(httpListenerRequest));
 


### PR DESCRIPTION
Fixes #165

While this could potentially be done without the duplication (e.g.
in HttpUtilities) it's not clear that it's worth doing that, and it
can be done later if necessary.

cc @tomkerkhove