### PR TITLE
Add methods to copy CloudEvents to HttpResponse

### DIFF
--- a/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtensions.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtensions.cs
@@ -118,9 +118,9 @@ namespace CloudNative.CloudEvents.AspNetCore
         /// </summary>
         /// <param name="httpRequest">The HTTP request to decode. Must not be null.</param>
         /// <param name="formatter">The event formatter to use to process the request body. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
-        /// <returns>The decoded CloudEvent.</returns>
-        /// <exception cref="ArgumentException">The request does not contain a CloudEvent.</exception>
+        /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvents. May be null.</param>
+        /// <returns>The decoded batch of CloudEvents.</returns>
+        /// <exception cref="ArgumentException">The request does not contain a CloudEvent batch.</exception>
         public static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
             this HttpRequest httpRequest,
             CloudEventFormatter formatter,
@@ -132,9 +132,9 @@ namespace CloudNative.CloudEvents.AspNetCore
         /// </summary>
         /// <param name="httpRequest">The HTTP request to decode. Must not be null.</param>
         /// <param name="formatter">The event formatter to use to process the request body. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
-        /// <returns>The decoded CloudEvent.</returns>
-        /// <exception cref="ArgumentException">The request does not contain a CloudEvent.</exception>
+        /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvents. May be null.</param>
+        /// <returns>The decoded batch of CloudEvents.</returns>
+        /// <exception cref="ArgumentException">The request does not contain a CloudEvent batch.</exception>
         public static async Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
             this HttpRequest httpRequest,
             CloudEventFormatter formatter,

