### PR TITLE
Release 2.7.1

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,10 @@
 # Version history (from 2.0)
 
+## 2.7.1 (2023-09-04)
+
+- Prevent string resource lookup if not required
+  Fixes ([#264](https://github.com/cloudevents/sdk-csharp/issues/264)).
+
 ## 2.7.0 (2023-07-31)
 
 - Add the ability to specify a custom serializer for Avro.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
       - We use the same version number for all stable
       - packages. See PROCESSES.md for details.
       -->
-    <Version>2.7.0</Version>
+    <Version>2.7.1</Version>
     
     <!-- Make the repository root available for other properties -->
     <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))</RepoRoot>


### PR DESCRIPTION
Changes since 2.7.0:

- Prevent string resource lookup if not required. Fixes ([#264](https://github.com/cloudevents/sdk-csharp/issues/264)).