### PR TITLE
feat: Allow empty payloads in Kafka, in order to support compaction tombstones

### DIFF
--- a/src/CloudNative.CloudEvents.Kafka/KafkaExtensions.cs
+++ b/src/CloudNative.CloudEvents.Kafka/KafkaExtensions.cs
@@ -140,8 +140,6 @@ namespace CloudNative.CloudEvents.Kafka
             Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
             Validation.CheckNotNull(formatter, nameof(formatter));
 
-            // TODO: Is this appropriate? Why can't we transport a CloudEvent without data in Kafka?
-            Validation.CheckArgument(cloudEvent.Data is object, nameof(cloudEvent), "Only CloudEvents with data can be converted to Kafka messages");
             var headers = MapHeaders(cloudEvent);
             string? key = (string?) cloudEvent[Partitioning.PartitionKeyAttribute];
             byte[] value;

--- a/test/CloudNative.CloudEvents.UnitTests/Kafka/KafkaTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Kafka/KafkaTest.cs
@@ -78,6 +78,7 @@ namespace CloudNative.CloudEvents.Kafka.UnitTests
             AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time!.Value);
             Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
+
             Assert.Equal("value", (string?)receivedCloudEvent["comexampleextension1"]);
         }
 

--- a/test/CloudNative.CloudEvents.UnitTests/Kafka/KafkaTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Kafka/KafkaTest.cs
@@ -133,6 +133,7 @@ namespace CloudNative.CloudEvents.Kafka.UnitTests
         [InlineData(MediaTypeNames.Application.Json, null)]
         [InlineData(MediaTypeNames.Application.Xml, "")]
         [InlineData(MediaTypeNames.Text.Plain, "")]
+        [InlineData(null, null)]
         public void KafkaBinaryMessageTombstoneTest(string contentType, object? expectedDecodedResult)
         {
             var jsonEventFormatter = new JsonEventFormatter();

--- a/test/CloudNative.CloudEvents.UnitTests/Kafka/KafkaTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Kafka/KafkaTest.cs
@@ -129,6 +129,58 @@ namespace CloudNative.CloudEvents.Kafka.UnitTests
             Assert.Equal("value", (string?)receivedCloudEvent["comexampleextension1"]);
         }
 
+        [Theory]
+        [InlineData(MediaTypeNames.Application.Octet, new byte[0])]
+        [InlineData(MediaTypeNames.Application.Json,null)]
+        [InlineData(MediaTypeNames.Application.Xml,"")]
+        [InlineData(MediaTypeNames.Text.Plain,"")]
+        public void KafkaBinaryMessageTombstoneTest(string contentType, object? expectedDecodedResult)
+        {
+            var jsonEventFormatter = new JsonEventFormatter();
+            var cloudEvent = new CloudEvent(Partitioning.AllAttributes)
+            {
+                Type = "com.github.pull.create",
+                Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
+                Id = "A234-1234-1234",
+                Time = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero),
+                DataContentType = contentType,
+                Data = null,
+                ["comexampleextension1"] = "value",
+                [Partitioning.PartitionKeyAttribute] = "hello much wow"
+            };
+
+            var message = cloudEvent.ToKafkaMessage(ContentMode.Binary, new JsonEventFormatter());
+            Assert.True(message.IsCloudEvent());
+            
+            // Sending an empty message is equivalent to a delete (tombstone) for that partition key, when using compacted topics in Kafka.
+            // This is the main use case for empty data messages with Kafka.
+            Assert.Empty(message.Value);
+
+            // Using serialization to create fully independent copy thus simulating message transport.
+            // The real transport will work in a similar way.
+            var serialized = JsonConvert.SerializeObject(message, new HeaderConverter());
+            var settings = new JsonSerializerSettings
+            {
+                Converters = { new HeadersConverter(), new HeaderConverter() }
+            };
+            var messageCopy = JsonConvert.DeserializeObject<Message<string?, byte[]>>(serialized, settings)!;
+
+            Assert.True(messageCopy.IsCloudEvent());
+            var receivedCloudEvent = messageCopy.ToCloudEvent(jsonEventFormatter, Partitioning.AllAttributes);
+
+            Assert.Equal(CloudEventsSpecVersion.Default, receivedCloudEvent.SpecVersion);
+            Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
+            Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
+            Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
+            AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time!.Value);
+            Assert.Equal(contentType,receivedCloudEvent.DataContentType);
+            Assert.Equal(expectedDecodedResult, receivedCloudEvent.Data);
+            Assert.Equal("hello much wow", (string?) receivedCloudEvent[Partitioning.PartitionKeyAttribute]);
+
+            Assert.Equal("value", (string?)receivedCloudEvent["comexampleextension1"]);
+        }
+
+        
         [Fact]
         public void ContentTypeCanBeInferredByFormatter()
         {

--- a/test/CloudNative.CloudEvents.UnitTests/Kafka/KafkaTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Kafka/KafkaTest.cs
@@ -57,7 +57,7 @@ namespace CloudNative.CloudEvents.Kafka.UnitTests
                 Data = "<much wow=\"xml\"/>",
                 ["comexampleextension1"] = "value"
             };
-       
+
             var message = cloudEvent.ToKafkaMessage(ContentMode.Structured, new JsonEventFormatter());
 
             Assert.True(message.IsCloudEvent());
@@ -78,7 +78,6 @@ namespace CloudNative.CloudEvents.Kafka.UnitTests
             AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time!.Value);
             Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
-
             Assert.Equal("value", (string?)receivedCloudEvent["comexampleextension1"]);
         }
 
@@ -124,16 +123,16 @@ namespace CloudNative.CloudEvents.Kafka.UnitTests
             AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time!.Value);
             Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
