### PR TITLE
Release 2.5.0

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,14 @@
 # Version history (from 2.0)
 
+## 2.5.0 (2022-10-17)
+
+- Dependencies: update dependencies in CloudNative.CloudEvents.AspNetCore:
+  - Remove dependency on Microsoft.AspNetCore.Mvc.Core (as we don't use it)
+  - Update dependency on Microsoft.AspNetCore.Http to 2.1.34
+  - Explicitly add dependency on System.Text.Encodings.Web 6.0.0 to avoid security issue in older version
+
+No APIs have changed, but this is a minor release due to the significant dependency changes.
+
 ## 2.4.0 (2022-09-08)
 
 - Feature: Implement underscore prefixes for AMQP (see below for more details) ([#236](https://github.com/cloudevents/sdk-csharp/pull/236))

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
       - We use the same version number for all stable
       - packages. See PROCESSES.md for details.
       -->
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     
     <!-- Make the repository root available for other properties -->
     <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))</RepoRoot>


### PR DESCRIPTION
Changes since 2.4.0:

- Dependencies: update dependencies in CloudNative.CloudEvents.AspNetCore:
  - Remove dependency on Microsoft.AspNetCore.Mvc.Core (as we don't use it)
  - Update dependency on Microsoft.AspNetCore.Http to 2.1.34
  - Explicitly add dependency on System.Text.Encodings.Web 6.0.0 to avoid security issue in older version

No APIs have changed, but this is a minor release due to the significant dependency changes.

Signed-off-by: Jon Skeet <jonskeet@google.com>