### PR TITLE
All packages release version 2.1.0

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,22 @@
 # Version history (from 2.0)
 
+## 2.1 (2021-07-14)
+
+New features:
+
+- Nullable reference type annotations ([#170](https://github.com/cloudevents/sdk-csharp/issues/170))
+- More batch support for HttpListener ([#166](https://github.com/cloudevents/sdk-csharp/issues/166))
+- CloudEvent.CopyToHttpResponse extension method (part of [#148](https://github.com/cloudevents/sdk-csharp/issues/148))
+
+Other improvements:
+
+- More informative error message for non-CE HTTP requests ([#165](https://github.com/cloudevents/sdk-csharp/issues/165))
+
+Bug fixes:
+
+- Various small XML docs typos ([commit](https://github.com/cloudevents/sdk-csharp/commit/626089ea1e5bb6741868aeb389cb4d314e9e72ed))
+- Don't set the content type to JSON in HttpListener when it's not set in the CloudEvent ([commit](https://github.com/cloudevents/sdk-csharp/commit/18e13635fe333b24432ac34d9ef040cd962d1063))
+
 ## 2.0 (2021-06-15)
 
 Initial GA release for 2.x. See the ["changes since 1.x"

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,10 +1,10 @@
 <Project>
   <PropertyGroup>
     <!-- 
-      - During beta, we use the same version number for all
+      - We use the same version number for all stable
       - packages. See PROCESSES.md for details.
       -->
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     
     <!-- Make the repository root available for other properties -->
     <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))</RepoRoot>


### PR DESCRIPTION
New features:

- Nullable reference type annotations ([#170](https://github.com/cloudevents/sdk-csharp/issues/170))
- More batch support for HttpListener ([#166](https://github.com/cloudevents/sdk-csharp/issues/166))
- CloudEvent.CopyToHttpResponse extension method (part of [#148](https://github.com/cloudevents/sdk-csharp/issues/148))

Other improvements:

- More informative error message for non-CE HTTP requests ([#165](https://github.com/cloudevents/sdk-csharp/issues/165))

Bug fixes:

- Various small XML docs typos ([commit](https://github.com/cloudevents/sdk-csharp/commit/626089ea1e5bb6741868aeb389cb4d314e9e72ed))
- Don't set the content type to JSON in HttpListener when it's not set in the CloudEvent ([commit](https://github.com/cloudevents/sdk-csharp/commit/18e13635fe333b24432ac34d9ef040cd962d1063))

Signed-off-by: Jon Skeet <jonskeet@google.com>