### PR TITLE
fix: adding missing mandatory Id attribute

### DIFF
--- a/samples/HttpSend/Program.cs
+++ b/samples/HttpSend/Program.cs
@@ -35,6 +35,7 @@ namespace HttpSend
         {
             var cloudEvent = new CloudEvent
             {
+                Id = new Guid().ToString(),
                 Type = Type,
                 Source = new Uri(Source),
                 DataContentType = MediaTypeNames.Application.Json,


### PR DESCRIPTION
without Id attribute in cloudEvent the program doesn't work and return an error:
`Unhandled exception. System.ArgumentException: CloudEvent is missing required attributes: id (Parameter 'cloudEvent')`