--- a/src/CloudNative.CloudEvents.AspNetCore/HttpResponseExtensions.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/HttpResponseExtensions.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Cloud Native Foundation.
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using CloudNative.CloudEvents.Core;
+using CloudNative.CloudEvents.Http;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Net.Mime;
+using System.Threading.Tasks;
+
+namespace CloudNative.CloudEvents.AspNetCore
+{
+    /// <summary>
+    /// Extension methods to convert between HTTP responses and CloudEvents.
+    /// </summary>
+    public static class HttpResponseExtensions
+    {
+        /// <summary>
+        /// Copies a <see cref="CloudEvent"/> into an <see cref="HttpResponse" />.
+        /// </summary>
+        /// <param name="cloudEvent">The CloudEvent to copy. Must not be null, and must be a valid CloudEvent.</param>
+        /// <param name="destination">The response to copy the CloudEvent to. Must not be null.</param>
+        /// <param name="contentMode">Content mode (structured or binary)</param>
+        /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        public static async Task CopyToHttpResponseAsync(this CloudEvent cloudEvent, HttpResponse destination,
+            ContentMode contentMode, CloudEventFormatter formatter)
+        {
+            Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
+            Validation.CheckNotNull(destination, nameof(destination));
+            Validation.CheckNotNull(formatter, nameof(formatter));
+
+            ReadOnlyMemory<byte> content;
+            ContentType contentType;
+            switch (contentMode)
+            {
+                case ContentMode.Structured:
+                    content = formatter.EncodeStructuredModeMessage(cloudEvent, out contentType);
+                    break;
+                case ContentMode.Binary:
+                    content = formatter.EncodeBinaryModeEventData(cloudEvent);
+                    contentType = MimeUtilities.CreateContentTypeOrNull(cloudEvent.DataContentType);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(contentMode), $"Unsupported content mode: {contentMode}");
+            }
+            if (contentType is object)
+            {
+                destination.ContentType = contentType.ToString();
+            }
+            else if (content.Length != 0)
+            {
+                throw new ArgumentException("The 'datacontenttype' attribute value must be specified", nameof(cloudEvent));
+            }
+
+            // Map headers in either mode.
+            // Including the headers in structured mode is optional in the spec (as they're already within the body) but
+            // can be useful.            
+            destination.Headers.Add(HttpUtilities.SpecVersionHttpHeader, HttpUtilities.EncodeHeaderValue(cloudEvent.SpecVersion.VersionId));
+            foreach (var attributeAndValue in cloudEvent.GetPopulatedAttributes())
+            {
+                var attribute = attributeAndValue.Key;
+                var value = attributeAndValue.Value;
+                // The content type is already handled based on the content mode.
+                if (attribute != cloudEvent.SpecVersion.DataContentTypeAttribute)
+                {
+                    string headerValue = HttpUtilities.EncodeHeaderValue(attribute.Format(value));
+                    destination.Headers.Add(HttpUtilities.HttpHeaderPrefix + attribute.Name, headerValue);
+                }
+            }
+
+            destination.ContentLength = content.Length;
+            await BinaryDataUtilities.CopyToStreamAsync(content, destination.Body).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Copies a <see cref="CloudEvent"/> batch into an <see cref="HttpResponse" />.
+        /// </summary>
+        /// <param name="cloudEvents">The CloudEvent batch to copy. Must not be null, and must be a valid CloudEvent.</param>
+        /// <param name="destination">The response to copy the CloudEvent to. Must not be null.</param>
+        /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        public static async Task CopyToHttpResponseAsync(this IReadOnlyList<CloudEvent> cloudEvents,
+            HttpResponse destination, CloudEventFormatter formatter)
+        {
+            Validation.CheckCloudEventBatchArgument(cloudEvents, nameof(cloudEvents));
+            Validation.CheckNotNull(destination, nameof(destination));
+            Validation.CheckNotNull(formatter, nameof(formatter));
+
+            // TODO: Validate that all events in the batch have the same version?
+            // See https://github.com/cloudevents/spec/issues/807
+
+            ReadOnlyMemory<byte> content = formatter.EncodeBatchModeMessage(cloudEvents, out var contentType);
+            destination.ContentType = contentType.ToString();
+            destination.ContentLength = content.Length;
+            await BinaryDataUtilities.CopyToStreamAsync(content, destination.Body).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/CloudNative.CloudEvents/Http/HttpClientExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpClientExtensions.cs
@@ -177,12 +177,12 @@ namespace CloudNative.CloudEvents.Http
         }
 
         /// <summary>
-        /// Converts this HTTP response message into a CloudEvent object
+        /// Converts this HTTP response message into a CloudEvent batch.
         /// </summary>
         /// <param name="httpResponseMessage">The HTTP response message to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
-        /// <returns>A reference to a validated CloudEvent instance.</returns>
+        /// <param name="formatter">The event formatter to use to parse the CloudEvents. Must not be null.</param>
+        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvents. May be null.</param>
+        /// <returns>The decoded batch of CloudEvents.</returns>
         public static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
             this HttpResponseMessage httpResponseMessage,
             CloudEventFormatter formatter,
@@ -190,12 +190,12 @@ namespace CloudNative.CloudEvents.Http
             ToCloudEventBatchAsync(httpResponseMessage, formatter, (IEnumerable<CloudEventAttribute>) extensionAttributes);
 
         /// <summary>
-        /// Converts this HTTP response message into a CloudEvent object
+        /// Converts this HTTP response message into a CloudEvent batch.
         /// </summary>
         /// <param name="httpResponseMessage">The HTTP response message to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
-        /// <returns>A reference to a validated CloudEvent instance.</returns>
+        /// <param name="formatter">The event formatter to use to parse the CloudEvents. Must not be null.</param>
+        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvents. May be null.</param>
+        /// <returns>The decoded batch of CloudEvents.</returns>
         public static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
             this HttpResponseMessage httpResponseMessage,
             CloudEventFormatter formatter,
@@ -206,12 +206,12 @@ namespace CloudNative.CloudEvents.Http
         }
 
         /// <summary>
-        /// Converts this HTTP request message into a CloudEvent object.
+        /// Converts this HTTP request message into a CloudEvent batch.
         /// </summary>
         /// <param name="httpRequestMessage">The HTTP request message to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
-        /// <returns>A reference to a validated CloudEvent instance.</returns>
+        /// <param name="formatter">The event formatter to use to parse the CloudEvents. Must not be null.</param>
+        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvents. May be null.</param>
+        /// <returns>The decoded batch of CloudEvents.</returns>
         public static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
             this HttpRequestMessage httpRequestMessage,
             CloudEventFormatter formatter,
@@ -219,12 +219,12 @@ namespace CloudNative.CloudEvents.Http
             ToCloudEventBatchAsync(httpRequestMessage, formatter, (IEnumerable<CloudEventAttribute>) extensionAttributes);
 
         /// <summary>
-        /// Converts this HTTP request message into a CloudEvent object.
+        /// Converts this HTTP request message into a CloudEvent batch.
         /// </summary>
         /// <param name="httpRequestMessage">The HTTP request message to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
-        /// <returns>A reference to a validated CloudEvent instance.</returns>
+        /// <param name="formatter">The event formatter to use to parse the CloudEvents. Must not be null.</param>
+        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvents. May be null.</param>
+        /// <returns>The decoded batch of CloudEvents.</returns>
         public static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
             this HttpRequestMessage httpRequestMessage,
             CloudEventFormatter formatter,

--- a/src/CloudNative.CloudEvents/Http/HttpListenerExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpListenerExtensions.cs
@@ -98,11 +98,26 @@ namespace CloudNative.CloudEvents.Http
         }
 
         /// <summary>
