### PR TITLE
Release 2.3.1

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,10 @@
 # Version history (from 2.0)
 
+## 2.3.1 (2022-06-29)
+
+- Bug fix: ignore the charset when determining the content type for decoding JSON ([#216](https://github.com/cloudevents/sdk-csharp/issues/216))
+- Bug fix: make the NuGet package deterministic ([#175](https://github.com/cloudevents/sdk-csharp/issues/175))
+
 ## 2.3.0 (2022-05-31)
 
 - Bug fix: BinaryDataUtilities.AsArray misbehavior with array segments ([#209](https://github.com/cloudevents/sdk-csharp/issues/209))

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
       - We use the same version number for all stable
       - packages. See PROCESSES.md for details.
       -->
-    <Version>2.3.0</Version>
+    <Version>2.3.1</Version>
     
     <!-- Make the repository root available for other properties -->
     <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))</RepoRoot>


### PR DESCRIPTION
Changes since 2.3.0:

- Bug fix: ignore the charset when determining the content type for decoding JSON (#216)
- Bug fix: make the NuGet package deterministic (#175)

Signed-off-by: Jon Skeet <jonskeet@google.com>