### PR TITLE
Release 2.2.0 (with Protobuf 2.0.0-beta.1)

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,12 @@
 # Version history (from 2.0)
 
+## 2.2.0 (2022-02-02)
+
+- Bug fix: the "source" attribute is now validated to be non-empty
+- Bug fix: the JSON event formatters comply with the clarified JSON event format spec
+- Dependency: Apache.Avro dependency updated to 1.11.0
+- Feature: New package CloudNative.CloudEvents.Protobuf, released as 2.0.0-beta.1
+
 ## 2.1.1 (2021-07-21)
 
 Bug fix ([#77](https://github.com/cloudevents/sdk-csharp/pull/177)): dependency on the

--- a/src/CloudNative.CloudEvents.Protobuf/CloudNative.CloudEvents.Protobuf.csproj
+++ b/src/CloudNative.CloudEvents.Protobuf/CloudNative.CloudEvents.Protobuf.csproj
@@ -6,7 +6,7 @@
 	<PackageTags>cncf;cloudnative;cloudevents;events;protobuf</PackageTags>
 	<LangVersion>8.0</LangVersion>
 	<Nullable>enable</Nullable>
-	<Version>2.0.0-local.1</Version>
+	<Version>2.0.0-beta.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
       - We use the same version number for all stable
       - packages. See PROCESSES.md for details.
       -->
-    <Version>2.1.1</Version>
+    <Version>2.2.0</Version>
     
     <!-- Make the repository root available for other properties -->
     <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))</RepoRoot>


### PR DESCRIPTION
Changes in this release:

- Bug fix: the "source" attribute is now validated to be non-empty
- Bug fix: the JSON event formatters comply with the clarified JSON event format spec
- Dependency: Apache.Avro dependency updated to 1.11.0
- Feature: New package CloudNative.CloudEvents.Protobuf, released as 2.0.0-beta.1

Signed-off-by: Jon Skeet <jonskeet@google.com>