-            Assert.Equal("hello much wow", (string?) receivedCloudEvent[Partitioning.PartitionKeyAttribute]);
+            Assert.Equal("hello much wow", (string?)receivedCloudEvent[Partitioning.PartitionKeyAttribute]);
 
             Assert.Equal("value", (string?)receivedCloudEvent["comexampleextension1"]);
         }
 
         [Theory]
         [InlineData(MediaTypeNames.Application.Octet, new byte[0])]
-        [InlineData(MediaTypeNames.Application.Json,null)]
-        [InlineData(MediaTypeNames.Application.Xml,"")]
-        [InlineData(MediaTypeNames.Text.Plain,"")]
+        [InlineData(MediaTypeNames.Application.Json, null)]
+        [InlineData(MediaTypeNames.Application.Xml, "")]
+        [InlineData(MediaTypeNames.Text.Plain, "")]
         public void KafkaBinaryMessageTombstoneTest(string contentType, object? expectedDecodedResult)
         {
             var jsonEventFormatter = new JsonEventFormatter();
@@ -151,7 +150,7 @@ namespace CloudNative.CloudEvents.Kafka.UnitTests
 
             var message = cloudEvent.ToKafkaMessage(ContentMode.Binary, new JsonEventFormatter());
             Assert.True(message.IsCloudEvent());
-            
+
             // Sending an empty message is equivalent to a delete (tombstone) for that partition key, when using compacted topics in Kafka.
             // This is the main use case for empty data messages with Kafka.
             Assert.Empty(message.Value);
@@ -173,14 +172,14 @@ namespace CloudNative.CloudEvents.Kafka.UnitTests
             Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
             Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
             AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time!.Value);
-            Assert.Equal(contentType,receivedCloudEvent.DataContentType);
+            Assert.Equal(contentType, receivedCloudEvent.DataContentType);
             Assert.Equal(expectedDecodedResult, receivedCloudEvent.Data);
-            Assert.Equal("hello much wow", (string?) receivedCloudEvent[Partitioning.PartitionKeyAttribute]);
+            Assert.Equal("hello much wow", (string?)receivedCloudEvent[Partitioning.PartitionKeyAttribute]);
 
             Assert.Equal("value", (string?)receivedCloudEvent["comexampleextension1"]);
         }
 
-        
+
         [Fact]
         public void ContentTypeCanBeInferredByFormatter()
         {
@@ -208,17 +207,16 @@ namespace CloudNative.CloudEvents.Kafka.UnitTests
                 {
                     return null;
                 }
-                else 
-                {
-                    var surrogate = serializer.Deserialize<List<Header>>(reader)!;
-                    var headers = new Headers();
 
-                    foreach(var header in surrogate)
-                    {
-                        headers.Add(header.Key, header.GetValueBytes());
-                    }
-                    return headers;
+                var surrogate = serializer.Deserialize<List<Header>>(reader)!;
+                var headers = new Headers();
+
+                foreach (var header in surrogate)
+                {
+                    headers.Add(header.Key, header.GetValueBytes());
                 }
+
+                return headers;
             }
 
             public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)

--- a/test/CloudNative.CloudEvents.UnitTests/Kafka/KafkaTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Kafka/KafkaTest.cs
@@ -57,7 +57,7 @@ namespace CloudNative.CloudEvents.Kafka.UnitTests
                 Data = "<much wow=\"xml\"/>",
                 ["comexampleextension1"] = "value"
             };
-
+       
             var message = cloudEvent.ToKafkaMessage(ContentMode.Structured, new JsonEventFormatter());
 
             Assert.True(message.IsCloudEvent());
@@ -123,7 +123,7 @@ namespace CloudNative.CloudEvents.Kafka.UnitTests
             AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time!.Value);
             Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
-            Assert.Equal("hello much wow", (string?)receivedCloudEvent[Partitioning.PartitionKeyAttribute]);
+            Assert.Equal("hello much wow", (string?) receivedCloudEvent[Partitioning.PartitionKeyAttribute]);
 
             Assert.Equal("value", (string?)receivedCloudEvent["comexampleextension1"]);
         }
@@ -176,10 +176,8 @@ namespace CloudNative.CloudEvents.Kafka.UnitTests
             Assert.Equal(contentType, receivedCloudEvent.DataContentType);
             Assert.Equal(expectedDecodedResult, receivedCloudEvent.Data);
             Assert.Equal("hello much wow", (string?)receivedCloudEvent[Partitioning.PartitionKeyAttribute]);
-
             Assert.Equal("value", (string?)receivedCloudEvent["comexampleextension1"]);
         }
-
 
         [Fact]
         public void ContentTypeCanBeInferredByFormatter()
@@ -208,16 +206,17 @@ namespace CloudNative.CloudEvents.Kafka.UnitTests
                 {
                     return null;
                 }
-
-                var surrogate = serializer.Deserialize<List<Header>>(reader)!;
-                var headers = new Headers();
-
-                foreach (var header in surrogate)
+                else 
                 {
-                    headers.Add(header.Key, header.GetValueBytes());
-                }
+                    var surrogate = serializer.Deserialize<List<Header>>(reader)!;
+                    var headers = new Headers();
 
-                return headers;
+                    foreach(var header in surrogate)
+                    {
+                        headers.Add(header.Key, header.GetValueBytes());
+                    }
+                    return headers;
+                }
             }
 
             public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)


### PR DESCRIPTION
In order to support deletes for compacted topics, this PR allows empty / null payloads to be sent when using the Kafka extension.  The previous requirement that the payload is present has been dropped, and tests added.

Ref [Log compaction](https://kafka.apache.org/documentation/#compaction)