### PR TITLE
fix: Perform release builds with ContinuousIntegrationBuild=true

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Build
       run: |
-        dotnet build -c Release
+        dotnet build -c Release -p:ContinuousIntegrationBuild=true
         dotnet test -c Release
         mkdir nuget
 


### PR DESCRIPTION
(The build needs to be done this way, not just the packing.)

Fixes #175

Signed-off-by: Jon Skeet <jonskeet@google.com>