### PR TITLE
Protocol bindings for AWS SNS publication, AWS SQS consumption.

### DIFF
--- a/CloudEvents.sln
+++ b/CloudEvents.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29001.49
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32014.148
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CloudNative.CloudEvents", "src\CloudNative.CloudEvents\CloudNative.CloudEvents.csproj", "{C5DC9F44-7C03-4A70-80EF-7A29696455EB}"
 EndProject
@@ -33,7 +33,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CloudNative.CloudEvents.Avr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CloudNative.CloudEvents.NewtonsoftJson", "src\CloudNative.CloudEvents.NewtonsoftJson\CloudNative.CloudEvents.NewtonsoftJson.csproj", "{9DC17081-21D8-4123-8650-D97C2153DB8C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CloudNative.CloudEvents.SystemTextJson", "src\CloudNative.CloudEvents.SystemTextJson\CloudNative.CloudEvents.SystemTextJson.csproj", "{FACB3EF2-F078-479A-A91C-719894CB66BF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CloudNative.CloudEvents.SystemTextJson", "src\CloudNative.CloudEvents.SystemTextJson\CloudNative.CloudEvents.SystemTextJson.csproj", "{FACB3EF2-F078-479A-A91C-719894CB66BF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CloudNative.CloudEvents.AwsSns", "src\CloudNative.CloudEvents.AwsSns\CloudNative.CloudEvents.AwsSns.csproj", "{CAE57A21-D672-4908-9CFF-BD6E092BDC32}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CloudNative.CloudEvents.AwsSqs", "src\CloudNative.CloudEvents.AwsSqs\CloudNative.CloudEvents.AwsSqs.csproj", "{D6D46207-1DFF-4CBA-A8C2-1F64981E033B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -189,6 +193,30 @@ Global
 		{FACB3EF2-F078-479A-A91C-719894CB66BF}.Release|x64.Build.0 = Release|Any CPU
 		{FACB3EF2-F078-479A-A91C-719894CB66BF}.Release|x86.ActiveCfg = Release|Any CPU
 		{FACB3EF2-F078-479A-A91C-719894CB66BF}.Release|x86.Build.0 = Release|Any CPU
+		{CAE57A21-D672-4908-9CFF-BD6E092BDC32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CAE57A21-D672-4908-9CFF-BD6E092BDC32}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CAE57A21-D672-4908-9CFF-BD6E092BDC32}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CAE57A21-D672-4908-9CFF-BD6E092BDC32}.Debug|x64.Build.0 = Debug|Any CPU
+		{CAE57A21-D672-4908-9CFF-BD6E092BDC32}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CAE57A21-D672-4908-9CFF-BD6E092BDC32}.Debug|x86.Build.0 = Debug|Any CPU
+		{CAE57A21-D672-4908-9CFF-BD6E092BDC32}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CAE57A21-D672-4908-9CFF-BD6E092BDC32}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CAE57A21-D672-4908-9CFF-BD6E092BDC32}.Release|x64.ActiveCfg = Release|Any CPU
+		{CAE57A21-D672-4908-9CFF-BD6E092BDC32}.Release|x64.Build.0 = Release|Any CPU
+		{CAE57A21-D672-4908-9CFF-BD6E092BDC32}.Release|x86.ActiveCfg = Release|Any CPU
+		{CAE57A21-D672-4908-9CFF-BD6E092BDC32}.Release|x86.Build.0 = Release|Any CPU
+		{D6D46207-1DFF-4CBA-A8C2-1F64981E033B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6D46207-1DFF-4CBA-A8C2-1F64981E033B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6D46207-1DFF-4CBA-A8C2-1F64981E033B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D6D46207-1DFF-4CBA-A8C2-1F64981E033B}.Debug|x64.Build.0 = Debug|Any CPU
+		{D6D46207-1DFF-4CBA-A8C2-1F64981E033B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D6D46207-1DFF-4CBA-A8C2-1F64981E033B}.Debug|x86.Build.0 = Debug|Any CPU
+		{D6D46207-1DFF-4CBA-A8C2-1F64981E033B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6D46207-1DFF-4CBA-A8C2-1F64981E033B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D6D46207-1DFF-4CBA-A8C2-1F64981E033B}.Release|x64.ActiveCfg = Release|Any CPU
+		{D6D46207-1DFF-4CBA-A8C2-1F64981E033B}.Release|x64.Build.0 = Release|Any CPU
+		{D6D46207-1DFF-4CBA-A8C2-1F64981E033B}.Release|x86.ActiveCfg = Release|Any CPU
+		{D6D46207-1DFF-4CBA-A8C2-1F64981E033B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
@@ -171,6 +171,10 @@ namespace CloudNative.CloudEvents
             throw new NotSupportedException("The Avro event formatter does not support binary content mode");
 
         /// <inheritdoc />
+        public override ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent, out ContentType contentType) =>
+            throw new NotSupportedException("The Avro event formatter does not support binary content mode");
+
+        /// <inheritdoc />
         public override void DecodeBinaryModeEventData(ReadOnlyMemory<byte> body, CloudEvent cloudEvent) =>
             throw new NotSupportedException("The Avro event formatter does not support binary content mode");
     }

