### PR TITLE
Implement underscore prefixes for AMQP

### DIFF
--- a/test/CloudNative.CloudEvents.UnitTests/Amqp/AmqpTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Amqp/AmqpTest.cs
@@ -5,7 +5,6 @@
 using Amqp;
 using Amqp.Framing;
 using CloudNative.CloudEvents.NewtonsoftJson;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Net.Mime;
 using System.Text;
@@ -20,55 +19,18 @@ namespace CloudNative.CloudEvents.Amqp.UnitTests
         public void AmqpStructuredMessageTest()
         {
             // The AMQPNetLite library is factored such that we don't need to do a wire test here.
-            var cloudEvent = new CloudEvent
-            {
-                Type = "com.github.pull.create",
-                Source = new Uri("https://github.com/cloudevents/spec/pull"),
-                Subject = "123",
-                Id = "A234-1234-1234",
-                Time = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero),
-                DataContentType = MediaTypeNames.Text.Xml,
-                Data = "<much wow=\"xml\"/>",
-                ["comexampleextension1"] = "value"
-            };
-
+            var cloudEvent = CreateSampleCloudEvent();
             var message = cloudEvent.ToAmqpMessage(ContentMode.Structured, new JsonEventFormatter());
             Assert.True(message.IsCloudEvent());
-            var encodedAmqpMessage = message.Encode();
-
-            var message1 = Message.Decode(encodedAmqpMessage);
-            Assert.True(message1.IsCloudEvent());
-            var receivedCloudEvent = message1.ToCloudEvent(new JsonEventFormatter());
-
-            Assert.Equal(CloudEventsSpecVersion.Default, receivedCloudEvent.SpecVersion);
-            Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
-            Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull"), receivedCloudEvent.Source);
-            Assert.Equal("123", receivedCloudEvent.Subject);
-            Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-            AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time!.Value);
-            Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
-            Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
-
-            Assert.Equal("value", (string?)receivedCloudEvent["comexampleextension1"]);
+            AssertDecodeThenEqual(cloudEvent, message);
         }
 
         [Fact]
         public void AmqpBinaryMessageTest()
         {
             // The AMQPNetLite library is factored such that we don't need to do a wire test here.
-            var cloudEvent = new CloudEvent
-            {
-                Type = "com.github.pull.create",
-                Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
-                Subject = "123",
-                Id = "A234-1234-1234",
-                Time = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero),
-                DataContentType = MediaTypeNames.Text.Xml,
-                Data = "<much wow=\"xml\"/>",
-                ["comexampleextension1"] = "value"
-            };
-
-            var message = cloudEvent.ToAmqpMessage(ContentMode.Binary, new JsonEventFormatter());
+            var cloudEvent = CreateSampleCloudEvent();
+            var message = cloudEvent.ToAmqpMessage(ContentMode.Binary, new JsonEventFormatter());            
             Assert.True(message.IsCloudEvent());
             var encodedAmqpMessage = message.Encode();
 
@@ -76,15 +38,7 @@ namespace CloudNative.CloudEvents.Amqp.UnitTests
             Assert.True(message1.IsCloudEvent());
             var receivedCloudEvent = message1.ToCloudEvent(new JsonEventFormatter());
 
-            Assert.Equal(CloudEventsSpecVersion.Default, receivedCloudEvent.SpecVersion);
-            Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
-            Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
-            Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-            AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time!.Value);
-            Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
-            Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
-
-            Assert.Equal("value", (string?)receivedCloudEvent["comexampleextension1"]);
+            AssertCloudEventsEqual(cloudEvent, receivedCloudEvent);
         }
 
         [Fact]
@@ -108,9 +62,7 @@ namespace CloudNative.CloudEvents.Amqp.UnitTests
                 Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
                 Id = "A234-1234-1234",
                 // 2018-04-05T18:31:00+01:00 => 2018-04-05T17:31:00Z
