### PR TITLE
Update guide.md - correct NuGet package name

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -19,7 +19,7 @@ unnecessary dependencies. These packages are:
 |[CloudNative.CloudEvents.Kafka](https://www.nuget.org/packages/CloudNative.CloudEvents.Kafka)|Kafka protocol binding using [Confluent.Kafka](https://www.nuget.org/packages/Confluent.Kafka)|
 |[CloudNative.CloudEvents.Mqtt](https://www.nuget.org/packages/CloudNative.CloudEvents.Mqtt)|MQTT protocol binding using [MQTTnet](https://www.nuget.org/packages/MQTTnet)|
 |[CloudNative.CloudEvents.NewtonsoftJson](https://www.nuget.org/packages/CloudNative.CloudEvents.NewtonsoftJson)|JSON event formatter using [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json)|
-|[CloudNative.CloudEvents.System.Text.Json](https://www.nuget.org/packages/CloudNative.CloudEvents.SystemTextJson)|JSON event formatter using [System.Text.Json](https://www.nuget.org/packages/System.Text.Json)|
+|[CloudNative.CloudEvents.SystemTextJson](https://www.nuget.org/packages/CloudNative.CloudEvents.SystemTextJson)|JSON event formatter using [System.Text.Json](https://www.nuget.org/packages/System.Text.Json)|
 
 Note that protocol bindings for HTTP using `HttpRequestMessage`,
 `HttpResponseMessage`, `HttpContent`, `HttpListenerRequest`,


### PR DESCRIPTION
Minor fix - the name of the event formatter should be `CloudNative.CloudEvents.SystemTextJson` and not `CloudNative.CloudEvents.System.Text.Json`