### PR TITLE
fix: Put AvroEventFormatter in the right namespace

### DIFF
--- a/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Mime;
 
-namespace CloudNative.CloudEvents
+namespace CloudNative.CloudEvents.Avro
 {
     /// <summary>
     /// Formatter that implements the Avro Event Format.

--- a/src/CloudNative.CloudEvents.Avro/CloudNative.CloudEvents.Avro.csproj
+++ b/src/CloudNative.CloudEvents.Avro/CloudNative.CloudEvents.Avro.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>Avro extensions for CloudNative.CloudEvents</Description>
     <PackageTags>cncf;cloudnative;cloudevents;events;avro</PackageTags>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/CloudNative.CloudEvents.Avro/ObsoleteFormatter.cs
+++ b/src/CloudNative.CloudEvents.Avro/ObsoleteFormatter.cs
@@ -1,0 +1,20 @@
+﻿// Copyright 2021 Cloud Native Foundation. 
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace CloudNative.CloudEvents;
+
+/// <summary>
+/// Formatter that implements the Avro Event Format.
+/// </summary>
+/// <remarks>
+/// This class is the wrong namespace, and is only present for backward compatibility reasons.
+/// Please use CloudNative.CloudEvents.Avro.AvroEventFormatter instead
+/// (which this class derives from for convenience).
+/// </remarks>
+[Obsolete("This class is the wrong namespace, and is only present for backward compatibility reasons. Please use CloudNative.CloudEvents.Avro.AvroEventFormatter.")]
+public class AvroEventFormatter : Avro.AvroEventFormatter
+{
+}


### PR DESCRIPTION
We still need it in CloudNative.CloudEvents for backward
compatibility, but we can do that via derivation - which is
pleasantly simple given that the only constructor is parameterless.

Users should update to use the CloudNative.CloudEvents.Avro
namespace at their earliest convenience.

Fixes #219.

Signed-off-by: Jon Skeet <jonskeet@google.com>