### PR TITLE
Release 2.3.0

### DIFF
--- a/docs/bindings.md
+++ b/docs/bindings.md
@@ -1,6 +1,6 @@
 # Implementing a protocol binding
 
-From the [specification](https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#protocol-binding):
+From the [specification](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#protocol-binding):
 
 > A protocol binding describes how events are sent and received over a given protocol.
 

--- a/docs/formatters.md
+++ b/docs/formatters.md
@@ -2,7 +2,7 @@
 
 The `CloudEventFormatter` abstract type in the C# SDK is an
 augmentation of the [Event
-Format](https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#event-format)
+Format](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#event-format)
 concept in the specification.
 
 Strictly speaking, CloudEvent data is simply a sequence of bytes. In

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -47,7 +47,7 @@ There are three kinds of attributes:
 - Extension: these attributes are not formalized as part of the
   CloudEvents specification. The CloudEvents specification repository
   [includes descriptions of some extension
-  attributes](https://github.com/cloudevents/spec/tree/v1.0.1/extensions)
+  attributes](https://github.com/cloudevents/spec/tree/main/cloudevents/extensions)
   that may become standardized over time, but they are not
   considered part of the specification.
   

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,14 @@
 # Version history (from 2.0)
 
+## 2.3.0 (2022-05-31)
+
+- Bug fix: BinaryDataUtilities.AsArray misbehavior with array segments ([#209](https://github.com/cloudevents/sdk-csharp/issues/209))
+- Bug fix: Links within XML documentation corrected after spec repo change
+- Feature: Reject "data" as a context attribute name (spec has been clarified for this)
+- Feature: Support Data content type inference in event formatters
+  - The JsonEventFormatter classes infer "application/json" for all data
+- Feature: CloudNative.CloudEvents.Protobuf is now GA (same version as other packages)
+
 ## 2.2.0 (2022-02-02)
 
 - Bug fix: the "source" attribute is now validated to be non-empty
@@ -9,7 +18,7 @@
 
 ## 2.1.1 (2021-07-21)
 
-Bug fix ([#77](https://github.com/cloudevents/sdk-csharp/pull/177)): dependency on the
+Bug fix ([#177](https://github.com/cloudevents/sdk-csharp/pull/177)): dependency on the
 `Nullable` package was not declared with `PrivateAssets=all`,
 leading to that showing up as a dependency. This would break users
 who explicitly have a dependency on an older version of `Nullable`.

--- a/src/CloudNative.CloudEvents.Protobuf/CloudNative.CloudEvents.Protobuf.csproj
+++ b/src/CloudNative.CloudEvents.Protobuf/CloudNative.CloudEvents.Protobuf.csproj
@@ -6,7 +6,6 @@
 	<PackageTags>cncf;cloudnative;cloudevents;events;protobuf</PackageTags>
 	<LangVersion>8.0</LangVersion>
 	<Nullable>enable</Nullable>
-	<Version>2.0.0-beta.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
       - We use the same version number for all stable
       - packages. See PROCESSES.md for details.
       -->
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     
     <!-- Make the repository root available for other properties -->
     <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))</RepoRoot>


### PR DESCRIPTION
Changes since 2.2.0:

- Bug fix: BinaryDataUtilities.AsArray misbehavior with array segments ([https://github.com/cloudevents/sdk-csharp/issues/209](https://github.com/cloudevents/sdk-csharp/issues/209))
- Bug fix: Links within XML documentation corrected after spec repo change
- Feature: Reject "data" as a context attribute name (spec has been clarified for this)
- Feature: Support Data content type inference in event formatters
  - The JsonEventFormatter classes infer "application/json" for all data
- Feature: CloudNative.CloudEvents.Protobuf is now GA (same version as other packages)

