### PR TITLE
Enable nullable reference types in all production code

### DIFF
--- a/src/CloudNative.CloudEvents.Amqp/AmqpExtensions.cs
+++ b/src/CloudNative.CloudEvents.Amqp/AmqpExtensions.cs
@@ -44,8 +44,8 @@ namespace CloudNative.CloudEvents.Amqp
         public static CloudEvent ToCloudEvent(
             this Message message,
             CloudEventFormatter formatter,
-            params CloudEventAttribute[] extensionAttributes) =>
-            ToCloudEvent(message, formatter, (IEnumerable<CloudEventAttribute>) extensionAttributes);
+            params CloudEventAttribute[]? extensionAttributes) =>
+            ToCloudEvent(message, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
 
         /// <summary>
         /// Converts this AMQP message into a CloudEvent object.
@@ -57,7 +57,7 @@ namespace CloudNative.CloudEvents.Amqp
         public static CloudEvent ToCloudEvent(
             this Message message,
             CloudEventFormatter formatter,
-            IEnumerable<CloudEventAttribute> extensionAttributes)
+            IEnumerable<CloudEventAttribute>? extensionAttributes)
         {
             Validation.CheckNotNull(message, nameof(message));
             Validation.CheckNotNull(formatter, nameof(formatter));
@@ -135,7 +135,7 @@ namespace CloudNative.CloudEvents.Amqp
             }
         }
 