-        /// Indicates whether this HttpListenerRequest holds a CloudEvent
+        /// Indicates whether this HttpListenerRequest holds a single CloudEvent.
         /// </summary>
-        public static bool IsCloudEvent(this HttpListenerRequest httpListenerRequest) =>
-            HasCloudEventsContentType(httpListenerRequest) ||
-            httpListenerRequest.Headers[HttpUtilities.SpecVersionHttpHeader] is object;
+        /// <param name="httpListenerRequest">The request to check for the presence of a single CloudEvent. Must not be null.</param>
+        public static bool IsCloudEvent(this HttpListenerRequest httpListenerRequest)
+        {
+            Validation.CheckNotNull(httpListenerRequest, nameof(httpListenerRequest));
+            return HasCloudEventsContentType(httpListenerRequest) ||
+                httpListenerRequest.Headers[HttpUtilities.SpecVersionHttpHeader] is object;
+        }
+
+        /// <summary>
+        /// Indicates whether this <see cref="HttpListenerRequest"/> holds a batch of CloudEvents.
+        /// </summary>
+        /// <param name="httpListenerRequest">The message to check for the presence of a CloudEvent batch. Must not be null.</param>
+        /// <returns>true, if the request is a CloudEvent batch</returns>
+        public static bool IsCloudEventBatch(this HttpListenerRequest httpListenerRequest)
+        {
+            Validation.CheckNotNull(httpListenerRequest, nameof(httpListenerRequest));
+            return HasCloudEventsBatchContentType(httpListenerRequest);
+        }
 
         /// <summary>
         /// Converts this listener request into a CloudEvent object, with the given extension attributes.

--- a/src/CloudNative.CloudEvents/Http/HttpListenerExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpListenerExtensions.cs
@@ -42,7 +42,6 @@ namespace CloudNative.CloudEvents.Http
                 case ContentMode.Binary:
                     content = formatter.EncodeBinaryModeEventData(cloudEvent);
                     contentType = MimeUtilities.CreateContentTypeOrNull(cloudEvent.DataContentType);
-                        destination.ContentType = cloudEvent.DataContentType?.ToString() ?? "application/json";
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(contentMode), $"Unsupported content mode: {contentMode}");