--- a/src/CloudNative.CloudEvents.AwsSns/CloudNative.CloudEvents.AwsSns.csproj
+++ b/src/CloudNative.CloudEvents.AwsSns/CloudNative.CloudEvents.AwsSns.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+		<Description>AWS SNS extensions for CloudNative.CloudEvents</Description>
+		<PackageTags>cncf;cloudnative;cloudevents;events;aws;sns</PackageTags>
+		<LangVersion>8.0</LangVersion>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.10" />
+		<ProjectReference Include="..\CloudNative.CloudEvents\CloudNative.CloudEvents.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/CloudNative.CloudEvents.AwsSns/SnsPublishRequestExtensions.cs
+++ b/src/CloudNative.CloudEvents.AwsSns/SnsPublishRequestExtensions.cs
@@ -1,0 +1,188 @@
+﻿// Copyright (c) Cloud Native Foundation.
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Mime;
+using Amazon.SimpleNotificationService.Model;
+using CloudNative.CloudEvents.Core;
+
+namespace CloudNative.CloudEvents.AwsSns
+{
+    /// <summary>
+    ///     Extension methods to convert between CloudEvents and AWS.SNS request.
+    /// </summary>
+    public static class SnsPublishRequestExtensions
+    {
+        /// <summary>
+        ///     Message attribute key for ContentType
+        /// </summary>
+        public const string ContentTypeAttributeKey = "content-type";
+
+        /// <summary>
+        ///     Message attribute key for SpecVersion
+        /// </summary>
+        public const string SpecVersionAttributeKey = "spec-version";
+
+        /// <summary>
+        ///     A prefix for cloud event attributes keys to distinguish them from other.
+        /// </summary>
+        public const string CloudEventAttributeKeyPrefix = "cloud_event_";
+
+        /// <summary>
+        ///     Converts <see cref="CloudEvent" /> into new instance of <see cref="PublishRequest" />.
+        /// </summary>
+        /// <param name="cloudEvent">The CloudEvent to convert. Must not be null, and must be a valid CloudEvent.</param>
+        /// <param name="contentMode">Content mode. Structured or binary.</param>
+        /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
+        /// <returns>New instance of <see cref="PublishRequest" /></returns>
+        public static PublishRequest ToSnsPublishRequest(
+            this CloudEvent cloudEvent,
+            ContentMode contentMode,
+            CloudEventFormatter formatter)
+        {
+            return cloudEvent.CopyToSnsPublishRequest(new PublishRequest(), contentMode, formatter);
+        }
+
+        /// <summary>
+        ///     Assign <see cref="CloudEvent" /> to existing instance of <see cref="PublishRequest" />.
+        /// </summary>
+        /// <param name="publishRqRequest">The instance of PublishRequest to which serialized cloud event data will be assigned.</param>
+        /// <param name="cloudEvent">The CloudEvent to convert. Must not be null, and must be a valid CloudEvent.</param>
+        /// <param name="contentMode">Content mode. Structured or binary.</param>
+        /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
+        /// <returns>
+        ///     <see cref="PublishRequest" />
+        /// </returns>
+        public static PublishRequest CopyToSnsPublishRequest(
+            this CloudEvent cloudEvent,
+            PublishRequest publishRqRequest,
+            ContentMode contentMode,
+            CloudEventFormatter formatter)
+        {
+            Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
+            Validation.CheckNotNull(publishRqRequest, nameof(publishRqRequest));
+            Validation.CheckNotNull(formatter, nameof(formatter));
+
+            var message = Serialize(cloudEvent, contentMode, formatter);
+
+            publishRqRequest.Message = message.Message;
+            publishRqRequest.MessageStructure = "String";
+
+            foreach (var messageAttribute in message.MessageAttributes)
+            {
+                publishRqRequest.MessageAttributes.Add(messageAttribute.Key, messageAttribute.Value);
+            }
+
+            return publishRqRequest;
+        }
+
+        /// <summary>
+        ///     Serialize CloudEvent
+        /// </summary>
+        /// <param name="cloudEvent">The CloudEvent to convert. Must not be null, and must be a valid CloudEvent.</param>
+        /// <param name="contentMode">Content mode. Structured or binary.</param>
+        /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
+        /// <returns></returns>
+        public static (string Message, Dictionary<string, MessageAttributeValue> MessageAttributes) Serialize(
+            CloudEvent cloudEvent,
+            ContentMode contentMode,
+            CloudEventFormatter formatter)
+        {
+            if (contentMode == ContentMode.Structured)
+            {
+                return SerializeInStructuredMode(cloudEvent, formatter);
+            }
+
+            return SerializeInBinaryMode(cloudEvent, formatter);
+        }
+
+        private static (string Message, Dictionary<string, MessageAttributeValue> MessageAttributes)
+            SerializeInStructuredMode(
+                CloudEvent cloudEvent,
+                CloudEventFormatter formatter)
+        {
+            var bytesRepresentation =
+                BinaryDataUtilities.AsArray(formatter.EncodeStructuredModeMessage(cloudEvent, out var contentType));
+
+            var encoding = MimeUtilities.GetEncoding(contentType);
+
+            var message = encoding.GetString(bytesRepresentation);
+
+            var messageAttributes = new Dictionary<string, MessageAttributeValue>()
+                .AddContentTypeAttribute(contentType);
+
+            return (Message: message, MessageAttributes: messageAttributes);
+        }
+
+        private static (string Message, Dictionary<string, MessageAttributeValue> MessageAttributes)
+            SerializeInBinaryMode(
+                CloudEvent cloudEvent,
+                CloudEventFormatter formatter)
+        {
+            var bytesRepresentation =
+                BinaryDataUtilities.AsArray(formatter.EncodeBinaryModeEventData(cloudEvent, out var contentType));
+
+            var message = Convert.ToBase64String(bytesRepresentation);
+
+            var messageAttributes = new Dictionary<string, MessageAttributeValue>()
+                .AddContentTypeAttribute(contentType)
+                .AddSpecVersionAttribute(cloudEvent)
+                .AddCloudEventAttributes(cloudEvent);
+
+            return (Message: message, MessageAttributes: messageAttributes);
+        }
+
+        private static Dictionary<string, MessageAttributeValue> AddContentTypeAttribute(
+            this Dictionary<string, MessageAttributeValue> attributes,
+            ContentType? contentType)
+        {
+            if (contentType != null)
+            {
+                attributes.Add(
+                    ContentTypeAttributeKey,
+                    new MessageAttributeValue
+                    {
+                        DataType = "String",
+                        StringValue = contentType.ToString()
+                    });
+            }
+
+            return attributes;
+        }
+
+        private static Dictionary<string, MessageAttributeValue> AddSpecVersionAttribute(
+            this Dictionary<string, MessageAttributeValue> attributes,
+            CloudEvent cloudEvent)
+        {
+            attributes.Add(SpecVersionAttributeKey,
+                new MessageAttributeValue
+                {
+                    DataType = "String",
+                    StringValue = cloudEvent.SpecVersion.VersionId
+                });
+            return attributes;
+        }
+
+        private static Dictionary<string, MessageAttributeValue> AddCloudEventAttributes(
+            this Dictionary<string, MessageAttributeValue> attributes,
+            CloudEvent cloudEvent)
+        {
+            foreach (var cloudEventAttributePair in cloudEvent.GetPopulatedAttributes())
+            {
+                var attribute = cloudEventAttributePair.Key;
+                var attributeValue = attribute.Format(cloudEventAttributePair.Value);
+
+                attributes.Add($"{CloudEventAttributeKeyPrefix}{attribute.Name}",
+                    new MessageAttributeValue
+                    {
+                        DataType = "String",
+                        StringValue = attributeValue
+                    });
+            }
+
+            return attributes;
+        }
+    }
+}

