### PR TITLE
"Nullable" package should be added as a development dependency

### DIFF
--- a/src/CloudNative.CloudEvents/CloudNative.CloudEvents.csproj
+++ b/src/CloudNative.CloudEvents/CloudNative.CloudEvents.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <!-- Source-only package with nullable reference annotations. -->
-    <PackageReference Include="Nullable" Version="1.3.0" />
+    <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Based on the [doc](https://github.com/manuelroemer/Nullable#quickstart) of **Nullable** package:

This package should be added as a development dependency.
