### PR TITLE
Release 2.6.0

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,16 @@
 # Version history (from 2.0)
 
+## 2.6.0 (2023-03-07)
+
+- Dependencies: system-level dependencies updated
+- The NuGet package now uses PackageLicenseExpression (but still
+  includes the licence file as well).
+  Fixes ([#252](https://github.com/cloudevents/sdk-csharp/issues/252)).
+- Regenerated protobuf schema using the original filename of
+  cloudevents.proto instead of ProtoSchema.proto. An additional
+  ProtoSchemaReflection class has been added purely for compatibility.
+  Fixes ([#256](https://github.com/cloudevents/sdk-csharp/issues/256)).
+
 ## 2.5.1 (2022-11-10)
 
 - Dependencies: update dependencies in CloudNative.CloudEvents.Avro

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
       - We use the same version number for all stable
       - packages. See PROCESSES.md for details.
       -->
-    <Version>2.5.1</Version>
+    <Version>2.6.0</Version>
     
     <!-- Make the repository root available for other properties -->
     <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))</RepoRoot>


### PR DESCRIPTION
Changes since 2.5.1:

- Dependencies: system-level dependencies updated
- The NuGet package now uses PackageLicenseExpression (but still includes the licence file as well). Fixes ([#252](https://github.com/cloudevents/sdk-csharp/issues/252)).
- Regenerated protobuf schema using the original filename of cloudevents.proto instead of ProtoSchema.proto. An additional ProtoSchemaReflection class has been added purely for compatibility. Fixes ([#256](https://github.com/cloudevents/sdk-csharp/issues/256)).