-                Time = new DateTimeOffset(2018, 4, 5, 18, 31, 0, TimeSpan.FromHours(1)),
-                DataContentType = MediaTypeNames.Text.Xml,
-                Data = "<much wow=\"xml\"/>"
+                Time = new DateTimeOffset(2018, 4, 5, 18, 31, 0, TimeSpan.FromHours(1))
             };
 
             var message = cloudEvent.ToAmqpMessage(ContentMode.Binary, new JsonEventFormatter());
@@ -134,5 +86,57 @@ namespace CloudNative.CloudEvents.Amqp.UnitTests
             var text = Encoding.UTF8.GetString(body.Binary);
             Assert.Equal("some text", text);
         }
+
+        [Fact]
+        public void DefaultPrefix()
+        {
+            var cloudEvent = CreateSampleCloudEvent();
+
+            var message = cloudEvent.ToAmqpMessage(ContentMode.Binary, new JsonEventFormatter());
+            Assert.Equal(cloudEvent.Id, message.ApplicationProperties["cloudEvents:id"]);
+            AssertDecodeThenEqual(cloudEvent, message);
+        }
+
+        [Fact]
+        public void UnderscorePrefix()
+        {
+            var cloudEvent = CreateSampleCloudEvent();
+            var message = cloudEvent.ToAmqpMessageWithUnderscorePrefix(ContentMode.Binary, new JsonEventFormatter());
+            Assert.Equal(cloudEvent.Id, message.ApplicationProperties["cloudEvents_id"]);
+            AssertDecodeThenEqual(cloudEvent, message);
+        }
+
+        [Fact]
+        public void ColonPrefix()
+        {
+            var cloudEvent = CreateSampleCloudEvent();
+            var message = cloudEvent.ToAmqpMessageWithColonPrefix(ContentMode.Binary, new JsonEventFormatter());
+            Assert.Equal(cloudEvent.Id, message.ApplicationProperties["cloudEvents:id"]);
+            AssertDecodeThenEqual(cloudEvent, message);
+        }
+
+        private void AssertDecodeThenEqual(CloudEvent cloudEvent, Message message)
+        {
+            var encodedAmqpMessage = message.Encode();
+
+            var message1 = Message.Decode(encodedAmqpMessage);
+            var receivedCloudEvent = message1.ToCloudEvent(new JsonEventFormatter());
+            AssertCloudEventsEqual(cloudEvent, receivedCloudEvent);
+        }
+
+        /// <summary>
+        /// Returns a CloudEvent with XML data and an extension.
+        /// </summary>
+        private static CloudEvent CreateSampleCloudEvent() => new CloudEvent
+        {
+            Type = "com.github.pull.create",
+            Source = new Uri("https://github.com/cloudevents/spec/pull"),
+            Subject = "123",
+            Id = "A234-1234-1234",
+            Time = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero),
+            DataContentType = MediaTypeNames.Text.Xml,
+            Data = "<much wow=\"xml\"/>",
+            ["comexampleextension1"] = "value"
+        };
     }
 }


### PR DESCRIPTION
The [binding specification](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/amqp-protocol-binding.md)
has changed to prefer `cloudEvents_` over `cloudEvents:`. Previously `cloudEvents_` wouldn't even have been valid.

With this change, users can either:

- Stick with the default prefix, which doesn't change immediately, but which will change in the first release on or after March 1st 2023
- Explicitly use one or other prefix using the explicitly-named methods

Other options considered:

- Changing the default now: that's too much of a breaking change. (I don't want to take a major version bump for this, and with enough time for the change, I think that's okay.)
- Adding a char or string parameter: that would invite using non-standard prefixes
- Adding a Boolean parameter: that would become problematic if we ever end up with a third prefix. (Let's hope we don't, but still...)
- Adding an enum and then a parameter for it: feels like overkill

Signed-off-by: Jon Skeet <jonskeet@google.com>