### PR TITLE
fix: Minor tweaks to the System.Text.Json JsonEventFormatter for compliance

### DIFF
--- a/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/JsonElementAsserter.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/JsonElementAsserter.cs
@@ -39,6 +39,7 @@ namespace CloudNative.CloudEvents.SystemTextJson.UnitTests
                         JsonValueKind.String => property.GetString(),
                         JsonValueKind.Number => property.GetInt32(),
                         JsonValueKind.Null => (object?) null,
+                        JsonValueKind.Object => JsonSerializer.Deserialize(property.GetRawText(), expectation.value.GetType()),
                         _ => throw new Exception($"Unhandled value kind: {property.ValueKind}")
                     };
 


### PR DESCRIPTION
- Make "JSON media type detection" configurable, and default to */json and */*+json
- Default to JSON content type (including making it present in the serialized event)
- Make a "binary vs non-binary" distinction as the first part of serialization (instead of as a fallback)
- Deserialize string data values regardless of content type
- Prohibit non-string data values for non-JSON content types

Signed-off-by: Jon Skeet <jonskeet@google.com>

(This is basically the System.Text.Json equivalent of #191 - it should be a 1:1 mapping between the two, and indeed a lot was copy/pasted to make that the case...)