--- a/src/CloudNative.CloudEvents.AwsSqs/CloudNative.CloudEvents.AwsSqs.csproj
+++ b/src/CloudNative.CloudEvents.AwsSqs/CloudNative.CloudEvents.AwsSqs.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+		<Description>AWS SNS extensions for CloudNative.CloudEvents</Description>
+		<PackageTags>cncf;cloudnative;cloudevents;events;aws;sqs</PackageTags>
+		<LangVersion>8.0</LangVersion>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="AWSSDK.SQS" Version="3.7.2.7" />
+		<ProjectReference Include="..\CloudNative.CloudEvents\CloudNative.CloudEvents.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/CloudNative.CloudEvents.AwsSqs/SqsResponseExtensions.cs
+++ b/src/CloudNative.CloudEvents.AwsSqs/SqsResponseExtensions.cs
@@ -1,0 +1,134 @@
+﻿// Copyright (c) Cloud Native Foundation.
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Mime;
+using Amazon.SQS.Model;
+using CloudNative.CloudEvents.Core;
+
+namespace CloudNative.CloudEvents.AwsSqs
+{
+    /// <summary>
+    ///     Extension methods to convert between CloudEvents and AWS.SQS response.
+    /// </summary>
+    public static class SqsResponseExtensions
+    {
+        /// <summary>
+        ///     Message attribute key for ContentType
+        /// </summary>
+        public const string ContentTypeAttributeKey = "content-type";
+
+        /// <summary>
+        ///     Message attribute key for SpecVersion
+        /// </summary>
+        public const string SpecVersionAttributeKey = "spec-version";
+
+        /// <summary>
+        ///     A prefix for cloud event attributes keys to distinguish them from other.
+        /// </summary>
+        public const string CloudEventAttributeKeyPrefix = "cloud_event_";
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sqsReceiveMessageResponse"></param>
+        /// <param name="formatter"></param>
+        /// <param name="extensionAttributes"></param>
+        /// <returns></returns>
+        public static ICollection<CloudEvent> ToCloudEvents(
+            this ReceiveMessageResponse sqsReceiveMessageResponse,
+            CloudEventFormatter formatter,
+            IEnumerable<CloudEventAttribute>? extensionAttributes = null)
+        {
+            Validation.CheckNotNull(sqsReceiveMessageResponse, nameof(sqsReceiveMessageResponse));
+            Validation.CheckNotNull(formatter, nameof(formatter));
+
+            return sqsReceiveMessageResponse
+                .Messages
+                .Select(message => ToCloudEventInternal(message, formatter, extensionAttributes))
+                .ToList();
+        }
+
+        private static CloudEvent ToCloudEventInternal(
+            Message message,
+            CloudEventFormatter formatter,
+            IEnumerable<CloudEventAttribute>? extensionAttributes)
+        {
+            if (!message.MessageAttributes.Any())
+            {
+                throw new ArgumentException(@"Received SQS message has no attributes. 
+                    If you are using SNS to SQS publication check if RawMessageDelivery mode is ENABLED, otherwise attributes are dropped in AWS.");
+            }
+
+            var contentType = ReadContentTypeAttribute(message);
+
+            if (MimeUtilities.IsCloudEventsContentType(contentType.ToString()))
+            {
+                var encoding = MimeUtilities.GetEncoding(contentType);
+                var bytes = encoding.GetBytes(message.Body);
+                var cloudEvent =
+                    formatter.DecodeStructuredModeMessage(new MemoryStream(bytes), contentType, extensionAttributes);
+                return Validation.CheckCloudEventArgument(cloudEvent, nameof(message));
+            }
+            else
+            {
+                var specVersion = ReadSpecVersion(message);
+
+                var cloudEvent = new CloudEvent(specVersion, extensionAttributes)
+                {
+                    DataContentType = contentType.ToString()
+                };
+
+                foreach (var messageAttribute in message.MessageAttributes)
+                {
+                    if (messageAttribute.Key.StartsWith(CloudEventAttributeKeyPrefix))
+                    {
+                        var attributeName = messageAttribute.Key.Substring(CloudEventAttributeKeyPrefix.Length)
+                            .ToLowerInvariant();
+                        cloudEvent.SetAttributeFromString(attributeName, messageAttribute.Value.StringValue);
+                    }
+                }
+
+                var messageBytes = Convert.FromBase64String(message.Body);
+                formatter.DecodeBinaryModeEventData(messageBytes, cloudEvent);
+                return Validation.CheckCloudEventArgument(cloudEvent, nameof(message));
+            }
+        }
+
+        private static ContentType ReadContentTypeAttribute(Message message)
+        {
+            message.MessageAttributes.TryGetValue(ContentTypeAttributeKey, out var contentType);
+
+            if (contentType?.StringValue is null)
+            {
+                throw new ArgumentException("Missing CloudEvent content type attribute.", nameof(message));
+            }
+
+            return new ContentType(contentType.StringValue);
+        }
+
+        private static CloudEventsSpecVersion ReadSpecVersion(Message message)
+        {
+            message.MessageAttributes.TryGetValue(SpecVersionAttributeKey, out var specVersionAttribute);
+
+            if (specVersionAttribute?.StringValue is null)
+            {
+                throw new ArgumentException("Missing CloudEvent spec version attribute.", nameof(message));
+            }
+
+            var specVersion = CloudEventsSpecVersion.FromVersionId(specVersionAttribute.StringValue);
+
+            if (specVersion is null)
+            {
+                throw new ArgumentException(
+                    $"Unknown CloudEvent spec version attribute '{specVersionAttribute.StringValue}'.",
+                    nameof(message));
+            }
+
+            return specVersion;
+        }
+    }
+}

--- a/src/CloudNative.CloudEvents.NewtonsoftJson/JsonEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.NewtonsoftJson/JsonEventFormatter.cs
@@ -466,13 +466,31 @@ namespace CloudNative.CloudEvents.NewtonsoftJson
         /// <inheritdoc />
         public override ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent)
         {
+            return EncodeBinaryModeEventData(cloudEvent, out var contentType);
+        }
+
+        /// <inheritdoc />
+        public override ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent, out ContentType contentType)
+        {
             Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
+
+            if (cloudEvent.DataContentType is null)
+            {
+                contentType = new ContentType(JsonMediaType)
+                {
+                    CharSet = Encoding.UTF8.WebName
+                };
+            }
+            else
+            {
+                contentType = new ContentType(cloudEvent.DataContentType);
+            }
 
             if (cloudEvent.Data is null)
             {
                 return Array.Empty<byte>();
             }
-            ContentType contentType = new ContentType(cloudEvent.DataContentType ?? JsonMediaType);
+
             if (contentType.MediaType == JsonMediaType)
             {
                 // TODO: Make this more efficient. We could write to a StreamWriter with a MemoryStream,

--- a/src/CloudNative.CloudEvents/CloudEventFormatter.cs
+++ b/src/CloudNative.CloudEvents/CloudEventFormatter.cs
@@ -106,6 +106,17 @@ namespace CloudNative.CloudEvents
         /// <summary>
         /// Encodes the data from <paramref name="cloudEvent"/> in a manner suitable for a binary mode message.
         /// </summary>
+        /// <param name="cloudEvent">The CloudEvents to encode. Must not be null.</param>
+        /// <param name="contentType">On successful return, the content type of the encoded CloudEvent Data.
+        /// Must not be null (on return).</param>
+        /// <exception cref="ArgumentException">The data in the given CloudEvent cannot be encoded by this
+        /// event formatter.</exception>
+        /// <returns>The binary-mode representation of the CloudEvent.</returns>
+        public abstract ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent, out ContentType contentType);
+
+        /// <summary>
+        /// Encodes the data from <paramref name="cloudEvent"/> in a manner suitable for a binary mode message.
+        /// </summary>
         /// <exception cref="ArgumentException">The data in the given CloudEvent cannot be encoded by this
         /// event formatter.</exception>
         /// <returns>The binary-mode representation of the CloudEvent.</returns>

--- a/test/CloudNative.CloudEvents.IntegrationTests/Aws/AwsIntegrationTestsLib.cs
+++ b/test/CloudNative.CloudEvents.IntegrationTests/Aws/AwsIntegrationTestsLib.cs
@@ -1,0 +1,343 @@
+﻿// Copyright (c) Cloud Native Foundation.
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.Auth.AccessControlPolicy;
+using Amazon.Runtime;
+using Amazon.SimpleNotificationService;
+using Amazon.SimpleNotificationService.Model;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+using Xunit;
+
+namespace CloudNative.CloudEvents.IntegrationTests.Aws
+{
+    public class AwsSqsSnsClientAdapter : IAsyncDisposable
+    {
+        private readonly ICollection<CreateQueueResponse> _createdQueues = new List<CreateQueueResponse>();
+        private readonly ICollection<CreateTopicResponse> _createdTopics = new List<CreateTopicResponse>();
+        private readonly IAmazonSimpleNotificationService _snsClient;
+        private readonly IAmazonSQS _sqsClient;
+
+        public AwsSqsSnsClientAdapter(AWSCredentials credentials, string serviceUrl)
+        {
+            _sqsClient = new AmazonSQSClient(
+                credentials,
+                new AmazonSQSConfig
+                {
+                    ServiceURL = serviceUrl
+                });
+
+            _snsClient = new AmazonSimpleNotificationServiceClient(
+                credentials,
+                new AmazonSimpleNotificationServiceConfig
+                {
+                    ServiceURL = serviceUrl
+                });
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            foreach (var queue in _createdQueues)
+            {
+                await _sqsClient.DeleteQueueAsync(queue.QueueUrl);
+            }
+
+            foreach (var topic in _createdTopics)
+            {
+                await _snsClient.DeleteTopicAsync(topic.TopicArn);
+            }
+
+            _sqsClient?.Dispose();
+            _snsClient?.Dispose();
+        }
+
+        public async Task<(string QueueUrl, string TopicArn)> CreateTopicWithSubscribedQueueAsync(
+            bool rawMessageDelivery,
+            CancellationToken cancellationToken = default)
+        {
+            var queueName = $"CloudEventsTestQueue_{Guid.NewGuid():N}";
+            var topicName = $"CloudEventsTestTopic_{Guid.NewGuid():N}";
+
+            var queue = await CreateQueueAsync(queueName, cancellationToken);
+            var topic = await CreateTopicAsync(topicName, cancellationToken);
+            var queueArn = await GetQueueArnAsync(queue.QueueUrl, cancellationToken);
+            await SubscribeSnsToSqsAsync(queueArn, topic.TopicArn, rawMessageDelivery, cancellationToken);
+            await AllowPublicationFromSnsToSqsAsync(queueArn, queue.QueueUrl, topic.TopicArn, cancellationToken);
+            return (queue.QueueUrl, topic.TopicArn);
+        }
+
+        public async Task<PublishResponse> SnsPublishMessageAsync(PublishRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _snsClient.PublishAsync(request, cancellationToken);
+
+            // A little delay to make message available on sqs
+            await Task.Delay(1000);
+            return response;
+        }
+
+        public async Task<SendMessageResponse> SqsSendMessageAsync(SendMessageRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            return await _sqsClient.SendMessageAsync(request, cancellationToken);
+        }
+
+        public async Task<ReceiveMessageResponse> SqsReceiveMessageAsync(string queueUrl,
+            CancellationToken cancellationToken = default)
+        {
+            return await _sqsClient.ReceiveMessageAsync(new ReceiveMessageRequest
+            {
+                QueueUrl = queueUrl,
+                MessageAttributeNames = new List<string> {"All"}
+            }, cancellationToken);
+        }
+
+        private async Task<CreateQueueResponse> CreateQueueAsync(string queueName,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _sqsClient.CreateQueueAsync(new CreateQueueRequest
+                {
+                    QueueName = queueName
+                },
+                cancellationToken);
+
+            _createdQueues.Add(response);
+            return response;
+        }
+
+        private async Task<CreateTopicResponse> CreateTopicAsync(string topicName,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _snsClient.CreateTopicAsync(new CreateTopicRequest
+                {
+                    Name = topicName
+                },
+                cancellationToken);
+
+            _createdTopics.Add(response);
+            return response;
+        }
+
+        private async Task<string> GetQueueArnAsync(string queueUrl, CancellationToken cancellationToken)
+        {
+            var response = await _sqsClient.GetQueueAttributesAsync(new GetQueueAttributesRequest
+            {
+                AttributeNames = new List<string> {"QueueArn"},
+                QueueUrl = queueUrl
+            }, cancellationToken);
+
+            return response.QueueARN;
+        }
+
+        private async Task<SubscribeResponse> SubscribeSnsToSqsAsync(
+            string queueArn,
+            string topicArn,
+            bool rawMessageDelivery,
+            CancellationToken cancellationToken)
+        {
+            var subscribeRequest = new SubscribeRequest
+            {
+                TopicArn = topicArn,
+                Protocol = "sqs",
+                Endpoint = queueArn,
+                Attributes = new Dictionary<string, string>
+                {
+                    {"RawMessageDelivery", rawMessageDelivery.ToString()}
+                }
+            };
+
+            return await _snsClient.SubscribeAsync(subscribeRequest, cancellationToken);
+        }
+
+        private async Task AllowPublicationFromSnsToSqsAsync(string queueArn, string queueUrl, string topicArn,
+            CancellationToken cancellationToken)
+        {
+            var sqsPolicy = new Policy()
+                .WithStatements(
+                    new Statement(Statement.StatementEffect.Allow)
+                        .WithPrincipals(new Principal(Principal.SERVICE_PROVIDER, "sns.amazonaws.com"))
+                        .WithResources(new Resource(queueArn))
+                        .WithConditions(ConditionFactory.NewCondition(ConditionFactory.ArnComparisonType.ArnEquals,
+                            "aws:SourceArn", topicArn))
+                        .WithActionIdentifiers(new ActionIdentifier("sqs:SendMessage")));
+
+            var setQueueAttributesRequest = new SetQueueAttributesRequest
+            {
+                QueueUrl = queueUrl,
+                Attributes = new Dictionary<string, string>
+                {
+                    {"Policy", sqsPolicy.ToJson()}
+                }
+            };
+
+            await _sqsClient.SetQueueAttributesAsync(setQueueAttributesRequest, cancellationToken);
+        }
+    }
+
+
+    [CollectionDefinition("LocalStack", DisableParallelization = false)]
+    public class LocalStackTestsCollection : ICollectionFixture<LocalStackTestCollectionFixture>
+    {
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition] and all the
+        // ICollectionFixture<> interfaces.
+    }
+
+    public class LocalStackTestCollectionFixture : IAsyncLifetime
+    {
+        internal LocalStackContainer LocalStackContainer;
+
+        /// <summary>
+        ///     SetUp for tests collection. Runs once - before the first test in collection.
+        /// </summary>
+        public async Task InitializeAsync()
+        {
+            LocalStackContainer = await LocalStackContainer.StartAsync();
+        }
+
+        /// <summary>
+        ///     TearDown for tests collection. Runs once - after the last test in collection.
+        /// </summary>
+        public async Task DisposeAsync()
+        {
+            if (LocalStackContainer != null)
+            {
+                await LocalStackContainer.DisposeAsync();
+                LocalStackContainer = null;
+            }
+        }
+    }
+
+    internal class LocalStackContainer : IAsyncDisposable, IDisposable
+    {
+        private readonly string _containerId;
+
+        public readonly string ServiceUrl;
+        private DockerClient _dockerClient;
+
+        public LocalStackContainer(DockerClient dockerClient, string containerId, string serviceUrl)
+        {
+            _dockerClient = dockerClient;
+            _containerId = containerId;
+            ServiceUrl = serviceUrl;
+        }
+
+        public AWSCredentials AwsCredentials => new BasicAWSCredentials("test", "test");
+
+        public async ValueTask DisposeAsync()
+        {
+            await DisposeAsyncCore().ConfigureAwait(false);
+            Dispose(false);
+            GC.SuppressFinalize(this);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        public static async Task<LocalStackContainer> StartAsync(CancellationToken cancellationToken = default)
+        {
+            // @SEE: https://github.com/Microsoft/Docker.DotNet#usage
+            var uri = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? "npipe://./pipe/docker_engine"
+                : "unix:///var/run/docker.sock";
+
+            var imageName = "localstack/localstack:0.13";
+            var freeTcpPort = GetFreeTcpPort();
+            var containerConfig = new CreateContainerParameters
+            {
+                Image = imageName,
+                Hostname = "localhost",
+                Name = $"local-stack-{Guid.NewGuid():N}",
+                Env = new List<string>
+                {
+                    "SERVICES=sns,sqs"
+                },
+                HostConfig = new HostConfig
+                {
+                    AutoRemove = true,
+                    PortBindings = new Dictionary<string, IList<PortBinding>>
+                    {
+                        {
+                            "4566/tcp",
+                            new List<PortBinding>
+                            {
+                                new PortBinding
+                                {
+                                    HostIP = "0.0.0.0",
+                                    HostPort = freeTcpPort.ToString(CultureInfo.InvariantCulture)
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var dockerClient = new DockerClientConfiguration(new Uri(uri)).CreateClient();
+
+            await dockerClient.Images.CreateImageAsync(
+                new ImagesCreateParameters
+                {
+                    FromImage = imageName
+                },
+                new AuthConfig(),
+                new Progress<JSONMessage>(),
+                cancellationToken);
+
+            var container = await dockerClient.Containers.CreateContainerAsync(
+                containerConfig,
+                cancellationToken);
+
+            await dockerClient.Containers.StartContainerAsync(
+                container.ID,
+                new ContainerStartParameters(),
+                cancellationToken);
+
+            var serviceUrl = $"http://{containerConfig.Hostname}:{freeTcpPort}";
+            return new LocalStackContainer(dockerClient, container.ID, serviceUrl);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _dockerClient.Containers.StopContainerAsync(_containerId, new ContainerStopParameters()).GetAwaiter()
+                    .GetResult();
+                _dockerClient?.Dispose();
+                _dockerClient = null;
+            }
+        }
+
+        protected virtual async ValueTask DisposeAsyncCore()
+        {
+            if (_dockerClient != null)
+            {
+                await _dockerClient.Containers.StopContainerAsync(_containerId, new ContainerStopParameters());
+                _dockerClient.Dispose();
+            }
+
+            _dockerClient = null;
+        }
+
+        private static int GetFreeTcpPort()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint) listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+    }
+}

--- a/test/CloudNative.CloudEvents.IntegrationTests/Aws/Sns/AwsSnsIntegrationTests.cs
+++ b/test/CloudNative.CloudEvents.IntegrationTests/Aws/Sns/AwsSnsIntegrationTests.cs
@@ -1,0 +1,148 @@
+﻿// Copyright (c) Cloud Native Foundation.
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Net.Mime;
+using System.Threading.Tasks;
+using Amazon.SimpleNotificationService.Model;
+using CloudNative.CloudEvents.AwsSns;
+using CloudNative.CloudEvents.AwsSqs;
+using CloudNative.CloudEvents.NewtonsoftJson;
+using Xunit;
+using static CloudNative.CloudEvents.IntegrationTests.TestHelpers;
+
+namespace CloudNative.CloudEvents.IntegrationTests.Aws.Sns
+{
+    [Collection("LocalStack")]
+    public class AwsSnsIntegrationTests : IAsyncLifetime
+    {
+        private readonly AwsSqsSnsClientAdapter _snsSqsAdapter;
+
+        public AwsSnsIntegrationTests(LocalStackTestCollectionFixture testFixture)
+        {
+            _snsSqsAdapter = new AwsSqsSnsClientAdapter(
+                testFixture.LocalStackContainer.AwsCredentials,
+                testFixture.LocalStackContainer.ServiceUrl);
+        }
+
+        public async Task InitializeAsync()
+        {
+            await Task.CompletedTask;
+        }
+
+        public async Task DisposeAsync()
+        {
+            await _snsSqsAdapter.DisposeAsync();
+        }
+
+        [Fact]
+        public async Task ItShouldPublishMessageInStructuredContentMode()
+        {
+            var infrastructure =  await _snsSqsAdapter.CreateTopicWithSubscribedQueueAsync(rawMessageDelivery: true);
+            var formatter = new JsonEventFormatter();
+
+            var cloudEvent = new CloudEvent
+            {
+                Type = "com.github.pull.create",
+                Source = new Uri("https://github.com/cloudevents/spec/pull"),
+                Subject = "123",
+                Id = "A234-1234-1234",
+                Time = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero),
+                DataContentType = MediaTypeNames.Text.Xml,
+                Data = "<much wow=\"xml\"/>",
+                ["comexampleextension1"] = "value"
+            };
+
+            var publishRequest = new PublishRequest
+            {
+                TopicArn = infrastructure.TopicArn,
+            };
+
+            cloudEvent.CopyToSnsPublishRequest(publishRequest, ContentMode.Structured, formatter);
+
+            await _snsSqsAdapter.SnsPublishMessageAsync(publishRequest);
+
+            var message = await _snsSqsAdapter.SqsReceiveMessageAsync(infrastructure.QueueUrl);
+
+            var cloudEvents = message.ToCloudEvents(formatter);
+            var receivedCloudEvent = cloudEvents.Single();
+
+            AssertCloudEventsEqual(cloudEvent, receivedCloudEvent);
+        }
+
+        [Fact]
+        public async Task ItShouldPublishMessageInBinaryContentMode()
+        {
+            var infrastructure = await _snsSqsAdapter.CreateTopicWithSubscribedQueueAsync(rawMessageDelivery: true);
+            var formatter = new JsonEventFormatter();
+
+            var cloudEvent = new CloudEvent
+            {
+                Type = "com.github.pull.create",
+                Source = new Uri("https://github.com/cloudevents/spec/pull"),
+                Subject = "123",
+                Id = "A234-1234-1234",
+                Time = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero),
+                DataContentType = MediaTypeNames.Text.Xml,
+                Data = "<much wow=\"xml\"/>",
+                ["comexampleextension1"] = "test value",
+                ["comexampleextension2"] = "extension 2",
+                ["comexampleextension3"] = "extension 3",
+                ["comexampleextension4"] = "4 extension",
+            };
+
+            var publishRequest = new PublishRequest
+            {
+                TopicArn = infrastructure.TopicArn,
+            };
+
+            cloudEvent.CopyToSnsPublishRequest(publishRequest, ContentMode.Binary, formatter);
+
+            await _snsSqsAdapter.SnsPublishMessageAsync(publishRequest);
+
+            var message = await _snsSqsAdapter.SqsReceiveMessageAsync(infrastructure.QueueUrl);
+
+            var cloudEvents = message.ToCloudEvents(formatter);
+            var receivedCloudEvent = cloudEvents.Single();
+
+            AssertCloudEventsEqual(cloudEvent, receivedCloudEvent);
+        }
+
+        [Fact]
+        public async Task ItShouldFailInBinaryContentModeWhenRawMessageDeliveryIsDisabled()
+        {
+            var infrastructure = await _snsSqsAdapter.CreateTopicWithSubscribedQueueAsync(rawMessageDelivery: false);
+            var formatter = new JsonEventFormatter();
+
+            var cloudEvent = new CloudEvent
+            {
+                Type = "com.github.pull.create",
+                Source = new Uri("https://github.com/cloudevents/spec/pull"),
+                Subject = "123",
+                Id = "A234-1234-1234",
+                Time = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero),
+                DataContentType = MediaTypeNames.Text.Xml,
+                Data = "<much wow=\"xml\"/>",
+                ["comexampleextension1"] = "test value",
+                ["comexampleextension2"] = "extension 2",
+                ["comexampleextension3"] = "extension 3",
+                ["comexampleextension4"] = "4 extension",
+            };
+
+            var publishRequest = new PublishRequest
+            {
+                TopicArn = infrastructure.TopicArn,
+            };
+
+            cloudEvent.CopyToSnsPublishRequest(publishRequest, ContentMode.Binary, formatter);
+
+            await _snsSqsAdapter.SnsPublishMessageAsync(publishRequest);
+
+            var message = await _snsSqsAdapter.SqsReceiveMessageAsync(infrastructure.QueueUrl);
+
+            Assert.Throws<ArgumentException>(() => message.ToCloudEvents(formatter));
+        }
+    }
+}

--- a/test/CloudNative.CloudEvents.IntegrationTests/CloudNative - Backup.CloudEvents.IntegrationTests.csproj
+++ b/test/CloudNative.CloudEvents.IntegrationTests/CloudNative - Backup.CloudEvents.IntegrationTests.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Aws\Sqs\" />
+    <Folder Include="Aws\NewFolder\" />
   </ItemGroup>
 
 </Project>

--- a/test/CloudNative.CloudEvents.IntegrationTests/TestHelpers.cs
+++ b/test/CloudNative.CloudEvents.IntegrationTests/TestHelpers.cs
@@ -1,0 +1,33 @@
+﻿// Copyright 2021 Cloud Native Foundation. 
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using Xunit;
+
+namespace CloudNative.CloudEvents.IntegrationTests
+{
+    /// <summary>
+    /// Helpers for test code, e.g. common non-trivial assertions.
+    /// </summary>
+    internal static class TestHelpers
+    {
+        // TODO: Use this more widely
+        internal static void AssertCloudEventsEqual(CloudEvent expected, CloudEvent actual)
+        {
+            Assert.Equal(expected.SpecVersion, actual.SpecVersion);
+            var expectedAttributes = expected.GetPopulatedAttributes().ToList();
+            var actualAttributes = actual.GetPopulatedAttributes().ToList();
+
+            Assert.Equal(expectedAttributes.Count, actualAttributes.Count);
+            foreach (var expectedAttribute in expectedAttributes)
+            {
+                var actualAttribute = actualAttributes.FirstOrDefault(actual => actual.Key.Name == expectedAttribute.Key.Name);
+                Assert.NotNull(actualAttribute.Key);
+
+                Assert.Equal(actualAttribute.Key.Type, expectedAttribute.Key.Type);
+                Assert.Equal(actualAttribute.Value, expectedAttribute.Value);
+            }
+        }
+    }
+}

--- a/test/CloudNative.CloudEvents.UnitTests/Aws/Sns/SnsRequestExtensionTests.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Aws/Sns/SnsRequestExtensionTests.cs
@@ -1,0 +1,201 @@
+﻿// Copyright (c) Cloud Native Foundation.
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Net.Mime;
+using Amazon.SimpleNotificationService.Model;
+using CloudNative.CloudEvents.AwsSns;
+using CloudNative.CloudEvents.NewtonsoftJson;
+using Xunit;
+using MessageAttributeValueSns = Amazon.SimpleNotificationService.Model.MessageAttributeValue;
+using MessageAttributeValueSqs = Amazon.SQS.Model.MessageAttributeValue;
+using static CloudNative.CloudEvents.UnitTests.TestHelpers;
+
+namespace CloudNative.CloudEvents.UnitTests.AwsSns
+{
+    public class SnsRequestExtensionTests
+    {
+        [Theory]
+        [InlineData(ContentMode.Structured)]
+        [InlineData(ContentMode.Binary)]
+        public void ShouldNotChangeAnySnsPublishRequestAttributesWhenCopyTo(ContentMode contentMode)
+        {
+            // Given 
+            var jsonEventFormatter = new JsonEventFormatter();
+
+            var cloudEvent = new CloudEvent
+            {
+                Type = "com.github.pull.create",
+                Source = new Uri("https://github.com/cloudevents/spec/pull"),
+                Subject = "123",
+                Id = "A234-1234-1234",
+                Time = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero),
+                DataContentType = MediaTypeNames.Text.Xml,
+                Data = "<much wow=\"xml\"/>",
+                ["comexampleextension1"] = "value"
+            };
+
+            var publishRequest = new PublishRequest
+            {
+                TopicArn = "Test topic",
+                MessageDeduplicationId = Guid.NewGuid().ToString("N"),
+                MessageGroupId = Guid.NewGuid().ToString("N"),
+                PhoneNumber = "1245",
+                Subject = "Message subject",
+                TargetArn = "Test target"
+            };
+            publishRequest.MessageAttributes.Add("my-custom-attribute", new MessageAttributeValueSns
+            {
+                StringValue = "my-custom-attribute-value",
+                DataType = "String"
+            });
+
+            var publishRequestCopy = DeepCopy(publishRequest);
+
+            // When
+            cloudEvent.CopyToSnsPublishRequest(publishRequest, contentMode, jsonEventFormatter);
+
+            // Then
+            var customAttribute = GetMessageAttribute(publishRequest, "my-custom-attribute");
+            Assert.Equal("String", customAttribute.DataType);
+            Assert.Equal("my-custom-attribute-value", customAttribute.StringValue);
+            Assert.Equal(publishRequestCopy.MessageDeduplicationId, publishRequest.MessageDeduplicationId);
+            Assert.Equal(publishRequestCopy.MessageGroupId, publishRequest.MessageGroupId);
+            Assert.Equal(publishRequestCopy.PhoneNumber, publishRequest.PhoneNumber);
+            Assert.Equal(publishRequestCopy.Subject, publishRequest.Subject);
+            Assert.Equal(publishRequestCopy.TargetArn, publishRequest.TargetArn);
+            Assert.Equal(publishRequestCopy.TopicArn, publishRequest.TopicArn);
+        }
+
+        [Fact]
+        public void ShouldAssignContentTypeAttributeInStructuredContentMode()
+        {
+            // Given 
+            const string expectedContentType = "application/cloudevents+json; charset=utf-8";
+            var jsonEventFormatter = new JsonEventFormatter();
+
+            var cloudEvent = new CloudEvent
+            {
+                Type = "com.github.pull.create",
+                Source = new Uri("https://github.com/cloudevents/spec/pull"),
+                Subject = "123",
+                Id = "A234-1234-1234",
+                Time = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero),
+                DataContentType = MediaTypeNames.Text.Xml,
+                Data = "<much wow=\"xml\"/>",
+                ["comexampleextension1"] = "value"
+            };
+
+            // When
+            var publishRequest = cloudEvent.ToSnsPublishRequest(ContentMode.Structured, jsonEventFormatter);
+
+            // Then
+            var contentTypeAttribute = GetMessageAttribute(publishRequest, "content-type");
+            Assert.Equal("String", contentTypeAttribute.DataType);
+            Assert.Equal(expectedContentType, contentTypeAttribute.StringValue);
+            Assert.Equal("String", publishRequest.MessageStructure);
+        }
+
+        [Theory]
+        [InlineData(MediaTypeNames.Text.Xml, MediaTypeNames.Text.Xml)]
+        [InlineData(MediaTypeNames.Text.Plain, MediaTypeNames.Text.Plain)]
+        [InlineData(null, "application/json; charset=utf-8")]
+        public void ItShouldAssignContentTypeAttributeInBinaryContentMode(string? dataContentType,
+            string expectedContentType)
+        {
+            // Given 
+            var jsonEventFormatter = new JsonEventFormatter();
+
+            var cloudEvent = new CloudEvent
+            {
+                Type = "com.github.pull.create",
+                Source = new Uri("https://github.com/cloudevents/spec/pull"),
+                Subject = "123",
+                Id = "A234-1234-1234",
+                Time = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero),
+                DataContentType = dataContentType,
+                Data = "<much wow=\"xml\"/>",
+                ["comexampleextension1"] = "value"
+            };
+
+            // When
+            var publishRequest = cloudEvent.ToSnsPublishRequest(ContentMode.Binary, jsonEventFormatter);
+
+            // Then
+            var contentTypeAttribute = GetMessageAttribute(publishRequest, "content-type");
+            Assert.Equal("String", contentTypeAttribute.DataType);
+            Assert.Equal(expectedContentType, contentTypeAttribute.StringValue);
+            Assert.Equal("String", publishRequest.MessageStructure);
+        }
+
+        [Theory]
+        [InlineData(ContentMode.Structured)]
+        [InlineData(ContentMode.Binary)]
+        public void ShouldAssignMessageStructureProperty(ContentMode contentMode)
+        {
+            var publishRequest = GetMinimalCloudEvent().ToSnsPublishRequest(contentMode, new JsonEventFormatter());
+            Assert.Equal("String", publishRequest.MessageStructure);
+        }
+
+        [Fact]
+        public void ShouldThrowWhenCreateSnsPublishRequestWithInvalidCloudEvent()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new CloudEvent()
+                    .ToSnsPublishRequest(ContentMode.Structured, new JsonEventFormatter()));
+        }
+
+        [Fact]
+        public void ShouldThrowWhenCopyToSnsPublishRequestWithInvalidCloudEvent()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new CloudEvent()
+                    .CopyToSnsPublishRequest(new PublishRequest(), ContentMode.Structured, new JsonEventFormatter()));
+        }
+
+        [Fact]
+        public void ShouldThrowWhenCreateSnsPublishRequestWithNullFormatter()
+        {
+#nullable disable
+            Assert.Throws<ArgumentNullException>(() =>
+                GetMinimalCloudEvent()
+                    .ToSnsPublishRequest(ContentMode.Structured, null));
+#nullable enable
+        }
+
+        [Fact]
+        public void ShouldThrowWhenCopyToSnsPublishRequestWithNullFormatter()
+        {
+#nullable disable
+            Assert.Throws<ArgumentNullException>(() =>
+                GetMinimalCloudEvent()
+                    .CopyToSnsPublishRequest(new PublishRequest(), ContentMode.Structured, null));
+#nullable enable
+        }
+
+        [Fact]
+        public void ShouldThrowWhenCopyToSnsPublishRequestWithNullPublishRequest()
+        {
+#nullable disable
+            Assert.Throws<ArgumentNullException>(() =>
+                GetMinimalCloudEvent()
+                    .CopyToSnsPublishRequest(null, ContentMode.Structured, new JsonEventFormatter()));
+#nullable enable
+        }
+
+        private static MessageAttributeValueSns GetMessageAttribute(PublishRequest publishRequest, string key)
+        {
+            return publishRequest
+                .MessageAttributes
+                .Single(c => c.Key == key)
+                .Value;
+        }
+
+        private static CloudEvent GetMinimalCloudEvent()
+        {
+            return new CloudEvent().PopulateRequiredAttributes();
+        }
+    }
+}