--- a/test/CloudNative.CloudEvents.UnitTests/AspNetCore/HttpResponseExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/AspNetCore/HttpResponseExtensionsTest.cs
@@ -1,0 +1,112 @@
+﻿// Copyright 2021 Cloud Native Foundation. 
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using CloudNative.CloudEvents.Core;
+using CloudNative.CloudEvents.NewtonsoftJson;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Internal;
+using System;
+using System.IO;
+using System.Net.Mime;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using static CloudNative.CloudEvents.UnitTests.TestHelpers;
+
+namespace CloudNative.CloudEvents.AspNetCore.UnitTests
+{
+    public class HttpResponseExtensionsTest
+    {
+        [Fact]
+        public async Task CopyToHttpResponseAsync_BinaryMode()
+        {
+            var cloudEvent = new CloudEvent
+            {
+                Data = "plain text",
+                DataContentType = "text/plain"
+            }.PopulateRequiredAttributes();
+            var formatter = new JsonEventFormatter();
+            var response = CreateResponse();
+            await cloudEvent.CopyToHttpResponseAsync(response, ContentMode.Binary, formatter);
+            
+            var content = GetContent(response);
+            Assert.Equal("text/plain", response.ContentType);
+            Assert.Equal("plain text", Encoding.UTF8.GetString(content.Span));
+            Assert.Equal("1.0", response.Headers["ce-specversion"]);
+            Assert.Equal(cloudEvent.Type, response.Headers["ce-type"]);
+            Assert.Equal(cloudEvent.Id, response.Headers["ce-id"]);
+            Assert.Equal(CloudEventAttributeType.UriReference.Format(cloudEvent.Source), response.Headers["ce-source"]);
+            // There's no data content type header; the content type itself is used for that.
+            Assert.False(response.Headers.ContainsKey("ce-datacontenttype"));
+        }
+        
+        [Fact]
+        public async Task CopyToHttpResponseAsync_ContentButNoContentType()
+        {
+            var cloudEvent = new CloudEvent
+            {
+                Data = "plain text",
+            }.PopulateRequiredAttributes();
+            var formatter = new JsonEventFormatter();
+            var response = CreateResponse();
+            await Assert.ThrowsAsync<ArgumentException>(() => cloudEvent.CopyToHttpResponseAsync(response, ContentMode.Binary, formatter));
+        }
+
+        [Fact]
+        public async Task CopyToHttpResponseAsync_BadContentMode()
+        {
+            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+            var formatter = new JsonEventFormatter();
+            var response = CreateResponse();
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => cloudEvent.CopyToHttpResponseAsync(response, (ContentMode)100, formatter));
+        }
+
+        [Fact]
+        public async Task CopyToHttpResponseAsync_StructuredMode()
+        {
+            var cloudEvent = new CloudEvent
+            {
+                Data = "plain text",
+                DataContentType = "text/plain"
+            }.PopulateRequiredAttributes();
+            var formatter = new JsonEventFormatter();
+            var response = CreateResponse();
+            await cloudEvent.CopyToHttpResponseAsync(response, ContentMode.Structured, formatter);
+            var content = GetContent(response);
+            Assert.Equal(MimeUtilities.MediaType + "+json; charset=utf-8", response.ContentType);
+
+            var parsed = new JsonEventFormatter().DecodeStructuredModeMessage(content, new ContentType(response.ContentType), extensionAttributes: null);
+            AssertCloudEventsEqual(cloudEvent, parsed);
+            Assert.Equal(cloudEvent.Data, parsed.Data);
+
+            // We populate headers even though we don't strictly need to; let's validate that.
+            Assert.Equal("1.0", response.Headers["ce-specversion"]);
+            Assert.Equal(cloudEvent.Type, response.Headers["ce-type"]);
+            Assert.Equal(cloudEvent.Id, response.Headers["ce-id"]);
+            Assert.Equal(CloudEventAttributeType.UriReference.Format(cloudEvent.Source), response.Headers["ce-source"]);
+            // We don't populate the data content type header
+            Assert.False(response.Headers.ContainsKey("ce-datacontenttype"));
+        }
+
+        [Fact]
+        public async Task CopyToHttpResponseAsync_Batch()
+        {
+            var batch = CreateSampleBatch();
+            var response = CreateResponse();
+            await batch.CopyToHttpResponseAsync(response, new JsonEventFormatter());
+
+            var content = GetContent(response);
+            Assert.Equal(MimeUtilities.BatchMediaType + "+json; charset=utf-8", response.ContentType);
+            var parsedBatch = new JsonEventFormatter().DecodeBatchModeMessage(content, new ContentType(response.ContentType), extensionAttributes: null);
+            AssertBatchesEqual(batch, parsedBatch);
+        }
+        
+        private static HttpResponse CreateResponse() => new DefaultHttpResponse(new DefaultHttpContext()) { Body = new MemoryStream() };
+        private static ReadOnlyMemory<byte> GetContent(HttpResponse response)
+        {
+            response.Body.Position = 0;
+            return BinaryDataUtilities.ToReadOnlyMemory(response.Body);
+        }
+    }
+}