-        private static bool HasCloudEventsContentType(Message message, out string contentType)
+        private static bool HasCloudEventsContentType(Message message, out string? contentType)
         {
             contentType = message.Properties.ContentType?.ToString();
             return MimeUtilities.IsCloudEventsContentType(contentType);

--- a/src/CloudNative.CloudEvents.Amqp/CloudNative.CloudEvents.Amqp.csproj
+++ b/src/CloudNative.CloudEvents.Amqp/CloudNative.CloudEvents.Amqp.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>AMQP extensions for CloudNative.CloudEvents</Description>
     <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
     <PackageTags>cncf;cloudnative;cloudevents;events;amqp</PackageTags>
   </PropertyGroup>
 

--- a/src/CloudNative.CloudEvents.Amqp/CloudNative.CloudEvents.Amqp.csproj
+++ b/src/CloudNative.CloudEvents.Amqp/CloudNative.CloudEvents.Amqp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>AMQP extensions for CloudNative.CloudEvents</Description>
     <LangVersion>8.0</LangVersion>
     <PackageTags>cncf;cloudnative;cloudevents;events;amqp</PackageTags>

--- a/src/CloudNative.CloudEvents.AspNetCore/CloudNative.CloudEvents.AspNetCore.csproj
+++ b/src/CloudNative.CloudEvents.AspNetCore/CloudNative.CloudEvents.AspNetCore.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>ASP.Net Core extensions for CloudNative.CloudEvents</Description>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
     <PackageTags>cncf;cloudnative;cloudevents;events;aspnetcore;aspnet</PackageTags>
   </PropertyGroup>
 

--- a/src/CloudNative.CloudEvents.AspNetCore/CloudNative.CloudEvents.AspNetCore.csproj
+++ b/src/CloudNative.CloudEvents.AspNetCore/CloudNative.CloudEvents.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>ASP.Net Core extensions for CloudNative.CloudEvents</Description>
     <PackageTags>cncf;cloudnative;cloudevents;events;aspnetcore;aspnet</PackageTags>
   </PropertyGroup>

--- a/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtensions.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtensions.cs
@@ -51,8 +51,8 @@ namespace CloudNative.CloudEvents.AspNetCore
         public static Task<CloudEvent> ToCloudEventAsync(
             this HttpRequest httpRequest,
             CloudEventFormatter formatter,
-            params CloudEventAttribute[] extensionAttributes) =>
-            ToCloudEventAsync(httpRequest, formatter, (IEnumerable<CloudEventAttribute>) extensionAttributes);
+            params CloudEventAttribute[]? extensionAttributes) =>
+            ToCloudEventAsync(httpRequest, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
 
         /// <summary>
         /// Converts this HTTP request into a CloudEvent object.
@@ -65,7 +65,7 @@ namespace CloudNative.CloudEvents.AspNetCore
         public static async Task<CloudEvent> ToCloudEventAsync(
             this HttpRequest httpRequest,
             CloudEventFormatter formatter,
-            IEnumerable<CloudEventAttribute> extensionAttributes)
+            IEnumerable<CloudEventAttribute>? extensionAttributes)
         {
             Validation.CheckNotNull(httpRequest, nameof(httpRequest));
             Validation.CheckNotNull(formatter, nameof(formatter));
@@ -93,7 +93,7 @@ namespace CloudNative.CloudEvents.AspNetCore
                 var cloudEvent = new CloudEvent(version, extensionAttributes);
                 foreach (var header in headers)
                 {
-                    string attributeName = HttpUtilities.GetAttributeNameFromHeaderName(header.Key);
+                    string? attributeName = HttpUtilities.GetAttributeNameFromHeaderName(header.Key);
                     if (attributeName is null || attributeName == CloudEventsSpecVersion.SpecVersionAttribute.Name)
                     {
                         continue;
@@ -124,8 +124,8 @@ namespace CloudNative.CloudEvents.AspNetCore
         public static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
             this HttpRequest httpRequest,
             CloudEventFormatter formatter,
-            params CloudEventAttribute[] extensionAttributes) =>
-            ToCloudEventBatchAsync(httpRequest, formatter, (IEnumerable<CloudEventAttribute>) extensionAttributes);
+            params CloudEventAttribute[]? extensionAttributes) =>
+            ToCloudEventBatchAsync(httpRequest, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
 
         /// <summary>
         /// Converts this HTTP request into a batch of CloudEvents.
@@ -138,7 +138,7 @@ namespace CloudNative.CloudEvents.AspNetCore
         public static async Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
             this HttpRequest httpRequest,
             CloudEventFormatter formatter,
-            IEnumerable<CloudEventAttribute> extensionAttributes)
+            IEnumerable<CloudEventAttribute>? extensionAttributes)
         {
             Validation.CheckNotNull(httpRequest, nameof(httpRequest));
             Validation.CheckNotNull(formatter, nameof(formatter));

--- a/src/CloudNative.CloudEvents.AspNetCore/HttpResponseExtensions.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/HttpResponseExtensions.cs
@@ -33,7 +33,7 @@ namespace CloudNative.CloudEvents.AspNetCore
             Validation.CheckNotNull(formatter, nameof(formatter));
 
             ReadOnlyMemory<byte> content;
-            ContentType contentType;
+            ContentType? contentType;
             switch (contentMode)
             {
                 case ContentMode.Structured:

--- a/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
@@ -55,30 +55,31 @@ namespace CloudNative.CloudEvents
         }
 
         /// <inheritdoc />
-        public override CloudEvent DecodeStructuredModeMessage(Stream body, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes)
+        public override CloudEvent DecodeStructuredModeMessage(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
         {
             Validation.CheckNotNull(body, nameof(body));
 
             var decoder = new BinaryDecoder(body);
-            var rawEvent = avroReader.Read<GenericRecord>(null, decoder);
+            // The reuse parameter *is* allowed to be null...
+            var rawEvent = avroReader.Read<GenericRecord>(reuse: null!, decoder);
             return DecodeGenericRecord(rawEvent, extensionAttributes);
         }
 
         /// <inheritdoc />
-        public override CloudEvent DecodeStructuredModeMessage(ReadOnlyMemory<byte> body, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes)
+        public override CloudEvent DecodeStructuredModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
         {
             return DecodeStructuredModeMessage(BinaryDataUtilities.AsStream(body), contentType, extensionAttributes);
         }
 
         /// <inheritdoc />
-        public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(ReadOnlyMemory<byte> body, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes) =>
+        public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
             throw new NotSupportedException("The Avro event formatter does not support batch content mode");
 
         /// <inheritdoc />
         public override ReadOnlyMemory<byte> EncodeBatchModeMessage(IEnumerable<CloudEvent> cloudEvent, out ContentType contentType) =>
             throw new NotSupportedException("The Avro event formatter does not support batch content mode");
 
-        private CloudEvent DecodeGenericRecord(GenericRecord record, IEnumerable<CloudEventAttribute> extensionAttributes)
+        private CloudEvent DecodeGenericRecord(GenericRecord record, IEnumerable<CloudEventAttribute>? extensionAttributes)
         {
             if (!record.TryGetValue(AttributeName, out var attrObj))
             {
@@ -91,7 +92,7 @@ namespace CloudNative.CloudEvents
             {
                 throw new ArgumentException("Specification version attribute is missing");
             }
-            CloudEventsSpecVersion version = CloudEventsSpecVersion.FromVersionId(versionIdString);
+            CloudEventsSpecVersion? version = CloudEventsSpecVersion.FromVersionId(versionIdString);
             if (version is null)
             {
                 throw new ArgumentException($"Unsupported CloudEvents spec version '{versionIdString}'");

--- a/src/CloudNative.CloudEvents.Avro/CloudNative.CloudEvents.Avro.csproj
+++ b/src/CloudNative.CloudEvents.Avro/CloudNative.CloudEvents.Avro.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>Avro extensions for CloudNative.CloudEvents</Description>
     <PackageTags>cncf;cloudnative;cloudevents;events;avro</PackageTags>
   </PropertyGroup>

--- a/src/CloudNative.CloudEvents.Avro/CloudNative.CloudEvents.Avro.csproj
+++ b/src/CloudNative.CloudEvents.Avro/CloudNative.CloudEvents.Avro.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>Avro extensions for CloudNative.CloudEvents</Description>
     <PackageTags>cncf;cloudnative;cloudevents;events;avro</PackageTags>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CloudNative.CloudEvents.Kafka/CloudNative.CloudEvents.Kafka.csproj
+++ b/src/CloudNative.CloudEvents.Kafka/CloudNative.CloudEvents.Kafka.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>Kafka extensions for CloudNative.CloudEvents</Description>
     <PackageTags>cncf;cloudnative;cloudevents;events;kafka</PackageTags>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CloudNative.CloudEvents.Kafka/CloudNative.CloudEvents.Kafka.csproj
+++ b/src/CloudNative.CloudEvents.Kafka/CloudNative.CloudEvents.Kafka.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>Kafka extensions for CloudNative.CloudEvents</Description>
     <PackageTags>cncf;cloudnative;cloudevents;events;kafka</PackageTags>
   </PropertyGroup>

--- a/src/CloudNative.CloudEvents.Mqtt/CloudNative.CloudEvents.Mqtt.csproj
+++ b/src/CloudNative.CloudEvents.Mqtt/CloudNative.CloudEvents.Mqtt.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>MQTT extensions for CloudNative.CloudEvents</Description>
     <PackageTags>cncf;cloudnative;cloudevents;events;mqtt</PackageTags>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CloudNative.CloudEvents.Mqtt/CloudNative.CloudEvents.Mqtt.csproj
+++ b/src/CloudNative.CloudEvents.Mqtt/CloudNative.CloudEvents.Mqtt.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>MQTT extensions for CloudNative.CloudEvents</Description>
     <PackageTags>cncf;cloudnative;cloudevents;events;mqtt</PackageTags>
   </PropertyGroup>

--- a/src/CloudNative.CloudEvents.Mqtt/MqttExtensions.cs
+++ b/src/CloudNative.CloudEvents.Mqtt/MqttExtensions.cs
@@ -22,8 +22,8 @@ namespace CloudNative.CloudEvents.Mqtt
         /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
         /// <returns>A reference to a validated CloudEvent instance.</returns>
         public static CloudEvent ToCloudEvent(this MqttApplicationMessage message,
-            CloudEventFormatter formatter, params CloudEventAttribute[] extensionAttributes) =>
-            ToCloudEvent(message, formatter, (IEnumerable<CloudEventAttribute>) extensionAttributes);
+            CloudEventFormatter formatter, params CloudEventAttribute[]? extensionAttributes) =>
+            ToCloudEvent(message, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
 
         /// <summary>
         /// Converts this MQTT message into a CloudEvent object.
@@ -33,7 +33,7 @@ namespace CloudNative.CloudEvents.Mqtt
         /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
         /// <returns>A reference to a validated CloudEvent instance.</returns>
         public static CloudEvent ToCloudEvent(this MqttApplicationMessage message,
-            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute> extensionAttributes)
+            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes)
         {
             Validation.CheckNotNull(formatter, nameof(formatter));
             Validation.CheckNotNull(message, nameof(message));
@@ -50,7 +50,7 @@ namespace CloudNative.CloudEvents.Mqtt
         /// <param name="contentMode">Content mode. Currently only structured mode is supported.</param>
         /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
         /// <param name="topic">The MQTT topic for the message. May be null.</param>
-        public static MqttApplicationMessage ToMqttApplicationMessage(this CloudEvent cloudEvent, ContentMode contentMode, CloudEventFormatter formatter, string topic)
+        public static MqttApplicationMessage ToMqttApplicationMessage(this CloudEvent cloudEvent, ContentMode contentMode, CloudEventFormatter formatter, string? topic)
         {
             Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
             Validation.CheckNotNull(formatter, nameof(formatter));

--- a/src/CloudNative.CloudEvents.NewtonsoftJson/CloudNative.CloudEvents.NewtonsoftJson.csproj
+++ b/src/CloudNative.CloudEvents.NewtonsoftJson/CloudNative.CloudEvents.NewtonsoftJson.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>JSON support for the CNCF CloudEvents SDK, based on Newtonsoft.Json.</Description>
     <LangVersion>8.0</LangVersion>
     <PackageTags>cncf;cloudnative;cloudevents;events;json;newtonsoft</PackageTags>

--- a/src/CloudNative.CloudEvents.NewtonsoftJson/CloudNative.CloudEvents.NewtonsoftJson.csproj
+++ b/src/CloudNative.CloudEvents.NewtonsoftJson/CloudNative.CloudEvents.NewtonsoftJson.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>JSON support for the CNCF CloudEvents SDK, based on Newtonsoft.Json.</Description>
     <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
     <PackageTags>cncf;cloudnative;cloudevents;events;json;newtonsoft</PackageTags>
   </PropertyGroup>
 

--- a/src/CloudNative.CloudEvents.SystemTextJson/CloudNative.CloudEvents.SystemTextJson.csproj
+++ b/src/CloudNative.CloudEvents.SystemTextJson/CloudNative.CloudEvents.SystemTextJson.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>JSON support for the CNCF CloudEvents SDK, based on System.Text.Json.</Description>
     <LangVersion>8.0</LangVersion>
     <PackageTags>cncf;cloudnative;cloudevents;events;json;systemtextjson</PackageTags>

--- a/src/CloudNative.CloudEvents.SystemTextJson/CloudNative.CloudEvents.SystemTextJson.csproj
+++ b/src/CloudNative.CloudEvents.SystemTextJson/CloudNative.CloudEvents.SystemTextJson.csproj
@@ -5,6 +5,7 @@
     <Description>JSON support for the CNCF CloudEvents SDK, based on System.Text.Json.</Description>
     <LangVersion>8.0</LangVersion>
     <PackageTags>cncf;cloudnative;cloudevents;events;json;systemtextjson</PackageTags>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CloudNative.CloudEvents.SystemTextJson/JsonEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.SystemTextJson/JsonEventFormatter.cs
@@ -86,7 +86,7 @@ namespace CloudNative.CloudEvents.SystemTextJson
         /// <summary>
         /// The options to use when serializing objects to JSON.
         /// </summary>
-        protected JsonSerializerOptions SerializerOptions { get; }
+        protected JsonSerializerOptions? SerializerOptions { get; }
 
         /// <summary>
         /// The options to use when parsing JSON documents.
@@ -107,25 +107,25 @@ namespace CloudNative.CloudEvents.SystemTextJson
         /// </summary>
         /// <param name="serializerOptions">The options to use when serializing objects to JSON. May be null.</param>
         /// <param name="documentOptions">The options to use when parsing JSON documents.</param>
-        public JsonEventFormatter(JsonSerializerOptions serializerOptions, JsonDocumentOptions documentOptions)
+        public JsonEventFormatter(JsonSerializerOptions? serializerOptions, JsonDocumentOptions documentOptions)
         {
             SerializerOptions = serializerOptions;
             DocumentOptions = documentOptions;
         }
 
         /// <inheritdoc />
-        public override async Task<CloudEvent> DecodeStructuredModeMessageAsync(Stream body, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes) =>
+        public override async Task<CloudEvent> DecodeStructuredModeMessageAsync(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
             await DecodeStructuredModeMessageImpl(body, contentType, extensionAttributes, true).ConfigureAwait(false);
 
         /// <inheritdoc />
-        public override CloudEvent DecodeStructuredModeMessage(Stream body, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes) =>
+        public override CloudEvent DecodeStructuredModeMessage(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
             DecodeStructuredModeMessageImpl(body, contentType, extensionAttributes, false).GetAwaiter().GetResult();
 
         /// <inheritdoc />
-        public override CloudEvent DecodeStructuredModeMessage(ReadOnlyMemory<byte> body, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes) =>
+        public override CloudEvent DecodeStructuredModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
             DecodeStructuredModeMessageImpl(BinaryDataUtilities.AsStream(body), contentType, extensionAttributes, false).GetAwaiter().GetResult();
 
-        private async Task<CloudEvent> DecodeStructuredModeMessageImpl(Stream data, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes, bool async)
+        private async Task<CloudEvent> DecodeStructuredModeMessageImpl(Stream data, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes, bool async)
         {
             Validation.CheckNotNull(data, nameof(data));
             JsonDocument document = await ReadDocumentAsync(data, contentType, async).ConfigureAwait(false);
@@ -136,18 +136,18 @@ namespace CloudNative.CloudEvents.SystemTextJson
         }
 
         /// <inheritdoc />
-        public override Task<IReadOnlyList<CloudEvent>> DecodeBatchModeMessageAsync(Stream body, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes) =>
+        public override Task<IReadOnlyList<CloudEvent>> DecodeBatchModeMessageAsync(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
             DecodeBatchModeMessageImpl(body, contentType, extensionAttributes, true);
 
         /// <inheritdoc />
-        public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(Stream body, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes) =>
+        public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
             DecodeBatchModeMessageImpl(body, contentType, extensionAttributes, false).GetAwaiter().GetResult();
 
         /// <inheritdoc />
-        public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(ReadOnlyMemory<byte> body, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes) =>
+        public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
             DecodeBatchModeMessageImpl(BinaryDataUtilities.AsStream(body), contentType, extensionAttributes, false).GetAwaiter().GetResult();
 
-        private async Task<IReadOnlyList<CloudEvent>> DecodeBatchModeMessageImpl(Stream data, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes, bool async)
+        private async Task<IReadOnlyList<CloudEvent>> DecodeBatchModeMessageImpl(Stream data, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes, bool async)
         {
             Validation.CheckNotNull(data, nameof(data));
             var document = await ReadDocumentAsync(data, contentType, async).ConfigureAwait(false);
@@ -168,7 +168,7 @@ namespace CloudNative.CloudEvents.SystemTextJson
             }
         }
 
-        private async Task<JsonDocument> ReadDocumentAsync(Stream data, ContentType contentType, bool async)
+        private async Task<JsonDocument> ReadDocumentAsync(Stream data, ContentType? contentType, bool async)
         {
             var encoding = MimeUtilities.GetEncoding(contentType);
             if (encoding is UTF8Encoding)
@@ -187,7 +187,7 @@ namespace CloudNative.CloudEvents.SystemTextJson
             }
         }
 
-        private CloudEvent DecodeJsonElement(JsonElement element, IEnumerable<CloudEventAttribute> extensionAttributes, string paramName)
+        private CloudEvent DecodeJsonElement(JsonElement element, IEnumerable<CloudEventAttribute>? extensionAttributes, string paramName)
         {
             if (element.ValueKind != JsonValueKind.Object)
             {
@@ -234,7 +234,7 @@ namespace CloudNative.CloudEvents.SystemTextJson
                 // TODO: This currently performs more conversions than it really should, in the cause of simplicity.
                 // We basically need a matrix of "attribute type vs token type" but that's rather complicated.
 
-                string attributeValue = value.ValueKind switch
+                string? attributeValue = value.ValueKind switch
                 {
                     JsonValueKind.String => value.GetString(),
                     JsonValueKind.True => CloudEventAttributeType.Boolean.Format(true),
@@ -255,7 +255,7 @@ namespace CloudNative.CloudEvents.SystemTextJson
             }
         }
 
-        private void ValidateTokenTypeForAttribute(CloudEventAttribute attribute, JsonValueKind valueKind)
+        private void ValidateTokenTypeForAttribute(CloudEventAttribute? attribute, JsonValueKind valueKind)
         {
             // We can't validate unknown attributes, don't check for extension attributes,
             // and null values will be ignored anyway.
@@ -470,7 +470,8 @@ namespace CloudNative.CloudEvents.SystemTextJson
             }
             else
             {
-                throw new ArgumentException($"{nameof(JsonEventFormatter)} cannot serialize data of type {cloudEvent.Data.GetType()} with content type '{cloudEvent.DataContentType}'");
+                // We assume CloudEvent.Data is not null due to the way this is called.
+                throw new ArgumentException($"{nameof(JsonEventFormatter)} cannot serialize data of type {cloudEvent.Data!.GetType()} with content type '{cloudEvent.DataContentType}'");
             }
         }
 

--- a/src/CloudNative.CloudEvents/CloudEvent.cs
+++ b/src/CloudNative.CloudEvents/CloudEvent.cs
@@ -44,7 +44,7 @@ namespace CloudNative.CloudEvents
         /// </summary>
         /// <param name="extensionAttributes">Initial extension attributes. May be null, which is equivalent
         /// to an empty sequence.</param>
-        public CloudEvent(IEnumerable<CloudEventAttribute> extensionAttributes) : this(CloudEventsSpecVersion.Default, extensionAttributes)
+        public CloudEvent(IEnumerable<CloudEventAttribute>? extensionAttributes) : this(CloudEventsSpecVersion.Default, extensionAttributes)
         {
         }
 
@@ -55,7 +55,7 @@ namespace CloudNative.CloudEvents
         /// <param name="specVersion">CloudEvents Specification version for this instance. Must not be null.</param>
         /// <param name="extensionAttributes">Initial extension attributes. May be null, which is equivalent
         /// to an empty sequence.</param>
-        public CloudEvent(CloudEventsSpecVersion specVersion, IEnumerable<CloudEventAttribute> extensionAttributes)
+        public CloudEvent(CloudEventsSpecVersion specVersion, IEnumerable<CloudEventAttribute>? extensionAttributes)
         {
             // TODO: Work out how to be more efficient, e.g. not creating a dictionary at all if there are no
             // extension attributes.
@@ -117,7 +117,7 @@ namespace CloudNative.CloudEvents
         /// </remarks>
         /// <param name="attribute">The attribute whose value should be set or fetched.</param>
         /// <returns>The fetched attribute value, or null if the attribute has no value in this event.</returns>
-        public object this[CloudEventAttribute attribute]
+        public object? this[CloudEventAttribute attribute]
         {
             get
             {
@@ -175,7 +175,7 @@ namespace CloudNative.CloudEvents
         /// The indexer cannot be used to access the 'specversion' attribute. Use <see cref="SpecVersion"/>
         /// for that purpose.
         /// </remarks>
-        public object this[string attributeName]
+        public object? this[string attributeName]
         {
             get
             {
@@ -197,7 +197,7 @@ namespace CloudNative.CloudEvents
                 {
                     Validation.CheckArgument(value is null || value is string,
                         nameof(value), "Cannot assign value of type {0} to unknown attribute '{1}'",
-                        value.GetType(), attributeName);
+                        value?.GetType(), attributeName);
                     knownAttribute = CloudEventAttribute.CreateExtension(attributeName, CloudEventAttributeType.String);
                     extensionAttributes[attributeName] = knownAttribute;
                 }
@@ -218,7 +218,7 @@ namespace CloudNative.CloudEvents
         /// 'contenttype' attribute (e.g. application/json).
         /// </summary>
         /// <see href="https://github.com/cloudevents/spec/blob/master/spec.md#data-1"/>
-        public object Data { get; set; }
+        public object? Data { get; set; }
 
         /// <summary>
         /// CloudEvent <see href="https://github.com/cloudevents/spec/blob/master/spec.md#id">'datacontenttype'</see> attribute.
@@ -227,10 +227,10 @@ namespace CloudNative.CloudEvents
         /// format and encoding might differ from that of the chosen event format.
         /// </summary>
         /// <see href="https://github.com/cloudevents/spec/blob/master/spec.md#contenttype"/>
-        public string DataContentType
+        public string? DataContentType
         {
             // TODO: Guard against a version that doesn't have this attribute?
-            get => (string)this[SpecVersion.DataContentTypeAttribute];
+            get => (string?)this[SpecVersion.DataContentTypeAttribute];
             set => this[SpecVersion.DataContentTypeAttribute] = value;
         }
 
@@ -238,9 +238,9 @@ namespace CloudNative.CloudEvents
         /// CloudEvent <see href="https://github.com/cloudevents/spec/blob/master/spec.md#id">'id'</see> attribute,
         /// This is the ID of the event. When combined with <see cref="Source"/>, this enables deduplication.
         /// </summary>
-        public string Id
+        public string? Id
         {
-            get => (string)this[SpecVersion.IdAttribute];
+            get => (string?)this[SpecVersion.IdAttribute];
             set => this[SpecVersion.IdAttribute] = value;
         }
 
@@ -249,9 +249,9 @@ namespace CloudNative.CloudEvents
         /// A link to the schema that the data attribute adheres to.
         /// Incompatible changes to the schema SHOULD be reflected by a different URI.
         /// </summary>
-        public Uri DataSchema
+        public Uri? DataSchema
         {
-            get => (Uri)this[SpecVersion.DataSchemaAttribute];
+            get => (Uri?)this[SpecVersion.DataSchemaAttribute];
             set => this[SpecVersion.DataSchemaAttribute] = value;
         }
 
@@ -261,9 +261,9 @@ namespace CloudNative.CloudEvents
         /// organization publishing the event, the process that produced the event, and some unique identifiers.
         /// When combined with <see cref="Id"/>, this enables deduplication.
         /// </summary>
-        public Uri Source
+        public Uri? Source
         {
-            get => (Uri)this[SpecVersion.SourceAttribute];
+            get => (Uri?)this[SpecVersion.SourceAttribute];
             set => this[SpecVersion.SourceAttribute] = value;
         }
 
@@ -279,9 +279,9 @@ namespace CloudNative.CloudEvents
         /// but the source identifier alone might not be sufficient as a qualifier for any specific event if the source context has
         /// internal sub-structure.
         /// </summary>
-        public string Subject
+        public string? Subject
         {
-            get => (string)this[SpecVersion.SubjectAttribute];
+            get => (string?)this[SpecVersion.SubjectAttribute];
             set => this[SpecVersion.SubjectAttribute] = value;
         }
 
@@ -300,9 +300,9 @@ namespace CloudNative.CloudEvents
         /// Type of occurrence which has happened.
         /// Often this attribute is used for routing, observability, policy enforcement, etc.
         /// </summary>
-        public string Type
+        public string? Type
         {
-            get => (string)this[SpecVersion.TypeAttribute];
+            get => (string?)this[SpecVersion.TypeAttribute];
             set => this[SpecVersion.TypeAttribute] = value;
         }
 
@@ -314,7 +314,7 @@ namespace CloudNative.CloudEvents
         /// <param name="name">The attribute name to look up.</param>
         /// <returns>The attribute with the given name, or null if no this event
         /// does not know of such an attribute.</returns>
-        public CloudEventAttribute GetAttribute(string name) =>
+        public CloudEventAttribute? GetAttribute(string name) =>
             SpecVersion.GetAttributeByName(name) ?? extensionAttributes.GetValueOrDefault(name);
 
         /// <summary>
@@ -332,7 +332,7 @@ namespace CloudNative.CloudEvents
         {
             foreach (var pair in attributeValues)
             {
-                yield return new KeyValuePair<CloudEventAttribute, object>(GetAttribute(pair.Key), pair.Value);
+                yield return new KeyValuePair<CloudEventAttribute, object>(GetAttribute(pair.Key)!, pair.Value);
             }
         }
 

--- a/src/CloudNative.CloudEvents/CloudEventAttribute.cs
+++ b/src/CloudNative.CloudEvents/CloudEventAttribute.cs
@@ -37,17 +37,17 @@ namespace CloudNative.CloudEvents
         /// </summary>
         public bool IsExtension { get; }
 
-        private Action<object> validator;
+        private Action<object>? validator;
 
         // TODO: Have a "mode" of Required/Optional/Extension?
 
-        private CloudEventAttribute(string name, CloudEventAttributeType type, bool required, bool extension, Action<object> validator) =>
+        private CloudEventAttribute(string name, CloudEventAttributeType type, bool required, bool extension, Action<object>? validator) =>
             (Name, Type, IsRequired, IsExtension, this.validator) = (ValidateName(name), Validation.CheckNotNull(type, nameof(type)), required, extension, validator);
 
-        internal static CloudEventAttribute CreateRequired(string name, CloudEventAttributeType type, Action<object> validator) =>
+        internal static CloudEventAttribute CreateRequired(string name, CloudEventAttributeType type, Action<object>? validator) =>
             new CloudEventAttribute(name, type, required: true, extension: false, validator: validator);
 
-        internal static CloudEventAttribute CreateOptional(string name, CloudEventAttributeType type, Action<object> validator) =>
+        internal static CloudEventAttribute CreateOptional(string name, CloudEventAttributeType type, Action<object>? validator) =>
             new CloudEventAttribute(name, type, required: false, extension: false, validator: validator);
 
         /// <summary>
@@ -72,12 +72,12 @@ namespace CloudNative.CloudEvents
         /// </summary>
         /// <param name="name">The extension attribute name. Must not be null, and must not be 'specversion'.</param>
         /// <param name="type">The extension attribute type. Must not be null.</param>
-        /// <param name="validator">Validator to use when parsing or formatting values.
-        /// This is only ever called with a non-null value which can be cast to the attribute type's corresponding
+        /// <param name="validator">Validator to use when parsing or formatting values. May be null.
+        /// This delegate is only ever called with a non-null value which can be cast to the attribute type's corresponding
         /// CLR type. If the validator throws any exception, it is wrapped in an ArgumentException containing the
         /// attribute details.</param>
         /// <returns>The extension attribute represented as a <see cref="CloudEventAttribute"/>.</returns>
-        public static CloudEventAttribute CreateExtension(string name, CloudEventAttributeType type, Action<object> validator) =>
+        public static CloudEventAttribute CreateExtension(string name, CloudEventAttributeType type, Action<object>? validator) =>
             new CloudEventAttribute(name, type, required: false, extension: true, validator: validator);
 
         /// <summary>

--- a/src/CloudNative.CloudEvents/CloudEventAttributeType.cs
+++ b/src/CloudNative.CloudEvents/CloudEventAttributeType.cs
@@ -99,7 +99,7 @@ namespace CloudNative.CloudEvents
             ClrType = clrType;
         }
 
-        private abstract class GenericCloudEventsAttributeType<T> : CloudEventAttributeType
+        private abstract class GenericCloudEventsAttributeType<T> : CloudEventAttributeType where T : notnull
         {
             protected GenericCloudEventsAttributeType(string name, CloudEventAttributeTypeOrdinal ordinal) : base(name, ordinal, typeof(T))
             {

--- a/src/CloudNative.CloudEvents/CloudEventFormatter.cs
+++ b/src/CloudNative.CloudEvents/CloudEventFormatter.cs
@@ -40,13 +40,13 @@ namespace CloudNative.CloudEvents
         /// <summary>
         /// Decodes a CloudEvent from a structured-mode message body, represented as a read-only memory segment.
         /// </summary>
-        /// <param name="body">The message body (content). Must not be null.</param>
+        /// <param name="body">The message body (content).</param>
         /// <param name="contentType">The content type of the message, or null if no content type is known.
         /// Typically this is a content type with a media type of "application/cloudevents"; the additional
         /// information such as the charset parameter may be needed in order to decode the message body.</param>
         /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
         /// <returns>The CloudEvent derived from the structured message body.</returns>
-        public abstract CloudEvent DecodeStructuredModeMessage(ReadOnlyMemory<byte> body, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes);
+        public abstract CloudEvent DecodeStructuredModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes);
 
         /// <summary>
         /// Decodes a CloudEvent from a structured-mode message body, represented as a stream. The default implementation copies the
@@ -59,7 +59,7 @@ namespace CloudNative.CloudEvents
         /// information such as the charset parameter may be needed in order to decode the message body.</param>
         /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
         /// <returns>The decoded CloudEvent.</returns>
-        public virtual CloudEvent DecodeStructuredModeMessage(Stream messageBody, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes)
+        public virtual CloudEvent DecodeStructuredModeMessage(Stream messageBody, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
         {
             var bytes = BinaryDataUtilities.ToReadOnlyMemory(messageBody);
             return DecodeStructuredModeMessage(bytes, contentType, extensionAttributes);
@@ -76,7 +76,7 @@ namespace CloudNative.CloudEvents
         /// information such as the charset parameter may be needed in order to decode the message body.</param>
         /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
         /// <returns>The CloudEvent derived from the structured message body.</returns>
-        public virtual async Task<CloudEvent> DecodeStructuredModeMessageAsync(Stream body, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes)
+        public virtual async Task<CloudEvent> DecodeStructuredModeMessageAsync(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
         {
             var bytes = await BinaryDataUtilities.ToReadOnlyMemoryAsync(body).ConfigureAwait(false);
             return DecodeStructuredModeMessage(bytes, contentType, extensionAttributes);
@@ -114,13 +114,13 @@ namespace CloudNative.CloudEvents
         /// <summary>
         /// Decodes a collection CloudEvents from a batch-mode message body, represented as a read-only memory segment.
         /// </summary>
-        /// <param name="body">The message body (content). Must not be null.</param>
+        /// <param name="body">The message body (content).</param>
         /// <param name="contentType">The content type of the message, or null if no content type is known.
         /// Typically this is a content type with a media type with a prefix of "application/cloudevents-batch"; the additional
         /// information such as the charset parameter may be needed in order to decode the message body.</param>
         /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
         /// <returns>The collection of CloudEvents derived from the batch message body.</returns>
-        public abstract IReadOnlyList<CloudEvent> DecodeBatchModeMessage(ReadOnlyMemory<byte> body, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes);
+        public abstract IReadOnlyList<CloudEvent> DecodeBatchModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes);
 
         /// <summary>
         /// Decodes a collection CloudEvents from a batch-mode message body, represented as a stream. The default implementation copies the
@@ -133,7 +133,7 @@ namespace CloudNative.CloudEvents
         /// information such as the charset parameter may be needed in order to decode the message body.</param>
         /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
         /// <returns>The collection of CloudEvents derived from the batch message body.</returns>
-        public virtual IReadOnlyList<CloudEvent> DecodeBatchModeMessage(Stream body, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes)
+        public virtual IReadOnlyList<CloudEvent> DecodeBatchModeMessage(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
         {
             var bytes = BinaryDataUtilities.ToReadOnlyMemory(body);
             return DecodeBatchModeMessage(bytes, contentType, extensionAttributes);
@@ -150,7 +150,7 @@ namespace CloudNative.CloudEvents
         /// information such as the charset parameter may be needed in order to decode the message body.</param>
         /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
         /// <returns>The collection of CloudEvents derived from the batch message body.</returns>
-        public virtual async Task<IReadOnlyList<CloudEvent>> DecodeBatchModeMessageAsync(Stream body, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes)
+        public virtual async Task<IReadOnlyList<CloudEvent>> DecodeBatchModeMessageAsync(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
         {
             var bytes = await BinaryDataUtilities.ToReadOnlyMemoryAsync(body).ConfigureAwait(false);
             return DecodeBatchModeMessage(bytes, contentType, extensionAttributes);

--- a/src/CloudNative.CloudEvents/CloudEventFormatterAttribute.cs
+++ b/src/CloudNative.CloudEvents/CloudEventFormatterAttribute.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
+using CloudNative.CloudEvents.Core;
 using System;
 using System.Reflection;
 
@@ -34,12 +35,13 @@ namespace CloudNative.CloudEvents
         /// the specified target type (or an ancestor) has the attribute applied to it. This method does not
         /// perform any caching; callers may wish to cache the results themselves.
         /// </summary>
-        /// <param name="targetType">The type for which to create a formatter if possible.</param>
+        /// <param name="targetType">The type for which to create a formatter if possible. Must not be null</param>
         /// <exception cref="InvalidOperationException">The target type is decorated with this attribute, but the
         /// type cannot be instantiated or does not derive from <see cref="CloudEventFormatter"/>.</exception>
         /// <returns>A new instance of the specified formatter, or null if the type is not decorated with this attribute.</returns>
-        public static CloudEventFormatter CreateFormatter(Type targetType)
+        public static CloudEventFormatter? CreateFormatter(Type targetType)
         {
+            Validation.CheckNotNull(targetType, nameof(targetType));
             var attribute = targetType.GetCustomAttribute<CloudEventFormatterAttribute>(inherit: true);
             if (attribute is null)
             {

--- a/src/CloudNative.CloudEvents/CloudEventsSpecVersion.cs
+++ b/src/CloudNative.CloudEvents/CloudEventsSpecVersion.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net.Mime;
 using static CloudNative.CloudEvents.CloudEventAttribute;
@@ -50,6 +51,9 @@ namespace CloudNative.CloudEvents
         /// </summary>
         public string VersionId { get; }
 
+        // TODO: Should any of these properties be nullable? What if CloudEvents 2.0 removes the Subject attribute, for example? We'd need a breaking change...
+        // (On the other hand, that's unlikely, and keeping them non-nullable is really convenient...)
+
         /// <summary>
         /// The attribute for the <see cref="CloudEvent.Id"/> property.
         /// </summary>
@@ -94,7 +98,8 @@ namespace CloudNative.CloudEvents
         /// or null if no such version is known.
         /// </summary>
         /// <param name="versionId">The version ID to check. May be null, in which case the result will be null.</param>
-        public static CloudEventsSpecVersion FromVersionId(string versionId) =>
+        [return:NotNullIfNotNull(nameof(VersionId))]
+        public static CloudEventsSpecVersion? FromVersionId(string? versionId) =>
             allVersions.FirstOrDefault(version => version.VersionId == versionId);
 
         private CloudEventsSpecVersion(
@@ -134,7 +139,7 @@ namespace CloudNative.CloudEvents
         /// </summary>
         /// <param name="name">The name of the attribute to find.</param>
         /// <returns>The attribute with the given name, or null if this spec version does not contain any such attribute.</returns>
-        internal CloudEventAttribute GetAttributeByName(string name) => attributesByName.GetValueOrDefault(name);
+        internal CloudEventAttribute? GetAttributeByName(string name) => attributesByName.GetValueOrDefault(name);
 
         /// <summary>
         /// Returns all required attributes in this version of the CloudEvents specification.

--- a/src/CloudNative.CloudEvents/CloudNative.CloudEvents.csproj
+++ b/src/CloudNative.CloudEvents/CloudNative.CloudEvents.csproj
@@ -4,11 +4,14 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>CNCF CloudEvents SDK</Description>
     <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
     <PackageTags>cloudnative;cloudevents;events</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.4" />
+    <!-- Source-only package with nullable reference annotations. -->
+    <PackageReference Include="Nullable" Version="1.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CloudNative.CloudEvents/CloudNative.CloudEvents.csproj
+++ b/src/CloudNative.CloudEvents/CloudNative.CloudEvents.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>CNCF CloudEvents SDK</Description>
     <LangVersion>8.0</LangVersion>
     <PackageTags>cloudnative;cloudevents;events</PackageTags>

--- a/src/CloudNative.CloudEvents/CollectionExtensions.cs
+++ b/src/CloudNative.CloudEvents/CollectionExtensions.cs
@@ -12,7 +12,9 @@ namespace CloudNative.CloudEvents
     /// </summary>
     internal static class CollectionExtensions
     {
-        internal static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue = default(TValue)) =>
-            dictionary.TryGetValue(key, out var value) ? value : defaultValue;
+        // Note: this is a bit more specialized than the versoin in the framework, to make defaulting simpler to handle.
+        internal static TValue? GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key)
+            where TValue : class =>
+            dictionary.TryGetValue(key, out var value) ? value : default(TValue?);
     }
 }

--- a/src/CloudNative.CloudEvents/Core/MimeUtilities.cs
+++ b/src/CloudNative.CloudEvents/Core/MimeUtilities.cs
@@ -32,7 +32,7 @@ namespace CloudNative.CloudEvents.Core
         /// <param name="contentType">The content type, or null if no content type is known.</param>
         /// <returns>An encoding suitable for the charset specified in <paramref name="contentType"/>,
         /// or UTF-8 if no charset has been specified.</returns>
-        public static Encoding GetEncoding(ContentType contentType) =>
+        public static Encoding GetEncoding(ContentType? contentType) =>
             contentType?.CharSet is string charSet ? Encoding.GetEncoding(charSet) : Encoding.UTF8;
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace CloudNative.CloudEvents.Core
         /// </summary>
         /// <param name="headerValue">The header value to convert. May be null.</param>
         /// <returns>The converted content type, or null if <paramref name="headerValue"/> is null.</returns>
-        public static ContentType ToContentType(MediaTypeHeaderValue headerValue) =>
+        public static ContentType? ToContentType(MediaTypeHeaderValue? headerValue) =>
             headerValue is null ? null : new ContentType(headerValue.ToString());
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace CloudNative.CloudEvents.Core
         /// </summary>
         /// <param name="contentType">The content type to convert. May be null.</param>
         /// <returns>The converted media type header value, or null if <paramref name="contentType"/> is null.</returns>
-        public static MediaTypeHeaderValue ToMediaTypeHeaderValue(ContentType contentType)
+        public static MediaTypeHeaderValue? ToMediaTypeHeaderValue(ContentType? contentType)
         {
             if (contentType is null)
             {
@@ -68,7 +68,7 @@ namespace CloudNative.CloudEvents.Core
         /// </summary>
         /// <param name="contentType">The content type textual value. May be null.</param>
         /// <returns>The converted content type, or null if <paramref name="contentType"/> is null.</returns>
-        public static ContentType CreateContentTypeOrNull(string contentType) =>
+        public static ContentType? CreateContentTypeOrNull(string? contentType) =>
             contentType is null ? null : new ContentType(contentType);
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace CloudNative.CloudEvents.Core
         /// </summary>
         /// <param name="contentType">The content type to check. May be null, in which case the result is false.</param>
         /// <returns>true if the given content type denotes a (non-batch) CloudEvent; false otherwise</returns>
-        public static bool IsCloudEventsContentType(string contentType) =>
+        public static bool IsCloudEventsContentType(string? contentType) =>
             contentType is string &&
             contentType.StartsWith(MediaType, StringComparison.InvariantCultureIgnoreCase) &&
             !contentType.StartsWith(BatchMediaType, StringComparison.InvariantCultureIgnoreCase);
@@ -86,7 +86,7 @@ namespace CloudNative.CloudEvents.Core
         /// </summary>
         /// <param name="contentType">The content type to check. May be null, in which case the result is false.</param>
         /// <returns>true if the given content type represents a CloudEvent batch; false otherwise</returns>
-        public static bool IsCloudEventsBatchContentType(string contentType) =>
+        public static bool IsCloudEventsBatchContentType(string? contentType) =>
             contentType is string && contentType.StartsWith(BatchMediaType, StringComparison.InvariantCultureIgnoreCase);
     }
 }

--- a/src/CloudNative.CloudEvents/Core/Validation.cs
+++ b/src/CloudNative.CloudEvents/Core/Validation.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace CloudNative.CloudEvents.Core
@@ -22,7 +23,7 @@ namespace CloudNative.CloudEvents.Core
         /// <param name="paramName">The parameter name to use in the exception if <paramref name="value"/> is null.
         /// May be null.</param>
         /// <returns>The value of <paramref name="value"/>, for convenient method chaining or assignment.</returns>
-        public static T CheckNotNull<T>(T value, string paramName) where T : class =>
+        public static T CheckNotNull<T>(T value, string? paramName) where T : class =>
             value ?? throw new ArgumentNullException(paramName);
 
         /// <summary>
@@ -31,7 +32,7 @@ namespace CloudNative.CloudEvents.Core
         /// <param name="condition">The condition to validate; this method will throw an <see cref="ArgumentException"/> if this is false.</param>
         /// <param name="paramName">The name of the parameter being validated. May be null.</param>
         /// <param name="message">The message to use in the exception, if one is thrown.</param>
-        public static void CheckArgument(bool condition, string paramName, string message)
+        public static void CheckArgument([DoesNotReturnIf(false)] bool condition, string paramName, string message)
         {
             if (!condition)
             {
@@ -46,8 +47,8 @@ namespace CloudNative.CloudEvents.Core
         /// <param name="paramName">The name of the parameter being validated. May be null.</param>
         /// <param name="messageFormat">The string format to use in the exception message, if one is thrown.</param>
         /// <param name="arg1">The first argument in the string format.</param>
-        public static void CheckArgument(bool condition, string paramName, string messageFormat,
-            object arg1)
+        public static void CheckArgument([DoesNotReturnIf(false)] bool condition, string paramName, string messageFormat,
+            object? arg1)
         {
             if (!condition)
             {
@@ -62,9 +63,9 @@ namespace CloudNative.CloudEvents.Core
         /// <param name="paramName">The name of the parameter being validated. May be null.</param>
         /// <param name="messageFormat">The string format to use in the exception message, if one is thrown.</param>
         /// <param name="arg1">The first argument in the string format.</param>
-        /// <param name="arg2">The first argument in the string format.</param>
+        /// <param name="arg2">The second argument in the string format.</param>
         public static void CheckArgument(bool condition, string paramName, string messageFormat,
-            object arg1, object arg2)
+            object? arg1, object? arg2)
         {
             if (!condition)
             {
@@ -84,7 +85,7 @@ namespace CloudNative.CloudEvents.Core
         /// <exception cref="ArgumentNullException"><paramref name="cloudEvent"/> is null.</exception>
         /// <exception cref="ArgumentException">The event is invalid.</exception>
         /// <returns>A reference to the same object, for simplicity of method chaining.</returns>
-        public static CloudEvent CheckCloudEventArgument(CloudEvent cloudEvent, string paramName)
+        public static CloudEvent CheckCloudEventArgument(CloudEvent cloudEvent, string? paramName)
         {
             CheckNotNull(cloudEvent, paramName);
             if (cloudEvent.IsValid)
@@ -103,7 +104,7 @@ namespace CloudNative.CloudEvents.Core
         /// <param name="cloudEvents">The event batch to validate.</param>
         /// <param name="paramName">The parameter name to use in the exception if <paramref name="cloudEvents"/> is null or invalid.
         /// May be null.</param>
-        public static void CheckCloudEventBatchArgument(IReadOnlyList<CloudEvent> cloudEvents, string paramName)
+        public static void CheckCloudEventBatchArgument(IReadOnlyList<CloudEvent> cloudEvents, string? paramName)
         {
             CheckNotNull(cloudEvents, paramName);
             foreach (var cloudEvent in cloudEvents)

--- a/src/CloudNative.CloudEvents/Extensions/Partitioning.cs
+++ b/src/CloudNative.CloudEvents/Extensions/Partitioning.cs
@@ -33,7 +33,7 @@ namespace CloudNative.CloudEvents.Extensions
         /// <param name="partitionKey">The partition key to set. May be null, in which case the attribute is
         /// removed from <paramref name="cloudEvent"/>.</param>
         /// <returns><paramref name="cloudEvent"/>, for convenient method chaining.</returns>
-        public static CloudEvent SetPartitionKey(this CloudEvent cloudEvent, string partitionKey)
+        public static CloudEvent SetPartitionKey(this CloudEvent cloudEvent, string? partitionKey)
         {
             Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
             cloudEvent[PartitionKeyAttribute] = partitionKey;
@@ -45,7 +45,7 @@ namespace CloudNative.CloudEvents.Extensions
         /// </summary>
         /// <param name="cloudEvent">The CloudEvent from which to retrieve the attribute. Must not be null.</param>
         /// <returns>The partition key, or null if <paramref name="cloudEvent"/> does not have a partition key set.</returns>
-        public static string GetPartitionKey(this CloudEvent cloudEvent) =>
-            (string) Validation.CheckNotNull(cloudEvent, nameof(cloudEvent))[PartitionKeyAttribute];
+        public static string? GetPartitionKey(this CloudEvent cloudEvent) =>
+            (string?) Validation.CheckNotNull(cloudEvent, nameof(cloudEvent))[PartitionKeyAttribute];
     }
 }

--- a/src/CloudNative.CloudEvents/Extensions/Sequence.cs
+++ b/src/CloudNative.CloudEvents/Extensions/Sequence.cs
@@ -47,7 +47,7 @@ namespace CloudNative.CloudEvents.Extensions
         /// <paramref name="cloudEvent"/>.</param>
         /// <exception cref="ArgumentException"><paramref name="value"/> is a non-null value for an unsupported sequence type.</exception>
         /// <returns><paramref name="cloudEvent"/>, for convenient method chaining.</returns>
-        public static CloudEvent SetSequence(this CloudEvent cloudEvent, object value)
+        public static CloudEvent SetSequence(this CloudEvent cloudEvent, object? value)
         {
             Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
             if (value is null)
@@ -76,8 +76,8 @@ namespace CloudNative.CloudEvents.Extensions
         /// </summary>
         /// <param name="cloudEvent">The CloudEvent from which to retrieve the attribute. Must not be null.</param>
         /// <returns>The <see cref="SequenceAttribute"/> value, as a string, or null if the attribute is not set.</returns>
-        public static string GetSequenceString(this CloudEvent cloudEvent) =>
-            (string) Validation.CheckNotNull(cloudEvent, nameof(cloudEvent))[SequenceAttribute];
+        public static string? GetSequenceString(this CloudEvent cloudEvent) =>
+            (string?) Validation.CheckNotNull(cloudEvent, nameof(cloudEvent))[SequenceAttribute];
 
         /// <summary>
         /// Retrieves the <see cref="SequenceTypeAttribute"/> value from the event, without any
@@ -85,8 +85,8 @@ namespace CloudNative.CloudEvents.Extensions
         /// </summary>
         /// <param name="cloudEvent">The CloudEvent from which to retrieve the attribute. Must not be null.</param>
         /// <returns>The <see cref="SequenceTypeAttribute"/> value, as a string, or null if the attribute is not set.</returns>
-        public static string GetSequenceType(this CloudEvent cloudEvent) =>
-            (string)Validation.CheckNotNull(cloudEvent, nameof(cloudEvent))[SequenceTypeAttribute];
+        public static string? GetSequenceType(this CloudEvent cloudEvent) =>
+            (string?)Validation.CheckNotNull(cloudEvent, nameof(cloudEvent))[SequenceTypeAttribute];
 
         /// <summary>
         /// Retrieves the <see cref="SequenceAttribute"/> value from the event,
@@ -96,9 +96,9 @@ namespace CloudNative.CloudEvents.Extensions
         /// </summary>
         /// <param name="cloudEvent"></param>
         /// <returns>The value of <see cref="SequenceAttribute"/> from <paramref name="cloudEvent"/>, transformed
-        /// based on the value of <see cref="SequenceTypeAttribute"/>.</returns>
+        /// based on the value of <see cref="SequenceTypeAttribute"/>, or null if the attribute is not set.</returns>
         /// <exception cref="InvalidOperationException">The <see cref="SequenceTypeAttribute"/> is present, but unknown to this library.</exception>
-        public static object GetSequenceValue(this CloudEvent cloudEvent)
+        public static object? GetSequenceValue(this CloudEvent cloudEvent)
         {
             Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
             var sequence = GetSequenceString(cloudEvent);

--- a/src/CloudNative.CloudEvents/Http/HttpClientExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpClientExtensions.cs
@@ -83,8 +83,8 @@ namespace CloudNative.CloudEvents.Http
         public static Task<CloudEvent> ToCloudEventAsync(
             this HttpResponseMessage httpResponseMessage,
             CloudEventFormatter formatter,
-            params CloudEventAttribute[] extensionAttributes) =>
-            ToCloudEventAsync(httpResponseMessage, formatter, (IEnumerable<CloudEventAttribute>) extensionAttributes);
+            params CloudEventAttribute[]? extensionAttributes) =>
+            ToCloudEventAsync(httpResponseMessage, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
 
         /// <summary>
         /// Converts this HTTP response message into a CloudEvent object
@@ -96,7 +96,7 @@ namespace CloudNative.CloudEvents.Http
         public static Task<CloudEvent> ToCloudEventAsync(
             this HttpResponseMessage httpResponseMessage,
             CloudEventFormatter formatter,
-            IEnumerable<CloudEventAttribute> extensionAttributes)
+            IEnumerable<CloudEventAttribute>? extensionAttributes)
         {
             Validation.CheckNotNull(httpResponseMessage, nameof(httpResponseMessage));
             return ToCloudEventInternalAsync(httpResponseMessage.Headers, httpResponseMessage.Content, formatter, extensionAttributes, nameof(httpResponseMessage));
@@ -112,8 +112,8 @@ namespace CloudNative.CloudEvents.Http
         public static Task<CloudEvent> ToCloudEventAsync(
             this HttpRequestMessage httpRequestMessage,
             CloudEventFormatter formatter,
-            params CloudEventAttribute[] extensionAttributes) =>
-            ToCloudEventAsync(httpRequestMessage, formatter, (IEnumerable<CloudEventAttribute>) extensionAttributes);
+            params CloudEventAttribute[]? extensionAttributes) =>
+            ToCloudEventAsync(httpRequestMessage, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
 
         /// <summary>
         /// Converts this HTTP request message into a CloudEvent object.
@@ -125,14 +125,14 @@ namespace CloudNative.CloudEvents.Http
         public static Task<CloudEvent> ToCloudEventAsync(
             this HttpRequestMessage httpRequestMessage,
             CloudEventFormatter formatter,
-            IEnumerable<CloudEventAttribute> extensionAttributes)
+            IEnumerable<CloudEventAttribute>? extensionAttributes)
         {
             Validation.CheckNotNull(httpRequestMessage, nameof(httpRequestMessage));
             return ToCloudEventInternalAsync(httpRequestMessage.Headers, httpRequestMessage.Content, formatter, extensionAttributes, nameof(httpRequestMessage));
         }
 
         private static async Task<CloudEvent> ToCloudEventInternalAsync(HttpHeaders headers, HttpContent content,
-            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute> extensionAttributes, string paramName)
+            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes, string paramName)
         {
             Validation.CheckNotNull(formatter, nameof(formatter));
 
@@ -143,7 +143,7 @@ namespace CloudNative.CloudEvents.Http
             }
             else
             {
-                string versionId = headers.Contains(HttpUtilities.SpecVersionHttpHeader)
+                string? versionId = headers.Contains(HttpUtilities.SpecVersionHttpHeader)
                     ? headers.GetValues(HttpUtilities.SpecVersionHttpHeader).First()
                     : null;
                 if (versionId is null)
@@ -156,7 +156,7 @@ namespace CloudNative.CloudEvents.Http
                 var cloudEvent = new CloudEvent(version, extensionAttributes);
                 foreach (var header in headers)
                 {
-                    string attributeName = HttpUtilities.GetAttributeNameFromHeaderName(header.Key);
+                    string? attributeName = HttpUtilities.GetAttributeNameFromHeaderName(header.Key);
                     if (attributeName is null || attributeName == CloudEventsSpecVersion.SpecVersionAttribute.Name)
                     {
                         continue;
@@ -228,14 +228,14 @@ namespace CloudNative.CloudEvents.Http
         public static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
             this HttpRequestMessage httpRequestMessage,
             CloudEventFormatter formatter,
-            IEnumerable<CloudEventAttribute> extensionAttributes)
+            IEnumerable<CloudEventAttribute>? extensionAttributes)
         {
             Validation.CheckNotNull(httpRequestMessage, nameof(httpRequestMessage));
             return ToCloudEventBatchInternalAsync(httpRequestMessage.Content, formatter, extensionAttributes, nameof(httpRequestMessage));
         }
 
         private static async Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchInternalAsync(HttpContent content,
-            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute> extensionAttributes, string paramName)
+            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes, string paramName)
         {
             Validation.CheckNotNull(formatter, nameof(formatter));
 
@@ -265,7 +265,7 @@ namespace CloudNative.CloudEvents.Http
 
             ReadOnlyMemory<byte> content;
             // The content type to include in the ContentType header - may be the data content type, or the formatter's content type.
-            ContentType contentType;
+            ContentType? contentType;
             switch (contentMode)
             {
                 case ContentMode.Structured:

--- a/src/CloudNative.CloudEvents/Http/HttpListenerExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpListenerExtensions.cs
@@ -33,7 +33,7 @@ namespace CloudNative.CloudEvents.Http
             Validation.CheckNotNull(formatter, nameof(formatter));
 
             ReadOnlyMemory<byte> content;
-            ContentType contentType;
+            ContentType? contentType;
             switch (contentMode)
             {
                 case ContentMode.Structured:
@@ -126,10 +126,10 @@ namespace CloudNative.CloudEvents.Http
         /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
         /// <returns>A reference to a validated CloudEvent instance.</returns>
         public static Task<CloudEvent> ToCloudEventAsync(this HttpListenerRequest httpListenerRequest,
-            CloudEventFormatter formatter, params CloudEventAttribute[] extensionAttributes) =>
+            CloudEventFormatter formatter, params CloudEventAttribute[]? extensionAttributes) =>
             // No async/await here, as the delegation is to *such* a similar method (same name, same parameter names)
             // that the stack trace will still be very easy to understand.
-            ToCloudEventAsync(httpListenerRequest, formatter, (IEnumerable<CloudEventAttribute>) extensionAttributes);
+            ToCloudEventAsync(httpListenerRequest, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
 
         /// <summary>
         /// Converts this listener request into a CloudEvent object, with the given extension attributes.
@@ -139,7 +139,7 @@ namespace CloudNative.CloudEvents.Http
         /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
         /// <returns>A reference to a validated CloudEvent instance.</returns>
         public async static Task<CloudEvent> ToCloudEventAsync(this HttpListenerRequest httpListenerRequest,
-            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute> extensionAttributes) =>
+            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
             await ToCloudEventAsyncImpl(httpListenerRequest, formatter, extensionAttributes, async: true).ConfigureAwait(false);
 
         /// <summary>
@@ -150,8 +150,8 @@ namespace CloudNative.CloudEvents.Http
         /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
         /// <returns>A reference to a validated CloudEvent instance.</returns>
         public static CloudEvent ToCloudEvent(this HttpListenerRequest httpListenerRequest,
-            CloudEventFormatter formatter, params CloudEventAttribute[] extensionAttributes) =>
-            ToCloudEvent(httpListenerRequest, formatter, (IEnumerable<CloudEventAttribute>) extensionAttributes);
+            CloudEventFormatter formatter, params CloudEventAttribute[]? extensionAttributes) =>
+            ToCloudEvent(httpListenerRequest, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
 
         /// <summary>
         /// Converts this listener request into a CloudEvent object, with the given extension attributes.
@@ -161,11 +161,11 @@ namespace CloudNative.CloudEvents.Http
         /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
         /// <returns>A reference to a validated CloudEvent instance.</returns>
         public static CloudEvent ToCloudEvent(this HttpListenerRequest httpListenerRequest,
-            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute> extensionAttributes) =>
+            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
             ToCloudEventAsyncImpl(httpListenerRequest, formatter, extensionAttributes, async: false).GetAwaiter().GetResult();
 
         private async static Task<CloudEvent> ToCloudEventAsyncImpl(HttpListenerRequest httpListenerRequest,
-            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute> extensionAttributes, bool async)
+            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes, bool async)
         {
             Validation.CheckNotNull(httpListenerRequest, nameof(httpListenerRequest));
             Validation.CheckNotNull(formatter, nameof(formatter));
@@ -191,7 +191,7 @@ namespace CloudNative.CloudEvents.Http
                 var headers = httpListenerRequest.Headers;
                 foreach (var key in headers.AllKeys)
                 {
-                    string attributeName = HttpUtilities.GetAttributeNameFromHeaderName(key);
+                    string? attributeName = HttpUtilities.GetAttributeNameFromHeaderName(key);
                     if (attributeName is null || attributeName == CloudEventsSpecVersion.SpecVersionAttribute.Name)
                     {
                         continue;
@@ -222,8 +222,8 @@ namespace CloudNative.CloudEvents.Http
         public static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
             this HttpListenerRequest httpListenerRequest,
             CloudEventFormatter formatter,
-            params CloudEventAttribute[] extensionAttributes) =>
-            ToCloudEventBatchAsync(httpListenerRequest, formatter, (IEnumerable<CloudEventAttribute>)extensionAttributes);
+            params CloudEventAttribute[]? extensionAttributes) =>
+            ToCloudEventBatchAsync(httpListenerRequest, formatter, (IEnumerable<CloudEventAttribute>?)extensionAttributes);
 
         /// <summary>
         /// Converts this HTTP request message into a CloudEvent batch.
@@ -235,7 +235,7 @@ namespace CloudNative.CloudEvents.Http
         public static async Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
             this HttpListenerRequest httpListenerRequest,
             CloudEventFormatter formatter,
-            IEnumerable<CloudEventAttribute> extensionAttributes) =>
+            IEnumerable<CloudEventAttribute>? extensionAttributes) =>
             await ToCloudEventBatchInternalAsync(httpListenerRequest, formatter, extensionAttributes, async: true).ConfigureAwait(false);
 
         /// <summary>
@@ -248,8 +248,8 @@ namespace CloudNative.CloudEvents.Http
         public static IReadOnlyList<CloudEvent> ToCloudEventBatch(
             this HttpListenerRequest httpListenerRequest,
             CloudEventFormatter formatter,
-            params CloudEventAttribute[] extensionAttributes) =>
-            ToCloudEventBatch(httpListenerRequest, formatter, (IEnumerable<CloudEventAttribute>) extensionAttributes);
+            params CloudEventAttribute[]? extensionAttributes) =>
+            ToCloudEventBatch(httpListenerRequest, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
 
         /// <summary>
         /// Converts this HTTP request message into a CloudEvent batch.
@@ -261,11 +261,11 @@ namespace CloudNative.CloudEvents.Http
         public static IReadOnlyList<CloudEvent> ToCloudEventBatch(
             this HttpListenerRequest httpListenerRequest,
             CloudEventFormatter formatter,
-            IEnumerable<CloudEventAttribute> extensionAttributes) =>
+            IEnumerable<CloudEventAttribute>? extensionAttributes) =>
             ToCloudEventBatchInternalAsync(httpListenerRequest, formatter, extensionAttributes, async: false).GetAwaiter().GetResult();
         
         private async static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchInternalAsync(HttpListenerRequest httpListenerRequest,
-            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute> extensionAttributes, bool async)
+            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes, bool async)
         {
             Validation.CheckNotNull(httpListenerRequest, nameof(httpListenerRequest));
             Validation.CheckNotNull(formatter, nameof(formatter));

--- a/src/CloudNative.CloudEvents/Http/HttpUtilities.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpUtilities.cs
@@ -34,7 +34,7 @@ namespace CloudNative.CloudEvents.Http
         /// <param name="headerName">The name of the header to check. Must not be null.</param>
         /// <returns>The corresponding attribute name if the header name matches the CloudEvents header prefix;
         /// null otherwise.</returns>
-        public static string GetAttributeNameFromHeaderName(string headerName) =>
+        public static string? GetAttributeNameFromHeaderName(string headerName) =>
             Validation.CheckNotNull(headerName, nameof(headerName)).StartsWith(HttpHeaderPrefix, StringComparison.InvariantCultureIgnoreCase)
             ? headerName.Substring(HttpHeaderPrefix.Length).ToLowerInvariant()
             : null;

--- a/src/CloudNative.CloudEvents/Http/HttpWebExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpWebExtensions.cs
@@ -35,7 +35,7 @@ namespace CloudNative.CloudEvents.Http
 
             ReadOnlyMemory<byte> content;
             // The content type to include in the ContentType header - may be the data content type, or the formatter's content type.
-            ContentType contentType;
+            ContentType? contentType;
             switch (contentMode)
             {
                 case ContentMode.Structured:

--- a/src/CloudNative.CloudEvents/Timestamps.cs
+++ b/src/CloudNative.CloudEvents/Timestamps.cs
@@ -129,6 +129,7 @@ namespace CloudNative.CloudEvents
             int totalMinutes = hours * 60 + minutes;
             if (minutes >= 60 || totalMinutes > MaxOffsetMinutes)
             {
+                offset = default;
                 return false;
             }
 

--- a/test/CloudNative.CloudEvents.UnitTests/Amqp/AmqpTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Amqp/AmqpTest.cs
@@ -45,11 +45,11 @@ namespace CloudNative.CloudEvents.Amqp.UnitTests
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull"), receivedCloudEvent.Source);
             Assert.Equal("123", receivedCloudEvent.Subject);
             Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-            AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time.Value);
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time!.Value);
             Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
 
-            Assert.Equal("value", (string)receivedCloudEvent["comexampleextension1"]);
+            Assert.Equal("value", (string?)receivedCloudEvent["comexampleextension1"]);
         }
 
         [Fact]
@@ -82,11 +82,11 @@ namespace CloudNative.CloudEvents.Amqp.UnitTests
             Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
             Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-            AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time.Value);
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time!.Value);
             Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
 
-            Assert.Equal("value", (string)receivedCloudEvent["comexampleextension1"]);
+            Assert.Equal("value", (string?)receivedCloudEvent["comexampleextension1"]);
         }
 
         [Fact]
@@ -109,7 +109,7 @@ namespace CloudNative.CloudEvents.Amqp.UnitTests
             var message1 = Message.Decode(encodedAmqpMessage);
             var receivedCloudEvent = message1.ToCloudEvent(new JsonEventFormatter());
 
-            AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time.Value);
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time!.Value);
         }
 
         [Fact]

--- a/test/CloudNative.CloudEvents.UnitTests/AspNetCore/HttpRequestExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/AspNetCore/HttpRequestExtensionsTest.cs
@@ -18,7 +18,7 @@ namespace CloudNative.CloudEvents.AspNetCore.UnitTests
 {
     public class HttpRequestExtensionsTest
     {
-        public static TheoryData<string, string, IDictionary<string, string>> SingleCloudEventMessages = new TheoryData<string, string, IDictionary<string, string>>
+        public static TheoryData<string, string, IDictionary<string, string>?> SingleCloudEventMessages = new TheoryData<string, string, IDictionary<string, string>?>
         {
             {
                 "Binary",
@@ -38,7 +38,7 @@ namespace CloudNative.CloudEvents.AspNetCore.UnitTests
             }
         };
 
-        public static TheoryData<string, string, IDictionary<string, string>> BatchMessages = new TheoryData<string, string, IDictionary<string, string>>
+        public static TheoryData<string, string, IDictionary<string, string>?> BatchMessages = new TheoryData<string, string, IDictionary<string, string>?>
         {
             {
                 "Batch",
@@ -47,7 +47,7 @@ namespace CloudNative.CloudEvents.AspNetCore.UnitTests
             }
         };
 
-        public static TheoryData<string, string, IDictionary<string, string>> NonCloudEventMessages = new TheoryData<string, string, IDictionary<string, string>>
+        public static TheoryData<string, string, IDictionary<string, string>?> NonCloudEventMessages = new TheoryData<string, string, IDictionary<string, string>?>
         {
             {
                 "Plain text",
@@ -58,7 +58,7 @@ namespace CloudNative.CloudEvents.AspNetCore.UnitTests
 
         [Theory]
         [MemberData(nameof(SingleCloudEventMessages))]
-        public void IsCloudEvent_True(string description, string contentType, IDictionary<string, string> headers)
+        public void IsCloudEvent_True(string description, string contentType, IDictionary<string, string>? headers)
         {
             // Really only present for display purposes.
             Assert.NotNull(description);
@@ -71,7 +71,7 @@ namespace CloudNative.CloudEvents.AspNetCore.UnitTests
         [Theory]
         [MemberData(nameof(BatchMessages))]
         [MemberData(nameof(NonCloudEventMessages))]
-        public void IsCloudEvent_False(string description, string contentType, IDictionary<string, string> headers)
+        public void IsCloudEvent_False(string description, string contentType, IDictionary<string, string>? headers)
         {
             // Really only present for display purposes.
             Assert.NotNull(description);
@@ -83,7 +83,7 @@ namespace CloudNative.CloudEvents.AspNetCore.UnitTests
 
         [Theory]
         [MemberData(nameof(BatchMessages))]
-        public void IsCloudEventBatch_True(string description, string contentType, IDictionary<string, string> headers)
+        public void IsCloudEventBatch_True(string description, string contentType, IDictionary<string, string>? headers)
         {
             // Really only present for display purposes.
             Assert.NotNull(description);
@@ -96,7 +96,7 @@ namespace CloudNative.CloudEvents.AspNetCore.UnitTests
         [Theory]
         [MemberData(nameof(SingleCloudEventMessages))]
         [MemberData(nameof(NonCloudEventMessages))]
-        public void IsCloudEventBatch_False(string description, string contentType, IDictionary<string, string> headers)
+        public void IsCloudEventBatch_False(string description, string contentType, IDictionary<string, string>? headers)
         {
             // Really only present for display purposes.
             Assert.NotNull(description);
@@ -138,7 +138,7 @@ namespace CloudNative.CloudEvents.AspNetCore.UnitTests
                 Body = BinaryDataUtilities.AsStream(content)
             };
 
-        private static void CopyHeaders(IDictionary<string, string> source, HttpRequest target)
+        private static void CopyHeaders(IDictionary<string, string>? source, HttpRequest target)
         {
             if (source is null)
             {

--- a/test/CloudNative.CloudEvents.UnitTests/AspNetCore/HttpResponseExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/AspNetCore/HttpResponseExtensionsTest.cs
@@ -36,7 +36,7 @@ namespace CloudNative.CloudEvents.AspNetCore.UnitTests
             Assert.Equal("1.0", response.Headers["ce-specversion"]);
             Assert.Equal(cloudEvent.Type, response.Headers["ce-type"]);
             Assert.Equal(cloudEvent.Id, response.Headers["ce-id"]);
-            Assert.Equal(CloudEventAttributeType.UriReference.Format(cloudEvent.Source), response.Headers["ce-source"]);
+            Assert.Equal(CloudEventAttributeType.UriReference.Format(cloudEvent.Source!), response.Headers["ce-source"]);
             // There's no data content type header; the content type itself is used for that.
             Assert.False(response.Headers.ContainsKey("ce-datacontenttype"));
         }
@@ -84,7 +84,7 @@ namespace CloudNative.CloudEvents.AspNetCore.UnitTests
             Assert.Equal("1.0", response.Headers["ce-specversion"]);
             Assert.Equal(cloudEvent.Type, response.Headers["ce-type"]);
             Assert.Equal(cloudEvent.Id, response.Headers["ce-id"]);
-            Assert.Equal(CloudEventAttributeType.UriReference.Format(cloudEvent.Source), response.Headers["ce-source"]);
+            Assert.Equal(CloudEventAttributeType.UriReference.Format(cloudEvent.Source!), response.Headers["ce-source"]);
             // We don't populate the data content type header
             Assert.False(response.Headers.ContainsKey("ce-datacontenttype"));
         }

--- a/test/CloudNative.CloudEvents.UnitTests/Avro/AvroEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Avro/AvroEventFormatterTest.cs
@@ -38,7 +38,7 @@ namespace CloudNative.CloudEvents.Avro.UnitTests
             Assert.Equal(cloudEvent2.Type, cloudEvent.Type);
             Assert.Equal(cloudEvent2.Source, cloudEvent.Source);
             Assert.Equal(cloudEvent2.Id, cloudEvent.Id);
-            AssertTimestampsEqual(cloudEvent2.Time.Value, cloudEvent.Time.Value);
+            AssertTimestampsEqual(cloudEvent2.Time!.Value, cloudEvent.Time!.Value);
             Assert.Equal(cloudEvent2.DataContentType, cloudEvent.DataContentType);
             Assert.Equal(cloudEvent2.Data, cloudEvent.Data);
         }
@@ -56,11 +56,11 @@ namespace CloudNative.CloudEvents.Avro.UnitTests
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time!.Value);
             Assert.Equal(MediaTypeNames.Text.Xml, cloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
 
-            Assert.Equal("value", (string)cloudEvent["comexampleextension1"]);
+            Assert.Equal("value", (string?)cloudEvent["comexampleextension1"]);
         }
         
         [Fact]
@@ -77,7 +77,7 @@ namespace CloudNative.CloudEvents.Avro.UnitTests
             Assert.Equal("com.github.pull.create", cloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
             Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time!.Value);
             Assert.Equal(MediaTypeNames.Text.Xml, cloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
 

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventAttributeTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventAttributeTest.cs
@@ -67,11 +67,11 @@ namespace CloudNative.CloudEvents.UnitTests
 
         [Fact]
         public void CreateExtension_NullName() =>
-            Assert.Throws<ArgumentNullException>(() => CloudEventAttribute.CreateExtension(null, CloudEventAttributeType.String));
+            Assert.Throws<ArgumentNullException>(() => CloudEventAttribute.CreateExtension(null!, CloudEventAttributeType.String));
 
         [Fact]
         public void CreateExtension_NullType() =>
-            Assert.Throws<ArgumentNullException>(() => CloudEventAttribute.CreateExtension("name", null));
+            Assert.Throws<ArgumentNullException>(() => CloudEventAttribute.CreateExtension("name", null!));
 
         [Fact]
         public void CreateExtension_SpecVersionName() =>

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventAttributeTypeTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventAttributeTypeTest.cs
@@ -51,12 +51,12 @@ namespace CloudNative.CloudEvents.UnitTests
         [Theory]
         [MemberData(nameof(AllTypes))]
         public void ParseNull(CloudEventAttributeType type) =>
-            Assert.Throws<ArgumentNullException>(() => type.Parse(null));
+            Assert.Throws<ArgumentNullException>(() => type.Parse(null!));
 
         [Theory]
         [MemberData(nameof(AllTypes))]
         public void FormatNull(CloudEventAttributeType type) =>
-            Assert.Throws<ArgumentNullException>(() => type.Format(null));
+            Assert.Throws<ArgumentNullException>(() => type.Format(null!));
 
         // None of our types can be constructed with a StringBuilder.
         [Theory]

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventFormatterAttributeTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventFormatterAttributeTest.cs
@@ -35,7 +35,7 @@ namespace CloudNative.CloudEvents.UnitTests
         {
         }
 
-        [CloudEventFormatter(null)]
+        [CloudEventFormatter(null!)]
         public class NullFormatterAttribute
         {
         }
@@ -56,13 +56,13 @@ namespace CloudNative.CloudEvents.UnitTests
 
         public class SampleCloudEventFormatter : CloudEventFormatter
         {
-            public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(ReadOnlyMemory<byte> body, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes) =>
+            public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
                 throw new NotImplementedException();
 
             public override void DecodeBinaryModeEventData(ReadOnlyMemory<byte> body, CloudEvent cloudEvent) =>
                 throw new NotImplementedException();
 
-            public override CloudEvent DecodeStructuredModeMessage(ReadOnlyMemory<byte> body, ContentType contentType, IEnumerable<CloudEventAttribute> extensionAttributes) =>
+            public override CloudEvent DecodeStructuredModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
                 throw new NotImplementedException();
 
             public override ReadOnlyMemory<byte> EncodeBatchModeMessage(IEnumerable<CloudEvent> cloudEvents, out ContentType contentType) =>

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventTest.cs
@@ -37,7 +37,7 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal(MediaTypeNames.Text.Xml, cloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
 
-            Assert.Equal("value", (string)cloudEvent["comexampleextension1"]);
+            Assert.Equal("value", (string?)cloudEvent["comexampleextension1"]);
         }
 
         [Fact]
@@ -143,7 +143,7 @@ namespace CloudNative.CloudEvents.UnitTests
 
         [Fact]
         public void Constructor_NullVersion() =>
-            Assert.Throws<ArgumentNullException>(() => new CloudEvent(specVersion: null));
+            Assert.Throws<ArgumentNullException>(() => new CloudEvent(specVersion: null!));
 
         [Fact]
         public void Constructor_SpecVersionAndExtensionAttributes()
@@ -167,7 +167,7 @@ namespace CloudNative.CloudEvents.UnitTests
         [Fact]
         public void Constructor_ExtensionAttributes_NullValue()
         {
-            var extensions = new CloudEventAttribute[] { null };
+            var extensions = new CloudEventAttribute[] { null! };
             Assert.Throws<ArgumentException>(() => new CloudEvent(extensions));
         }
 
@@ -236,8 +236,8 @@ namespace CloudNative.CloudEvents.UnitTests
             Assert.Equal("text", cloudEvent["string"]);
             Assert.Equal(10, cloudEvent["integer"]);
             Assert.Equal(new byte[] { 77 }, cloudEvent["binary"]);
-            Assert.True((bool) cloudEvent["boolean"]);
-            AssertTimestampsEqual("2021-02-09T11:58:12.242Z", (DateTimeOffset) cloudEvent["timestamp"]);
+            Assert.True((bool) cloudEvent["boolean"]!);
+            AssertTimestampsEqual("2021-02-09T11:58:12.242Z", (DateTimeOffset) cloudEvent["timestamp"]!);
             Assert.Equal(new Uri("https://cloudevents.io"), cloudEvent["uri"]);
             Assert.Equal(new Uri("//auth", UriKind.RelativeOrAbsolute), cloudEvent["urireference"]);
         }
@@ -256,17 +256,17 @@ namespace CloudNative.CloudEvents.UnitTests
             var cloudEvent = new CloudEvent();
             cloudEvent.SetAttributeFromString("ext", "text");
             Assert.Equal("text", cloudEvent["ext"]);
-            Assert.Equal(CloudEventAttributeType.String, cloudEvent.GetAttribute("ext").Type);
+            Assert.Equal(CloudEventAttributeType.String, cloudEvent.GetAttribute("ext")!.Type);
         }
 
         [Fact]
         public void Indexer_NullKey_Throws()
         {
             var cloudEvent = new CloudEvent();
-            Assert.Throws<ArgumentNullException>(() => cloudEvent[(string)null]);
-            Assert.Throws<ArgumentNullException>(() => cloudEvent[(CloudEventAttribute)null]);
-            Assert.Throws<ArgumentNullException>(() => cloudEvent[(string)null] = "text");
-            Assert.Throws<ArgumentNullException>(() => cloudEvent[(CloudEventAttribute)null] = "text");
+            Assert.Throws<ArgumentNullException>(() => cloudEvent[(string)null!]);
+            Assert.Throws<ArgumentNullException>(() => cloudEvent[(CloudEventAttribute)null!]);
+            Assert.Throws<ArgumentNullException>(() => cloudEvent[(string)null!] = "text");
+            Assert.Throws<ArgumentNullException>(() => cloudEvent[(CloudEventAttribute)null!] = "text");
         }
 
         [Fact]
@@ -326,7 +326,7 @@ namespace CloudNative.CloudEvents.UnitTests
             {
                 var cloudEvent = new CloudEvent();
                 cloudEvent["ext"] = "10";
-                Assert.Equal(CloudEventAttributeType.String, cloudEvent.GetAttribute("ext").Type);
+                Assert.Equal(CloudEventAttributeType.String, cloudEvent.GetAttribute("ext")?.Type);
 
                 var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer);
                 // Setting the event with the attribute updates the extension registry...

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventsSpecVersionTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventsSpecVersionTest.cs
@@ -24,7 +24,7 @@ namespace CloudNative.CloudEvents.UnitTests
         {
             var version = CloudEventsSpecVersion.FromVersionId(versionId);
             Assert.NotNull(version);
-            Assert.Equal(versionId, version.VersionId);
+            Assert.Equal(versionId, version!.VersionId);
         }
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/CloudNative.CloudEvents.UnitTests.csproj
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudNative.CloudEvents.UnitTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/CloudNative.CloudEvents.UnitTests/Core/CloudEventAttributeTypesTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Core/CloudEventAttributeTypesTest.cs
@@ -22,7 +22,7 @@ namespace CloudNative.CloudEvents.Core.UnitTests
 
         [Fact]
         public void GetOrdinal_NullInput() =>
-            Assert.Throws<ArgumentNullException>(() => CloudEventAttributeTypes.GetOrdinal(null));
+            Assert.Throws<ArgumentNullException>(() => CloudEventAttributeTypes.GetOrdinal(null!));
 
         [Theory]
         [MemberData(nameof(AllTypes))]

--- a/test/CloudNative.CloudEvents.UnitTests/Core/MimeUtilitiesTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Core/MimeUtilitiesTest.cs
@@ -22,9 +22,9 @@ namespace CloudNative.CloudEvents.Core.UnitTests
         {
             var originalContentType = new ContentType(text);
             var header = MimeUtilities.ToMediaTypeHeaderValue(originalContentType);
-            AssertEqualParts(text, header.ToString());
+            AssertEqualParts(text, header!.ToString());
             var convertedContentType = MimeUtilities.ToContentType(header);
-            AssertEqualParts(originalContentType.ToString(), convertedContentType.ToString());
+            AssertEqualParts(originalContentType.ToString(), convertedContentType!.ToString());
 
             // Conversions can end up reordering the parameters. In reality we're only
             // likely to end up with a media type and charset, but our tests use more parameters.
@@ -57,7 +57,7 @@ namespace CloudNative.CloudEvents.Core.UnitTests
         [Fact]
         public void ContentTypeGetEncoding_NoContentType()
         {
-            ContentType contentType = null;
+            ContentType? contentType = null;
             Encoding encoding = MimeUtilities.GetEncoding(contentType);
             Assert.Equal(Encoding.UTF8, encoding);
         }
@@ -75,7 +75,7 @@ namespace CloudNative.CloudEvents.Core.UnitTests
         [InlineData("text/plain")]
         public void CreateContentTypeOrNull_WithContentType(string text)
         {
-            ContentType ct = MimeUtilities.CreateContentTypeOrNull(text);
+            ContentType? ct = MimeUtilities.CreateContentTypeOrNull(text);
             Assert.Equal(text, ct?.ToString());
         }
 

--- a/test/CloudNative.CloudEvents.UnitTests/DocumentationSamples.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/DocumentationSamples.cs
@@ -94,10 +94,10 @@ namespace CloudNative.CloudEvents.UnitTests
         public class GameResult
         {
             [JsonProperty("playerId")]
-            public string PlayerId { get; set; }
+            public string? PlayerId { get; set; }
 
             [JsonProperty("gameId")]
-            public string GameId { get; set; }
+            public string? GameId { get; set; }
 
             [JsonProperty("score")]
             public int Score { get; set; }
@@ -137,8 +137,8 @@ namespace CloudNative.CloudEvents.UnitTests
             // Sample: guide.md#DeserializeGameResult1
             CloudEventFormatter formatter = new JsonEventFormatter();
             CloudEvent cloudEvent = await request.ToCloudEventAsync(formatter);
-            JObject dataAsJObject = (JObject) cloudEvent.Data;
-            GameResult result = dataAsJObject.ToObject<GameResult>();
+            JObject dataAsJObject = (JObject) cloudEvent.Data!;
+            GameResult result = dataAsJObject.ToObject<GameResult>()!;
             // End sample
             return result;
         }
@@ -148,7 +148,7 @@ namespace CloudNative.CloudEvents.UnitTests
             // Sample: guide.md#DeserializeGameResult2
             CloudEventFormatter formatter = new JsonEventFormatter<GameResult>();
             CloudEvent cloudEvent = await request.ToCloudEventAsync(formatter);
-            GameResult result = (GameResult) cloudEvent.Data;
+            GameResult result = (GameResult) cloudEvent.Data!;
             // End sample
             return result;
         }

--- a/test/CloudNative.CloudEvents.UnitTests/Http/HttpClientExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Http/HttpClientExtensionsTest.cs
@@ -23,7 +23,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
 {
     public class HttpClientExtensionsTest : HttpTestBase
     {
-        public static TheoryData<string, HttpContent, IDictionary<string, string>> SingleCloudEventMessages => new TheoryData<string, HttpContent, IDictionary<string, string>>
+        public static TheoryData<string, HttpContent, IDictionary<string, string>?> SingleCloudEventMessages => new TheoryData<string, HttpContent, IDictionary<string, string>?>
         {
             {
                 "Binary",
@@ -43,7 +43,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
             }
         };
 
-        public static TheoryData<string, HttpContent, IDictionary<string, string>> BatchMessages => new TheoryData<string, HttpContent, IDictionary<string, string>>
+        public static TheoryData<string, HttpContent, IDictionary<string, string>?> BatchMessages => new TheoryData<string, HttpContent, IDictionary<string, string>?>
         {
             {
                 "Batch",
@@ -52,7 +52,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
             }
         };
 
-        public static TheoryData<string, HttpContent, IDictionary<string, string>> NonCloudEventMessages => new TheoryData<string, HttpContent, IDictionary<string, string>>
+        public static TheoryData<string, HttpContent, IDictionary<string, string>?> NonCloudEventMessages => new TheoryData<string, HttpContent, IDictionary<string, string>?>
         {
             {
                 "Plain text",
@@ -63,7 +63,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
 
         [Theory]
         [MemberData(nameof(SingleCloudEventMessages))]
-        public void IsCloudEvent_True(string description, HttpContent content, IDictionary<string, string> headers)
+        public void IsCloudEvent_True(string description, HttpContent content, IDictionary<string, string>? headers)
         {
             // Really only present for display purposes.
             Assert.NotNull(description);
@@ -80,7 +80,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
         [Theory]
         [MemberData(nameof(BatchMessages))]
         [MemberData(nameof(NonCloudEventMessages))]
-        public void IsCloudEvent_False(string description, HttpContent content, IDictionary<string, string> headers)
+        public void IsCloudEvent_False(string description, HttpContent content, IDictionary<string, string>? headers)
         {
             // Really only present for display purposes.
             Assert.NotNull(description);
@@ -96,7 +96,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
 
         [Theory]
         [MemberData(nameof(BatchMessages))]
-        public void IsCloudEventBatch_True(string description, HttpContent content, IDictionary<string, string> headers)
+        public void IsCloudEventBatch_True(string description, HttpContent content, IDictionary<string, string>? headers)
         {
             // Really only present for display purposes.
             Assert.NotNull(description);
@@ -113,7 +113,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
         [Theory]
         [MemberData(nameof(SingleCloudEventMessages))]
         [MemberData(nameof(NonCloudEventMessages))]
-        public void IsCloudEventBatch_False(string description, HttpContent content, IDictionary<string, string> headers)
+        public void IsCloudEventBatch_False(string description, HttpContent content, IDictionary<string, string>? headers)
         {
             // Really only present for display purposes.
             Assert.NotNull(description);
@@ -222,7 +222,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
             Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
             Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-            AssertTimestampsEqual(SampleTimestamp, receivedCloudEvent.Time.Value);
+            AssertTimestampsEqual(SampleTimestamp, receivedCloudEvent.Time!.Value);
             Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
 
@@ -316,7 +316,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
             Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
             Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-            AssertTimestampsEqual(SampleTimestamp, receivedCloudEvent.Time.Value);
+            AssertTimestampsEqual(SampleTimestamp, receivedCloudEvent.Time!.Value);
             Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
 
@@ -426,7 +426,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
             AssertBatchesEqual(batch, parsedBatch);
         }
 
-        internal static void CopyHeaders(IDictionary<string, string> source, HttpHeaders target)
+        internal static void CopyHeaders(IDictionary<string, string>? source, HttpHeaders target)
         {
             if (source is null)
             {

--- a/test/CloudNative.CloudEvents.UnitTests/Http/HttpListenerExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Http/HttpListenerExtensionsTest.cs
@@ -21,7 +21,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
     {
         [Theory]
         [MemberData(nameof(HttpClientExtensionsTest.SingleCloudEventMessages), MemberType = typeof(HttpClientExtensionsTest))]
-        public async Task IsCloudEvent_True(string description, HttpContent content, IDictionary<string, string> headers)
+        public async Task IsCloudEvent_True(string description, HttpContent content, IDictionary<string, string>? headers)
         {
             // Really only present for display purposes.
             Assert.NotNull(description);
@@ -35,7 +35,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
         [Theory]
         [MemberData(nameof(HttpClientExtensionsTest.BatchMessages), MemberType = typeof(HttpClientExtensionsTest))]
         [MemberData(nameof(HttpClientExtensionsTest.NonCloudEventMessages), MemberType = typeof(HttpClientExtensionsTest))]
-        public async Task IsCloudEvent_False(string description, HttpContent content, IDictionary<string, string> headers)
+        public async Task IsCloudEvent_False(string description, HttpContent content, IDictionary<string, string>? headers)
         {
             // Really only present for display purposes.
             Assert.NotNull(description);
@@ -48,7 +48,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
 
         [Theory]
         [MemberData(nameof(HttpClientExtensionsTest.BatchMessages), MemberType = typeof(HttpClientExtensionsTest))]
-        public async Task IsCloudEventBatch_True(string description, HttpContent content, IDictionary<string, string> headers)
+        public async Task IsCloudEventBatch_True(string description, HttpContent content, IDictionary<string, string>? headers)
         {
             // Really only present for display purposes.
             Assert.NotNull(description);
@@ -62,7 +62,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
         [Theory]
         [MemberData(nameof(HttpClientExtensionsTest.SingleCloudEventMessages), MemberType = typeof(HttpClientExtensionsTest))]
         [MemberData(nameof(HttpClientExtensionsTest.NonCloudEventMessages), MemberType = typeof(HttpClientExtensionsTest))]
-        public async Task IsCloudEventBatch_False(string description, HttpContent content, IDictionary<string, string> headers)
+        public async Task IsCloudEventBatch_False(string description, HttpContent content, IDictionary<string, string>? headers)
         {
             // Really only present for display purposes.
             Assert.NotNull(description);
@@ -201,7 +201,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
             Assert.Equal("1.0", response.Headers.GetValues("ce-specversion").Single());
             Assert.Equal(cloudEvent.Type, response.Headers.GetValues("ce-type").Single());
             Assert.Equal(cloudEvent.Id, response.Headers.GetValues("ce-id").Single());
-            Assert.Equal(CloudEventAttributeType.UriReference.Format(cloudEvent.Source), response.Headers.GetValues("ce-source").Single());
+            Assert.Equal(CloudEventAttributeType.UriReference.Format(cloudEvent.Source!), response.Headers.GetValues("ce-source").Single());
             // There's no data content type header; the content type itself is used for that.
             Assert.False(response.Headers.Contains("ce-datacontenttype"));
         }
@@ -251,7 +251,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
             Assert.Equal("1.0", response.Headers.GetValues("ce-specversion").Single());
             Assert.Equal(cloudEvent.Type, response.Headers.GetValues("ce-type").Single());
             Assert.Equal(cloudEvent.Id, response.Headers.GetValues("ce-id").Single());
-            Assert.Equal(CloudEventAttributeType.UriReference.Format(cloudEvent.Source), response.Headers.GetValues("ce-source").Single());
+            Assert.Equal(CloudEventAttributeType.UriReference.Format(cloudEvent.Source!), response.Headers.GetValues("ce-source").Single());
             // We don't populate the data content type header
             Assert.False(response.Headers.Contains("ce-datacontenttype"));
         }
@@ -299,7 +299,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
             var content = await response.Content.ReadAsStringAsync();
             Assert.True(response.IsSuccessStatusCode, content);
             Assert.True(executed);
-            return result;
+            return result!;
         }
 
         /// <summary>

--- a/test/CloudNative.CloudEvents.UnitTests/Http/HttpWebExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Http/HttpWebExtensionsTest.cs
@@ -150,7 +150,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
             using var response = (HttpWebResponse) await request.GetResponseAsync();
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
             Assert.True(executed);
-            return result;
+            return result!;
         }
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/Mqtt/MqttTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Mqtt/MqttTest.cs
@@ -72,11 +72,11 @@ namespace CloudNative.CloudEvents.Mqtt.UnitTests
             Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
             Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-            AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time.Value);
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time!.Value);
             Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
 
-            Assert.Equal("value", (string)receivedCloudEvent["comexampleextension1"]);
+            Assert.Equal("value", (string?)receivedCloudEvent["comexampleextension1"]);
         }
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/AttributedModel.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/AttributedModel.cs
@@ -12,6 +12,6 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
         public const string JsonPropertyName = "customattribute";
 
         [JsonProperty(JsonPropertyName)]
-        public string AttributedProperty { get; set; }
+        public string? AttributedProperty { get; set; }
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/JTokenAsserter.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/JTokenAsserter.cs
@@ -13,7 +13,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
 
     internal class JTokenAsserter : IEnumerable
     {
-        private readonly List<(string name, JTokenType type, object value)> expectations = new List<(string, JTokenType, object)>();
+        private readonly List<(string name, JTokenType type, object? value)> expectations = new List<(string, JTokenType, object?)>();
 
         // Just for collection initializers
         public IEnumerator GetEnumerator() => throw new NotImplementedException();
@@ -21,14 +21,15 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
         public void Add<T>(string name, JTokenType type, T value) =>
             expectations.Add((name, type, value));
 
-        public void AssertProperties(JObject obj, bool assertCount)
+        public void AssertProperties(JObject? obj, bool assertCount)
         {
+            Assert.NotNull(obj);
             foreach (var expectation in expectations)
             {
                 Assert.True(
-                    obj.TryGetValue(expectation.name, out var token),
+                    obj!.TryGetValue(expectation.name, out var token),
                     $"Expected property '{expectation.name}' to be present");
-                Assert.Equal(expectation.type, token.Type);
+                Assert.Equal(expectation.type, token!.Type);
                 // No need to check null values, as they'll have a null token type.
                 if (expectation.value is object)
                 {
@@ -37,7 +38,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
             }
             if (assertCount)
             {
-                Assert.Equal(expectations.Count, obj.Count);
+                Assert.Equal(expectations.Count, obj!.Count);
             }
         }
     }

--- a/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/JsonEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/JsonEventFormatterTest.cs
@@ -97,7 +97,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
             cloudEvent.Data = new { Text = "simple text" };
             cloudEvent.DataContentType = "application/json";
             JObject obj = EncodeAndParseStructured(cloudEvent);
-            JObject dataProperty = (JObject) obj["data"];
+            JObject dataProperty = (JObject) obj["data"]!;
             var asserter = new JTokenAsserter
             {
                 { "Text", JTokenType.String, "simple text" }
@@ -119,7 +119,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
             var formatter = new JsonEventFormatter(serializer);
             var encoded = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
             JObject obj = ParseJson(encoded);
-            JObject dataProperty = (JObject) obj["data"];
+            JObject dataProperty = (JObject) obj["data"]!;
             var asserter = new JTokenAsserter
             {
                 { "DateValue", JTokenType.String, "2021-02-19" }
@@ -134,7 +134,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
             cloudEvent.Data = new AttributedModel { AttributedProperty = "simple text" };
             cloudEvent.DataContentType = "application/json";
             JObject obj = EncodeAndParseStructured(cloudEvent);
-            JObject dataProperty = (JObject) obj["data"];
+            JObject dataProperty = (JObject) obj["data"]!;
             var asserter = new JTokenAsserter
             {
                 { AttributedModel.JsonPropertyName, JTokenType.String, "simple text" }
@@ -149,7 +149,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
             cloudEvent.Data = new JValue(100);
             cloudEvent.DataContentType = "application/json";
             JObject obj = EncodeAndParseStructured(cloudEvent);
-            JToken data = obj["data"];
+            JToken data = obj["data"]!;
             Assert.Equal(JTokenType.Integer, data.Type);
             Assert.Equal(100, (int) data);
         }
@@ -171,9 +171,9 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
             cloudEvent.Data = "some text";
             cloudEvent.DataContentType = "text/anything";
             JObject obj = EncodeAndParseStructured(cloudEvent);
-            var dataProperty = obj["data"];
+            var dataProperty = obj["data"]!;
             Assert.Equal(JTokenType.String, dataProperty.Type);
-            Assert.Equal("some text", (string) dataProperty);
+            Assert.Equal("some text", (string?) dataProperty);
         }
 
         // A text content type with bytes as data is serialized like any other bytes.
@@ -185,9 +185,9 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
             cloudEvent.DataContentType = "text/anything";
             JObject obj = EncodeAndParseStructured(cloudEvent);
             Assert.False(obj.ContainsKey("data"));
-            var dataBase64 = obj["data_base64"];
+            var dataBase64 = obj["data_base64"]!;
             Assert.Equal(JTokenType.String, dataBase64.Type);
-            Assert.Equal(SampleBinaryDataBase64, (string) dataBase64);
+            Assert.Equal(SampleBinaryDataBase64, (string?) dataBase64);
         }
 
         [Fact]
@@ -208,9 +208,9 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
             cloudEvent.DataContentType = "not_text/or_json";
             JObject obj = EncodeAndParseStructured(cloudEvent);
             Assert.False(obj.ContainsKey("data"));
-            var dataBase64 = obj["data_base64"];
+            var dataBase64 = obj["data_base64"]!;
             Assert.Equal(JTokenType.String, dataBase64.Type);
-            Assert.Equal(SampleBinaryDataBase64, (string) dataBase64);
+            Assert.Equal(SampleBinaryDataBase64, (string?) dataBase64);
         }
 
         [Fact]
@@ -407,7 +407,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
             // Invalid CloudEvent
             Assert.Throws<ArgumentException>(() => formatter.EncodeBatchModeMessage(new[] { new CloudEvent() }, out _));
             // Null argument
-            Assert.Throws<ArgumentNullException>(() => formatter.EncodeBatchModeMessage(null, out _));
+            Assert.Throws<ArgumentNullException>(() => formatter.EncodeBatchModeMessage(null!, out _));
             // Null value within the argument. Arguably this should throw ArgumentException instead of
             // ArgumentNullException, but it's unlikely to cause confusion.
             Assert.Throws<ArgumentNullException>(() => formatter.EncodeBatchModeMessage(new CloudEvent[1], out _));
@@ -570,10 +570,10 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
             var formatter = new JsonEventFormatter();
             var cloudEvent = formatter.DecodeStructuredModeMessage(bytes, s_jsonCloudEventContentType, AllTypesExtensions);
             Assert.Equal(SampleBinaryData, cloudEvent["binary"]);
-            Assert.True((bool) cloudEvent["boolean"]);
+            Assert.True((bool) cloudEvent["boolean"]!);
             Assert.Equal(10, cloudEvent["integer"]);
             Assert.Equal("text", cloudEvent["string"]);
-            AssertTimestampsEqual(SampleTimestamp, (DateTimeOffset) cloudEvent["timestamp"]);
+            AssertTimestampsEqual(SampleTimestamp, (DateTimeOffset) cloudEvent["timestamp"]!);
             Assert.Equal(SampleUri, cloudEvent["uri"]);
             Assert.Equal(SampleUriReference, cloudEvent["urireference"]);
         }
@@ -694,8 +694,8 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
             }
             obj["data"] = 10;
             var cloudEvent = DecodeStructuredModeMessage(obj);
-            var token = (JToken) cloudEvent.Data;
-            Assert.Equal(JTokenType.Integer, token.Type);
+            var token = (JToken) cloudEvent.Data!;
+            Assert.Equal(JTokenType.Integer, token!.Type);
             Assert.Equal(10, (int) token);
         }
 
@@ -876,7 +876,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
             Assert.Null(event2.DataContentType);
         }
 
-        private static object DecodeBinaryModeEventData(byte[] bytes, string contentType)
+        private static object? DecodeBinaryModeEventData(byte[] bytes, string contentType)
         {
             var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
             cloudEvent.DataContentType = contentType;
@@ -912,7 +912,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
             {
                 DateParseHandling = DateParseHandling.None                
             };
-            return serializer.Deserialize<T>(new JsonTextReader(new StringReader(text)));                
+            return serializer.Deserialize<T>(new JsonTextReader(new StringReader(text)))!;
         }
 
 

--- a/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/SpecializedFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/SpecializedFormatterTest.cs
@@ -118,9 +118,10 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
             Assert.Equal("some text", cloudEvent.Data);
         }
 
-        private static void AssertToken(JTokenType expectedType, object expectedValue, JToken token)
+        private static void AssertToken(JTokenType expectedType, object expectedValue, JToken? token)
         {
-            Assert.Equal(expectedType, token.Type);
+            Assert.NotNull(token);
+            Assert.Equal(expectedType, token!.Type);
             Assert.Equal(expectedValue, token.ToObject(expectedValue.GetType()));
         }
 
@@ -157,7 +158,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
             {
                 if (cloudEvent.DataContentType == TextBinaryContentType && dataBase64Token.Type == JTokenType.String)
                 {
-                    cloudEvent.Data = Encoding.UTF8.GetString(Convert.FromBase64String((string)dataBase64Token));
+                    cloudEvent.Data = Encoding.UTF8.GetString(Convert.FromBase64String((string)dataBase64Token!));
                 }
                 else
                 {
@@ -169,7 +170,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
             {
                 if (cloudEvent.DataContentType == GuidContentType && dataToken.Type == JTokenType.String)
                 {
-                    string text = (string)dataToken;
+                    string text = (string)dataToken!;
                     if (!text.StartsWith(GuidPrefix))
                     {
                         throw new ArgumentException("Invalid GUID text data");

--- a/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/SpecializedJsonReaderTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/SpecializedJsonReaderTest.cs
@@ -35,8 +35,8 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
             var event1 = formatter.DecodeStructuredModeMessage(CreateJsonStream(), null, null);
             var event2 = formatter.DecodeStructuredModeMessage(CreateJsonStream(), null, null);
 
-            JObject data1 = (JObject)event1.Data;
-            JObject data2 = (JObject)event2.Data;
+            JObject data1 = (JObject)event1.Data!;
+            JObject data2 = (JObject)event2.Data!;
 
             var property1 = data1.Properties().Single();
             var property2 = data2.Properties().Single();
@@ -51,8 +51,8 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
             var event1 = formatter.DecodeStructuredModeMessage(CreateJsonStream(), null, null);
             var event2 = formatter.DecodeStructuredModeMessage(CreateJsonStream(), null, null);
 
-            JObject data1 = (JObject)event1.Data;
-            JObject data2 = (JObject)event2.Data;
+            JObject data1 = (JObject)event1.Data!;
+            JObject data2 = (JObject)event2.Data!;
 
             var property1 = data1.Properties().Single();
             var property2 = data2.Properties().Single();
@@ -72,7 +72,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
 
         private class CreateJsonReaderExposingFormatter : JsonEventFormatter
         {
-            public JsonReader CreateJsonReaderPublic(Stream stream, Encoding encoding) =>
+            public JsonReader CreateJsonReaderPublic(Stream stream, Encoding? encoding) =>
                 base.CreateJsonReader(stream, encoding);
         }
 
@@ -87,7 +87,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
                 table.Add("DataName");
             }
 
-            protected override JsonReader CreateJsonReader(Stream stream, Encoding encoding)
+            protected override JsonReader CreateJsonReader(Stream stream, Encoding? encoding)
             {
                 var reader = (JsonTextReader) base.CreateJsonReader(stream, encoding);
                 reader.PropertyNameTable = table;

--- a/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/AttributedModel.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/AttributedModel.cs
@@ -12,6 +12,6 @@ namespace CloudNative.CloudEvents.SystemTextJson.UnitTests
         public const string JsonPropertyName = "customattribute";
 
         [JsonPropertyName(JsonPropertyName)]
-        public string AttributedProperty { get; set; }
+        public string? AttributedProperty { get; set; }
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/JsonElementAsserter.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/JsonElementAsserter.cs
@@ -13,7 +13,7 @@ namespace CloudNative.CloudEvents.SystemTextJson.UnitTests
 {
     internal class JsonElementAsserter : IEnumerable
     {
-        private readonly List<(string name, JsonValueKind type, object value)> expectations = new List<(string, JsonValueKind, object)>();
+        private readonly List<(string name, JsonValueKind type, object? value)> expectations = new List<(string, JsonValueKind, object?)>();
 
         // Just for collection initializers
         public IEnumerator GetEnumerator() => throw new NotImplementedException();
@@ -38,7 +38,7 @@ namespace CloudNative.CloudEvents.SystemTextJson.UnitTests
                         JsonValueKind.False => false,
                         JsonValueKind.String => property.GetString(),
                         JsonValueKind.Number => property.GetInt32(),
-                        JsonValueKind.Null => (object) null,
+                        JsonValueKind.Null => (object?) null,
                         _ => throw new Exception($"Unhandled value kind: {property.ValueKind}")
                     };
 

--- a/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/JsonEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/JsonEventFormatterTest.cs
@@ -417,7 +417,7 @@ namespace CloudNative.CloudEvents.SystemTextJson.UnitTests
             // Invalid CloudEvent
             Assert.Throws<ArgumentException>(() => formatter.EncodeBatchModeMessage(new[] { new CloudEvent() }, out _));
             // Null argument
-            Assert.Throws<ArgumentNullException>(() => formatter.EncodeBatchModeMessage(null, out _));
+            Assert.Throws<ArgumentNullException>(() => formatter.EncodeBatchModeMessage(null!, out _));
             // Null value within the argument. Arguably this should throw ArgumentException instead of
             // ArgumentNullException, but it's unlikely to cause confusion.
             Assert.Throws<ArgumentNullException>(() => formatter.EncodeBatchModeMessage(new CloudEvent[1], out _));
@@ -591,10 +591,10 @@ namespace CloudNative.CloudEvents.SystemTextJson.UnitTests
             var formatter = new JsonEventFormatter();
             var cloudEvent = formatter.DecodeStructuredModeMessage(bytes, s_jsonCloudEventContentType, AllTypesExtensions);
             Assert.Equal(SampleBinaryData, cloudEvent["binary"]);
-            Assert.True((bool)cloudEvent["boolean"]);
+            Assert.True((bool)cloudEvent["boolean"]!);
             Assert.Equal(10, cloudEvent["integer"]);
             Assert.Equal("text", cloudEvent["string"]);
-            AssertTimestampsEqual(SampleTimestamp, (DateTimeOffset)cloudEvent["timestamp"]);
+            AssertTimestampsEqual(SampleTimestamp, (DateTimeOffset)cloudEvent["timestamp"]!);
             Assert.Equal(SampleUri, cloudEvent["uri"]);
             Assert.Equal(SampleUriReference, cloudEvent["urireference"]);
         }
@@ -715,7 +715,7 @@ namespace CloudNative.CloudEvents.SystemTextJson.UnitTests
             }
             obj["data"] = 10;
             var cloudEvent = DecodeStructuredModeMessage(obj);
-            var element = (JsonElement) cloudEvent.Data;
+            var element = (JsonElement) cloudEvent.Data!;
             Assert.Equal(JsonValueKind.Number, element.ValueKind);
             Assert.Equal(10, element.GetInt32());
         }
@@ -915,7 +915,7 @@ namespace CloudNative.CloudEvents.SystemTextJson.UnitTests
             var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
             cloudEvent.DataContentType = contentType;
             new JsonEventFormatter().DecodeBinaryModeEventData(bytes, cloudEvent);
-            return cloudEvent.Data;
+            return cloudEvent.Data!;
         }
 
         internal static JObject CreateMinimalValidJObject() =>

--- a/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/SpecializedFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/SpecializedFormatterTest.cs
@@ -170,7 +170,7 @@ namespace CloudNative.CloudEvents.SystemTextJson.UnitTests
             {
                 if (cloudEvent.DataContentType == GuidContentType && dataElement.ValueKind == JsonValueKind.String)
                 {
-                    string text = dataElement.GetString();
+                    string text = dataElement.GetString()!;
                     if (!text.StartsWith(GuidPrefix))
                     {
                         throw new ArgumentException("Invalid GUID text data");

--- a/test/CloudNative.CloudEvents.UnitTests/TestHelpers.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/TestHelpers.cs
@@ -150,7 +150,7 @@ namespace CloudNative.CloudEvents.UnitTests
             {
                 Assert.True(false, "Expected both values to be null, or neither to be null");
             }
-            AssertTimestampsEqual(expected.Value, actual.Value);
+            AssertTimestampsEqual(expected!.Value, actual!.Value);
         }
 
         // TODO: Use this more widely


### PR DESCRIPTION
Fixes #170.

As ever, the intention is to review one commit at a time.

This is mostly pretty straightforward, but please review carefully. (At least aside from the unit test project - that doesn't matter nearly as much in terms of "theoretical" safety.)

There's one thorny part, which is the Kafka message: because we may not have a partitioning key, everything is done in terms of `Message<string?, byte[]>`... but that means the `ToCloudEvent` (etc) methods don't work when you have an actual `Message<string, byte[]>`. You can cast, of course, but it's a bit ugly.