### PR TITLE
ci(nuget): make dotnet pack deterministic

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -35,6 +35,6 @@ jobs:
 
     - name: Push to NuGet
       run: |
-        dotnet pack -c Release -o $PWD/nuget
+        dotnet pack -c Release -p:ContinuousIntegrationBuild=true -o $PWD/nuget
         for file in nuget/*.nupkg; do dotnet nuget push -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}} $file; done
 


### PR DESCRIPTION
This should solve #175 according to [this blog post](https://devblogs.microsoft.com/dotnet/producing-packages-with-source-link/#deterministic-builds).

Alternatively one could also add 

```csproj
<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
  <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
</PropertyGroup>
```

to `src/Directory.Build.props`.