### PR TITLE
chore: Fix editorconfig-based warnings

### DIFF
--- a/samples/HttpSend/Program.cs
+++ b/samples/HttpSend/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Cloud Native Foundation.
+// Copyright (c) Cloud Native Foundation.
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
@@ -17,7 +17,7 @@ namespace HttpSend
 {
     // This application uses the McMaster.Extensions.CommandLineUtils library for parsing the command
     // line and calling the application code. The [Option] attributes designate the parameters.
-    class Program
+    internal class Program
     {
         [Option(Description = "CloudEvents 'source' (default: urn:example-com:mysource:abc)", LongName = "source", ShortName = "s")]
         private string Source { get; } = "urn:example-com:mysource:abc";

--- a/src/CloudNative.CloudEvents/CloudEventAttribute.cs
+++ b/src/CloudNative.CloudEvents/CloudEventAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Cloud Native Foundation. 
+// Copyright 2021 Cloud Native Foundation. 
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
@@ -44,7 +44,7 @@ namespace CloudNative.CloudEvents
         /// </summary>
         public bool IsExtension { get; }
 
-        private Action<object>? validator;
+        private readonly Action<object>? validator;
 
         // TODO: Have a "mode" of Required/Optional/Extension?
 

--- a/src/CloudNative.CloudEvents/CloudEventAttributeType.cs
+++ b/src/CloudNative.CloudEvents/CloudEventAttributeType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Cloud Native Foundation. 
+// Copyright 2021 Cloud Native Foundation. 
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
@@ -105,16 +105,16 @@ namespace CloudNative.CloudEvents
             {
             }
 
-            public override sealed object Parse(string value) => ParseImpl(Validation.CheckNotNull(value, nameof(value)));
+            public sealed override object Parse(string value) => ParseImpl(Validation.CheckNotNull(value, nameof(value)));
 
-            public override sealed string Format(object value)
+            public sealed override string Format(object value)
             {
                 Validate(value);
                 // TODO: Avoid the double cast.
                 return FormatImpl((T) value);
             }
 
-            public override sealed void Validate(object value)
+            public sealed override void Validate(object value)
             {
                 Validation.CheckNotNull(value, nameof(value));
                 if (!ClrType.IsInstanceOfType(value))

--- a/src/CloudNative.CloudEvents/CloudEventsSpecVersion.cs
+++ b/src/CloudNative.CloudEvents/CloudEventsSpecVersion.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Cloud Native Foundation. 
+// Copyright 2021 Cloud Native Foundation. 
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
@@ -89,7 +89,7 @@ namespace CloudNative.CloudEvents
         /// </summary>
         public CloudEventAttribute TypeAttribute { get; }
 
-        private Dictionary<string, CloudEventAttribute> attributesByName;
+        private readonly Dictionary<string, CloudEventAttribute> attributesByName;
 
         // TODO: What's the compatibility story? What might be in 1.1, and how would we handle that in 1.0?
 

--- a/src/CloudNative.CloudEvents/Core/BinaryDataUtilities.cs
+++ b/src/CloudNative.CloudEvents/Core/BinaryDataUtilities.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Cloud Native Foundation.
+// Copyright 2021 Cloud Native Foundation.
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
@@ -22,7 +22,7 @@ namespace CloudNative.CloudEvents.Core
         /// </summary>
         /// <param name="stream">The stream to read from. Must not be null.</param>
         /// <returns>The content of the stream (from its original position), as a read-only memory segment.</returns>
-        public async static Task<ReadOnlyMemory<byte>> ToReadOnlyMemoryAsync(Stream stream)
+        public static async Task<ReadOnlyMemory<byte>> ToReadOnlyMemoryAsync(Stream stream)
         {
             Validation.CheckNotNull(stream, nameof(stream));
             // TODO: Optimize if it's already a MemoryStream? Will only work in some cases,

--- a/src/CloudNative.CloudEvents/Http/HttpListenerExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpListenerExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Cloud Native Foundation.
+// Copyright 2021 Cloud Native Foundation.
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
@@ -138,7 +138,7 @@ namespace CloudNative.CloudEvents.Http
         /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
         /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
         /// <returns>A reference to a validated CloudEvent instance.</returns>
-        public async static Task<CloudEvent> ToCloudEventAsync(this HttpListenerRequest httpListenerRequest,
+        public static async Task<CloudEvent> ToCloudEventAsync(this HttpListenerRequest httpListenerRequest,
             CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
             await ToCloudEventAsyncImpl(httpListenerRequest, formatter, extensionAttributes, async: true).ConfigureAwait(false);
 
@@ -164,7 +164,7 @@ namespace CloudNative.CloudEvents.Http
             CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
             ToCloudEventAsyncImpl(httpListenerRequest, formatter, extensionAttributes, async: false).GetAwaiter().GetResult();
 
-        private async static Task<CloudEvent> ToCloudEventAsyncImpl(HttpListenerRequest httpListenerRequest,
+        private static async Task<CloudEvent> ToCloudEventAsyncImpl(HttpListenerRequest httpListenerRequest,
             CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes, bool async)
         {
             Validation.CheckNotNull(httpListenerRequest, nameof(httpListenerRequest));
@@ -264,7 +264,7 @@ namespace CloudNative.CloudEvents.Http
             IEnumerable<CloudEventAttribute>? extensionAttributes) =>
             ToCloudEventBatchInternalAsync(httpListenerRequest, formatter, extensionAttributes, async: false).GetAwaiter().GetResult();
 
-        private async static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchInternalAsync(HttpListenerRequest httpListenerRequest,
+        private static async Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchInternalAsync(HttpListenerRequest httpListenerRequest,
             CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes, bool async)
         {
             Validation.CheckNotNull(httpListenerRequest, nameof(httpListenerRequest));

--- a/test/CloudNative.CloudEvents.UnitTests/ConformanceTestData/SampleBatches.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/ConformanceTestData/SampleBatches.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2023 Cloud Native Foundation.
+// Copyright 2023 Cloud Native Foundation.
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
@@ -11,7 +11,7 @@ namespace CloudNative.CloudEvents.UnitTests.ConformanceTestData;
 
 public static class SampleBatches
 {
-    private static ConcurrentDictionary<string, IReadOnlyList<CloudEvent>> batchesById = new ConcurrentDictionary<string, IReadOnlyList<CloudEvent>>();
+    private static readonly ConcurrentDictionary<string, IReadOnlyList<CloudEvent>> batchesById = new ConcurrentDictionary<string, IReadOnlyList<CloudEvent>>();
 
     private static readonly IReadOnlyList<CloudEvent> empty = Register("empty");
     private static readonly IReadOnlyList<CloudEvent> minimal = Register("minimal", SampleEvents.Minimal);

--- a/test/CloudNative.CloudEvents.UnitTests/ConformanceTestData/SampleEvents.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/ConformanceTestData/SampleEvents.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2023 Cloud Native Foundation.
+// Copyright 2023 Cloud Native Foundation.
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
@@ -10,9 +10,9 @@ namespace CloudNative.CloudEvents.UnitTests.ConformanceTestData;
 
 internal static class SampleEvents
 {
-    private static ConcurrentDictionary<string, CloudEvent> eventsById = new ConcurrentDictionary<string, CloudEvent>();
+    private static readonly ConcurrentDictionary<string, CloudEvent> eventsById = new ConcurrentDictionary<string, CloudEvent>();
 
-    private static IReadOnlyList<CloudEventAttribute> allExtensionAttributes = new List<CloudEventAttribute>()
+    private static readonly IReadOnlyList<CloudEventAttribute> allExtensionAttributes = new List<CloudEventAttribute>()
     {
         CloudEventAttribute.CreateExtension("extinteger", CloudEventAttributeType.Integer),
         CloudEventAttribute.CreateExtension("extboolean", CloudEventAttributeType.Boolean),

--- a/test/CloudNative.CloudEvents.UnitTests/TimestampsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/TimestampsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Cloud Native Foundation. 
+// Copyright 2021 Cloud Native Foundation. 
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
@@ -79,7 +79,7 @@ namespace CloudNative.CloudEvents.UnitTests
             AssertParseSuccess(expected, text);
         }
 
-        static void AssertParseSuccess(DateTimeOffset expected, string text)
+        private static void AssertParseSuccess(DateTimeOffset expected, string text)
         {
             var parsed = Timestamps.Parse(text);
             AssertTimestampsEqual(expected, parsed);


### PR DESCRIPTION
(It can be hard to get these to show up without opening the code file itself. I've opened all files within VS, so we *should* be "clean" now.)

(Again, will self-merge - there's nothing semantic here.)