### PR TITLE
Use PackageLicenseExpression instead of PackageLicenseFile

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,7 +24,7 @@
 
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/cloudevents/sdk-csharp</RepositoryUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://cloudevents.io</PackageProjectUrl>
     <Copyright>Copyright Cloud Native Foundation</Copyright>
   </PropertyGroup>


### PR DESCRIPTION
Note that the license file is still embedded in the package (at the root) to conform with the requirement that it's delivered with the software.

Fixes #252

Signed-off-by: Jon Skeet <jonskeet@google.com>