--- a/test/CloudNative.CloudEvents.UnitTests/Http/HttpClientExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Http/HttpClientExtensionsTest.cs
@@ -23,7 +23,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
 {
     public class HttpClientExtensionsTest : HttpTestBase
     {
-        public static TheoryData<string, HttpContent, IDictionary<string, string>> SingleCloudEventMessages = new TheoryData<string, HttpContent, IDictionary<string, string>>
+        public static TheoryData<string, HttpContent, IDictionary<string, string>> SingleCloudEventMessages => new TheoryData<string, HttpContent, IDictionary<string, string>>
         {
             {
                 "Binary",
@@ -43,7 +43,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
             }
         };
 
-        public static TheoryData<string, HttpContent, IDictionary<string, string>> BatchMessages = new TheoryData<string, HttpContent, IDictionary<string, string>>
+        public static TheoryData<string, HttpContent, IDictionary<string, string>> BatchMessages => new TheoryData<string, HttpContent, IDictionary<string, string>>
         {
             {
                 "Batch",
@@ -52,7 +52,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
             }
         };
 
-        public static TheoryData<string, HttpContent, IDictionary<string, string>> NonCloudEventMessages = new TheoryData<string, HttpContent, IDictionary<string, string>>
+        public static TheoryData<string, HttpContent, IDictionary<string, string>> NonCloudEventMessages => new TheoryData<string, HttpContent, IDictionary<string, string>>
         {
             {
                 "Plain text",
@@ -69,7 +69,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
             Assert.NotNull(description);
 
             var request = new HttpRequestMessage { Content = content };
-            CopyHeaders(headers, request.Headers);            
+            CopyHeaders(headers, request.Headers);
             Assert.True(request.IsCloudEvent());
 
             var response = new HttpResponseMessage { Content = content };
@@ -328,7 +328,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
         public async Task HttpStructuredClientSendTest()
         {
             var cloudEvent = new CloudEvent
-            {                
+            {
                 Type = "com.github.pull.create",
                 Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
                 Id = "A234-1234-1234",
@@ -426,7 +426,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
             AssertBatchesEqual(batch, parsedBatch);
         }
 
-        private static void CopyHeaders(IDictionary<string, string> source, HttpHeaders target)
+        internal static void CopyHeaders(IDictionary<string, string> source, HttpHeaders target)
         {
             if (source is null)
             {

--- a/test/CloudNative.CloudEvents.UnitTests/Http/HttpClientExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Http/HttpClientExtensionsTest.cs
@@ -438,7 +438,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
             }
         }
 
-        private static HttpRequestMessage CreateRequestMessage(ReadOnlyMemory<byte> content, ContentType contentType) =>
+        internal static HttpRequestMessage CreateRequestMessage(ReadOnlyMemory<byte> content, ContentType contentType) =>
             new HttpRequestMessage
             {
                 Content = new ByteArrayContent(content.ToArray())
@@ -447,7 +447,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
                 }
             };
 
-        private static HttpResponseMessage CreateResponseMessage(ReadOnlyMemory<byte> content, ContentType contentType) =>
+        internal static HttpResponseMessage CreateResponseMessage(ReadOnlyMemory<byte> content, ContentType contentType) =>
             new HttpResponseMessage
             {
                 Content = new ByteArrayContent(content.ToArray())


### PR DESCRIPTION
(First commits are from #168; they'll be gone by the time we merge this.)