### PR TITLE
All packages release 2.1.1

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -1,6 +1,15 @@
 # Version history (from 2.0)
 
-## 2.1 (2021-07-14)
+## 2.1.1 (2021-07-21)
+
+Bug fix ([#77](https://github.com/cloudevents/sdk-csharp/pull/177)): dependency on the
+`Nullable` package was not declared with `PrivateAssets=all`,
+leading to that showing up as a dependency. This would break users
+who explicitly have a dependency on an older version of `Nullable`.
+
+This fix shouldn't break anyone, as far as we're aware.
+
+## 2.1.0 (2021-07-14)
 
 New features:
 
@@ -17,7 +26,7 @@ Bug fixes:
 - Various small XML docs typos ([commit](https://github.com/cloudevents/sdk-csharp/commit/626089ea1e5bb6741868aeb389cb4d314e9e72ed))
 - Don't set the content type to JSON in HttpListener when it's not set in the CloudEvent ([commit](https://github.com/cloudevents/sdk-csharp/commit/18e13635fe333b24432ac34d9ef040cd962d1063))
 
-## 2.0 (2021-06-15)
+## 2.0.0 (2021-06-15)
 
 Initial GA release for 2.x. See the ["changes since 1.x"
 document](changes-since-1x.md) for more detail around what has

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
       - We use the same version number for all stable
       - packages. See PROCESSES.md for details.
       -->
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     
     <!-- Make the repository root available for other properties -->
     <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))</RepoRoot>


### PR DESCRIPTION
Bug fix ([#77](https://github.com/cloudevents/sdk-csharp/pull/177)): dependency on the
`Nullable` package was not declared with `PrivateAssets=all`,
leading to that showing up as a dependency. This would break users
who explicitly have a dependency on an older version of `Nullable`.

This fix shouldn't break anyone, as far as we're aware.

Signed-off-by: Jon Skeet <jonskeet@google.com>