--- a/test/CloudNative.CloudEvents.UnitTests/Aws/SnsPublishSqsReceiveTests.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Aws/SnsPublishSqsReceiveTests.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Cloud Native Foundation.
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Mime;
+using Amazon.SimpleNotificationService.Model;
+using Amazon.SQS.Model;
+using CloudNative.CloudEvents.AwsSns;
+using CloudNative.CloudEvents.AwsSqs;
+using CloudNative.CloudEvents.NewtonsoftJson;
+using Xunit;
+using MessageAttributeValueSns = Amazon.SimpleNotificationService.Model.MessageAttributeValue;
+using MessageAttributeValueSqs = Amazon.SQS.Model.MessageAttributeValue;
+using static CloudNative.CloudEvents.UnitTests.TestHelpers;
+
+namespace CloudNative.CloudEvents.UnitTests.Aws
+{
+    public class SnsPublishSqsReceiveTests
+    {
+        [Theory]
+        [InlineData(ContentMode.Structured)]
+        [InlineData(ContentMode.Binary)]
+        public void ShouldProperlyEncodeAndDecode(ContentMode contentMode)
+        {
+            // Given 
+            var jsonEventFormatter = new JsonEventFormatter();
+
+            var cloudEvent = new CloudEvent
+            {
+                Type = "com.github.pull.create",
+                Source = new Uri("https://github.com/cloudevents/spec/pull"),
+                Subject = "123",
+                Id = "A234-1234-1234",
+                Time = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero),
+                DataContentType = MediaTypeNames.Text.Xml,
+                Data = "<much wow=\"xml\"/>",
+                ["comexampleextension1"] = "value"
+            };
+
+            // When
+            var publishRequest = cloudEvent.ToSnsPublishRequest(contentMode, jsonEventFormatter);
+
+            // Then
+            var response = SimulateMessageTransport(publishRequest);
+
+            var receivedCloudEvent = response.ToCloudEvents(jsonEventFormatter).Single();
+
+            AssertCloudEventsEqual(cloudEvent, receivedCloudEvent);
+        }
+
+        private static ReceiveMessageResponse SimulateMessageTransport(PublishRequest publishRequest)
+        {
+            // Using serialization to create fully independent copy thus simulating message transport
+            // real transport will work in a similar way
+            var publishRequestCopy = DeepCopy(publishRequest);
+
+            return new ReceiveMessageResponse
+            {
+                Messages = new List<Message>
+                {
+                    new Message
+                    {
+                        Body = publishRequestCopy.Message,
+                        MessageAttributes = publishRequestCopy.MessageAttributes.ToDictionary(
+                            c => c.Key,
+                            v => new MessageAttributeValueSqs
+                            {
+                                DataType = v.Value.DataType,
+                                StringValue = v.Value.StringValue
+                            })
+                    }
+                }
+            };
+        }
+    }
+}

--- a/test/CloudNative.CloudEvents.UnitTests/Aws/Sqs/SqsResponseExtensionTests.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Aws/Sqs/SqsResponseExtensionTests.cs
@@ -1,0 +1,274 @@
+﻿// Copyright (c) Cloud Native Foundation.
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Mime;
+using Amazon.SQS.Model;
+using CloudNative.CloudEvents.AwsSns;
+using CloudNative.CloudEvents.AwsSqs;
+using CloudNative.CloudEvents.NewtonsoftJson;
+using Xunit;
+using MessageAttributeValueSns = Amazon.SimpleNotificationService.Model.MessageAttributeValue;
+using MessageAttributeValueSqs = Amazon.SQS.Model.MessageAttributeValue;
+using static CloudNative.CloudEvents.UnitTests.TestHelpers;
+
+namespace CloudNative.CloudEvents.UnitTests.AwsSqs
+{
+    public class SqsResponseExtensionTests
+    {
+        [Fact]
+        public void ItShouldConvertInContentModeWhenContentTypeIsApplicationCloudEvent()
+        {
+            var sqsResponse = new ReceiveMessageResponse
+            {
+                Messages = new List<Message>
+                {
+                    new Message
+                    {
+                        Body =
+                            "{\"specversion\":\"1.0\",\"id\":\"Test Id\",\"source\":\"https://www.test_source\",\"type\":\"Test cloud event\",\"datacontenttype\":\"application/cloudevents+json; charset=utf-8\",\"data\":\"<much wow=\\\"xml\\\"/>\"}",
+                        MessageAttributes = new Dictionary<string, MessageAttributeValueSqs>
+                        {
+                            {
+                                "content-type",
+                                new MessageAttributeValueSqs
+                                {
+                                    DataType = "String",
+                                    StringValue = "application/cloudevents+json; charset=utf-8"
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var cloudEvent = sqsResponse.ToCloudEvents(new JsonEventFormatter()).Single();
+
+            var expected = GetSampleCloudEvent("application/cloudevents+json; charset=utf-8");
+            AssertCloudEventsEqual(expected, cloudEvent);
+        }
+
+        [Fact]
+        public void ItShouldConvertInBinaryModeWhenContentTypeIsNotApplicationCloudEvent()
+        {
+            var sqsResponse = new ReceiveMessageResponse
+            {
+                Messages = new List<Message>
+                {
+                    new Message
+                    {
+                        Body = "PG11Y2ggd293PSJ4bWwiLz4=",
+                        MessageAttributes = new Dictionary<string, MessageAttributeValueSqs>
+                        {
+                            {
+                                "spec-version",
+                                new MessageAttributeValueSqs
+                                {
+                                    DataType = "String",
+                                    StringValue = CloudEventsSpecVersion.V1_0.VersionId
+                                }
+                            },
+                            {
+                                "content-type",
+                                new MessageAttributeValueSqs
+                                {
+                                    DataType = "String",
+                                    StringValue = MediaTypeNames.Text.Xml
+                                }
+                            },
+                            {
+                                $"{SqsResponseExtensions.CloudEventAttributeKeyPrefix}id",
+                                new MessageAttributeValueSqs
+                                {
+                                    DataType = "String",
+                                    StringValue = "Test Id"
+                                }
+                            },
+                            {
+                                $"{SqsResponseExtensions.CloudEventAttributeKeyPrefix}type",
+                                new MessageAttributeValueSqs
+                                {
+                                    DataType = "String",
+                                    StringValue = "Test cloud event"
+                                }
+                            },
+                            {
+                                $"{SqsResponseExtensions.CloudEventAttributeKeyPrefix}source",
+                                new MessageAttributeValueSqs
+                                {
+                                    DataType = "String",
+                                    StringValue = "https://www.test_source"
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var cloudEvent = sqsResponse.ToCloudEvents(new JsonEventFormatter()).Single();
+
+            var expected = GetSampleCloudEvent("text/xml");
+            AssertCloudEventsEqual(expected, cloudEvent);
+        }
+
+        [Fact]
+        public void ItShouldThrowWhenConvertingWithNoAttributes()
+        {
+            var sqsResponse = new ReceiveMessageResponse
+            {
+                Messages = new List<Message>
+                {
+                    new Message
+                    {
+                        Body = "Message",
+                        MessageAttributes = new Dictionary<string, MessageAttributeValueSqs>()
+                    }
+                }
+            };
+
+            Assert.Throws<ArgumentException>(() => sqsResponse.ToCloudEvents(new JsonEventFormatter()))
+                .Message.Contains("Received SQS message has no attributes.");
+        }
+
+        [Fact]
+        public void ItShouldThrowWhenConvertingInContentModeWithMissingContentTypeAttribute()
+        {
+            var sqsResponse = new ReceiveMessageResponse
+            {
+                Messages = new List<Message>
+                {
+                    new Message
+                    {
+                        Body = "Message",
+                        MessageAttributes = new Dictionary<string, MessageAttributeValueSqs>
+                        {
+                            {
+                                "some-attribute",
+                                new MessageAttributeValueSqs
+                                {
+                                    DataType = "String",
+                                    StringValue = "some value"
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            Assert.Throws<ArgumentException>(() => sqsResponse.ToCloudEvents(new JsonEventFormatter()))
+                .Message.Contains("Missing CloudEvent content type attribute.");
+        }
+
+
+        [Fact]
+        public void ItShouldThrowWhenConvertingInBinaryModeWithMissingContentTypeAttribute()
+        {
+            var sqsResponse = new ReceiveMessageResponse
+            {
+                Messages = new List<Message>
+                {
+                    new Message
+                    {
+                        Body = "Message",
+                        MessageAttributes = new Dictionary<string, MessageAttributeValueSqs>
+                        {
+                            {
+                                "spec-version",
+                                new MessageAttributeValueSqs
+                                {
+                                    DataType = "String",
+                                    StringValue = CloudEventsSpecVersion.V1_0.VersionId
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            Assert.Throws<ArgumentException>(() => sqsResponse.ToCloudEvents(new JsonEventFormatter()))
+                .Message.Contains("Missing CloudEvent content type attribute.");
+        }
+
+
+        [Fact]
+        public void ItShouldThrowWhenConvertingInBinaryModeWithUnknownSpecVersion()
+        {
+            var sqsResponse = new ReceiveMessageResponse
+            {
+                Messages = new List<Message>
+                {
+                    new Message
+                    {
+                        Body = "Message",
+                        MessageAttributes = new Dictionary<string, MessageAttributeValueSqs>
+                        {
+                            {
+                                "content-type",
+                                new MessageAttributeValueSqs
+                                {
+                                    DataType = "String",
+                                    StringValue = MediaTypeNames.Text.Xml
+                                }
+                            },
+                            {
+                                "spec-version",
+                                new MessageAttributeValueSqs
+                                {
+                                    DataType = "String",
+                                    StringValue = "random value"
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            Assert.Throws<ArgumentException>(() => sqsResponse.ToCloudEvents(new JsonEventFormatter()))
+                .Message.Contains("Unknown CloudEvent spec version attribute");
+        }
+
+
+        [Fact]
+        public void ItShouldThrowWhenConvertingToCloudEventsWithNullFormatter()
+        {
+#nullable disable
+            Assert.Throws<ArgumentNullException>(() => new ReceiveMessageResponse().ToCloudEvents(null));
+#nullable enable
+        }
+
+        [Fact]
+        public void ItShouldThrowWhenConvertingToCloudEventsWithNullResponse()
+        {
+#nullable disable
+            ReceiveMessageResponse sqsResponse = null;
+            Assert.Throws<ArgumentNullException>(() => sqsResponse.ToCloudEvents(new JsonEventFormatter()));
+#nullable enable
+        }
+
+        [Fact]
+        public void AttributeValuesShouldBeEqual()
+        {
+            Assert.Equal(SnsPublishRequestExtensions.SpecVersionAttributeKey,
+                SqsResponseExtensions.SpecVersionAttributeKey);
+            Assert.Equal(SnsPublishRequestExtensions.ContentTypeAttributeKey,
+                SqsResponseExtensions.ContentTypeAttributeKey);
+            Assert.Equal(SnsPublishRequestExtensions.CloudEventAttributeKeyPrefix,
+                SqsResponseExtensions.CloudEventAttributeKeyPrefix);
+        }
+
+        private static CloudEvent GetSampleCloudEvent(string contentType)
+        {
+            return new CloudEvent
+            {
+                Id = "Test Id",
+                Source = new Uri("https://www.test_source"),
+                Type = "Test cloud event",
+                DataContentType = contentType,
+                Data = "<much wow=\"xml\"/>"
+            };
+        }
+    }
+}

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventFormatterAttributeTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventFormatterAttributeTest.cs
@@ -71,6 +71,9 @@ namespace CloudNative.CloudEvents.UnitTests
             public override ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent) =>
                 throw new NotImplementedException();
 
+            public override ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent, out ContentType contentType) =>
+                throw new NotImplementedException();
+
             public override ReadOnlyMemory<byte> EncodeStructuredModeMessage(CloudEvent cloudEvent, out ContentType contentType) =>
                 throw new NotImplementedException();
         }

--- a/test/CloudNative.CloudEvents.UnitTests/CloudNative.CloudEvents.UnitTests.csproj
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudNative.CloudEvents.UnitTests.csproj
@@ -21,6 +21,8 @@
     <ProjectReference Include="..\..\src\CloudNative.CloudEvents.Amqp\CloudNative.CloudEvents.Amqp.csproj" />
     <ProjectReference Include="..\..\src\CloudNative.CloudEvents.AspNetCore\CloudNative.CloudEvents.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\CloudNative.CloudEvents.Avro\CloudNative.CloudEvents.Avro.csproj" />
+    <ProjectReference Include="..\..\src\CloudNative.CloudEvents.AwsSns\CloudNative.CloudEvents.AwsSns.csproj" />
+    <ProjectReference Include="..\..\src\CloudNative.CloudEvents.AwsSqs\CloudNative.CloudEvents.AwsSqs.csproj" />
     <ProjectReference Include="..\..\src\CloudNative.CloudEvents.Kafka\CloudNative.CloudEvents.Kafka.csproj" />
     <ProjectReference Include="..\..\src\CloudNative.CloudEvents.Mqtt\CloudNative.CloudEvents.Mqtt.csproj" />
     <ProjectReference Include="..\..\src\CloudNative.CloudEvents.NewtonsoftJson\CloudNative.CloudEvents.NewtonsoftJson.csproj" />

--- a/test/CloudNative.CloudEvents.UnitTests/TestHelpers.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/TestHelpers.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace CloudNative.CloudEvents.UnitTests
@@ -178,6 +179,16 @@ namespace CloudNative.CloudEvents.UnitTests
             {
                 AssertCloudEventsEqual(pair.x, pair.y);
             }
+        }
+
+        /// <summary>
+        /// Deep copy object instance by serializing and deserializing it.
+        /// </summary>
+        /// <param name="object">The object to copy.</param>
+        internal static T DeepCopy<T>(T @object)
+        {
+            var serialized = JsonConvert.SerializeObject(@object);
+            return JsonConvert.DeserializeObject<T>(serialized)!;
         }
     }
 }


### PR DESCRIPTION
Hello dear maintainers, 
I'm Rafal and as the title of this PR says I want to propose a protocol binding implementation for AWS Simple Notification Service and AWS Simple Queue Service.

In my company we decided to use CloudEvents for communication between applications, and since we use AWS SNS and SQS services I had the opportunity to implement this functionality. For the sake of time I did it using only CotentMode.Structured. 
I liked the work, so later I went ahead and in my spare time extended the implementation so that it fully meets the requirements for protocol bindings. So here it is, awaiting review and I hope you like it. 

Notes:
1. I know up front that I have made some questionable decisions, but I am completely open to changing or even removing them.  For example, I added integration tests that run AWS services in a docker container. The execution time for these tests is about 10sec on my machine. Also the first setup of these tests can take a very long time if the required docker image is not present in the cache, I guess this always happens in github workflow. Nevertheless, I committed these tests because I think they are helpful and give confidence that the implementation works. I would like to know your opinion. 

2. Like I said, it's already working for us, so you can take your time during the review ;) 