### PR TITLE
Upgrade to .NET SDK 8.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,14 @@ jobs:
       with:
         submodules: true
 
-    # Build with .NET 6.0 SDK
-    - name: Setup .NET 6.0
+    # Build with .NET 8.0 SDK
+    # Test with .NET 6.0 and 8.0
+    - name: Setup .NET 6.0 and 8.0
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: |
+          8.0.x
+          6.0.x
 
     - name: Build
       run: |

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -17,11 +17,14 @@ jobs:
       with:
         submodules: true
 
-    # Build with .NET 6.0 SDK
-    - name: Setup .NET 6.0
+    # Build with .NET 8.0 SDK
+    # Test with .NET 6.0 and 8.0
+    - name: Setup .NET 6.0 and 8.0
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: |
+          8.0.x
+          6.0.x
 
     - name: Build
       run: |

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.100",
+    "allowPrerelease": false,
+    "rollForward": "latestMinor"
+  }
+}

--- a/src/CloudNative.CloudEvents.Amqp/AmqpExtensions.cs
+++ b/src/CloudNative.CloudEvents.Amqp/AmqpExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Cloud Native Foundation.
+// Copyright (c) Cloud Native Foundation.
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
@@ -8,6 +8,7 @@ using Amqp.Types;
 using CloudNative.CloudEvents.Core;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net.Mime;
 
@@ -145,7 +146,7 @@ namespace CloudNative.CloudEvents.Amqp
             }
         }
 
-        private static bool HasCloudEventsContentType(Message message, out string? contentType)
+        private static bool HasCloudEventsContentType(Message message, [NotNullWhen(true)] out string? contentType)
         {
             contentType = message.Properties.ContentType?.ToString();
             return MimeUtilities.IsCloudEventsContentType(contentType);

--- a/src/CloudNative.CloudEvents.Amqp/CloudNative.CloudEvents.Amqp.csproj
+++ b/src/CloudNative.CloudEvents.Amqp/CloudNative.CloudEvents.Amqp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <Description>AMQP extensions for CloudNative.CloudEvents</Description>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/CloudNative.CloudEvents.Amqp/CloudNative.CloudEvents.Amqp.csproj
+++ b/src/CloudNative.CloudEvents.Amqp/CloudNative.CloudEvents.Amqp.csproj
@@ -12,6 +12,8 @@
     <PackageReference Include="AMQPNetLite" Version="2.4.2" />
     <PackageReference Include="AMQPNetLite.Serialization" Version="2.4.2" />
     <ProjectReference Include="..\CloudNative.CloudEvents\CloudNative.CloudEvents.csproj" />
+    <!-- Source-only package with nullable reference annotations. -->
+    <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/CloudNative.CloudEvents.AspNetCore/CloudNative.CloudEvents.AspNetCore.csproj
+++ b/src/CloudNative.CloudEvents.AspNetCore/CloudNative.CloudEvents.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <Description>ASP.Net Core extensions for CloudNative.CloudEvents</Description>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
@@ -185,7 +185,7 @@ namespace CloudNative.CloudEvents.Avro
             // will fail and that's okay since the type is useless without the proper schema.
             using var sr = new StreamReader(typeof(AvroEventFormatter)
                 .Assembly
-                .GetManifestResourceStream("CloudNative.CloudEvents.Avro.AvroSchema.json"));
+                .GetManifestResourceStream("CloudNative.CloudEvents.Avro.AvroSchema.json")!);
 
             return (RecordSchema) Schema.Parse(sr.ReadToEnd());
         }

--- a/src/CloudNative.CloudEvents.Avro/CloudNative.CloudEvents.Avro.csproj
+++ b/src/CloudNative.CloudEvents.Avro/CloudNative.CloudEvents.Avro.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <Description>Avro extensions for CloudNative.CloudEvents</Description>
     <PackageTags>cncf;cloudnative;cloudevents;events;avro</PackageTags>
     <LangVersion>10.0</LangVersion>

--- a/src/CloudNative.CloudEvents.Kafka/CloudNative.CloudEvents.Kafka.csproj
+++ b/src/CloudNative.CloudEvents.Kafka/CloudNative.CloudEvents.Kafka.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <Description>Kafka extensions for CloudNative.CloudEvents</Description>
     <PackageTags>cncf;cloudnative;cloudevents;events;kafka</PackageTags>
     <LangVersion>8.0</LangVersion>

--- a/src/CloudNative.CloudEvents.Mqtt/CloudNative.CloudEvents.Mqtt.csproj
+++ b/src/CloudNative.CloudEvents.Mqtt/CloudNative.CloudEvents.Mqtt.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <Description>MQTT extensions for CloudNative.CloudEvents</Description>
     <PackageTags>cncf;cloudnative;cloudevents;events;mqtt</PackageTags>
     <LangVersion>8.0</LangVersion>

--- a/src/CloudNative.CloudEvents.NewtonsoftJson/CloudNative.CloudEvents.NewtonsoftJson.csproj
+++ b/src/CloudNative.CloudEvents.NewtonsoftJson/CloudNative.CloudEvents.NewtonsoftJson.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <Description>JSON support for the CNCF CloudEvents SDK, based on Newtonsoft.Json.</Description>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/CloudNative.CloudEvents.NewtonsoftJson/JsonEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.NewtonsoftJson/JsonEventFormatter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Cloud Native Foundation.
+// Copyright (c) Cloud Native Foundation.
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
@@ -345,7 +345,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson
             {
                 throw new ArgumentException($"Structured mode property '{DataBase64PropertyName}' must be a string, when present.");
             }
-            cloudEvent.Data = Convert.FromBase64String((string?) dataBase64Token);
+            cloudEvent.Data = Convert.FromBase64String((string) dataBase64Token!);
         }
 
         /// <summary>
@@ -498,7 +498,7 @@ namespace CloudNative.CloudEvents.NewtonsoftJson
         /// </summary>
         /// <param name="data">The CloudEvent to infer the data content from. Must not be null.</param>
         /// <returns>The inferred data content type, or null if no inference is performed.</returns>
-        protected override string? InferDataContentType(object data) => data is byte[]? null : JsonMediaType;
+        protected override string? InferDataContentType(object data) => data is byte[] ? null : JsonMediaType;
 
         /// <summary>
         /// Encodes structured mode data within a CloudEvent, writing it to the specified <see cref="JsonWriter"/>.
@@ -524,7 +524,14 @@ namespace CloudNative.CloudEvents.NewtonsoftJson
             }
             else
             {
-                ContentType dataContentType = new ContentType(GetOrInferDataContentType(cloudEvent));
+                string? dataContentTypeText = GetOrInferDataContentType(cloudEvent);
+                // This would only happen in a derived class which overrides GetOrInferDataContentType further...
+                // This class infers application/json for anything other than byte arrays.
+                if (dataContentTypeText is null)
+                {
+                    throw new ArgumentException("Data content type cannot be inferred");
+                }
+                ContentType dataContentType = new ContentType(dataContentTypeText);
                 if (IsJsonMediaType(dataContentType.MediaType))
                 {
                     writer.WritePropertyName(DataPropertyName);

--- a/src/CloudNative.CloudEvents.Protobuf/CloudNative.CloudEvents.Protobuf.csproj
+++ b/src/CloudNative.CloudEvents.Protobuf/CloudNative.CloudEvents.Protobuf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+	<TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
 	<Description>Support for the Protobuf event format in for CloudNative.CloudEvents</Description>
 	<PackageTags>cncf;cloudnative;cloudevents;events;protobuf</PackageTags>
 	<LangVersion>10.0</LangVersion>

--- a/src/CloudNative.CloudEvents.SystemTextJson/CloudNative.CloudEvents.SystemTextJson.csproj
+++ b/src/CloudNative.CloudEvents.SystemTextJson/CloudNative.CloudEvents.SystemTextJson.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <Description>JSON support for the CNCF CloudEvents SDK, based on System.Text.Json.</Description>
     <LangVersion>8.0</LangVersion>
     <PackageTags>cncf;cloudnative;cloudevents;events;json;systemtextjson</PackageTags>

--- a/src/CloudNative.CloudEvents/CloudEventFormatterAttribute.cs
+++ b/src/CloudNative.CloudEvents/CloudEventFormatterAttribute.cs
@@ -56,7 +56,7 @@ namespace CloudNative.CloudEvents
                 throw new ArgumentException($"The {nameof(CloudEventFormatterAttribute)} on type {targetType} has no converter type specified.", nameof(targetType));
             }
 
-            object instance;
+            object? instance;
             try
             {
                 instance = Activator.CreateInstance(formatterType);

--- a/src/CloudNative.CloudEvents/CloudNative.CloudEvents.csproj
+++ b/src/CloudNative.CloudEvents/CloudNative.CloudEvents.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='netstandard2.1'" />
     <!-- Source-only package with nullable reference annotations. -->
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
   </ItemGroup>

--- a/src/CloudNative.CloudEvents/CloudNative.CloudEvents.csproj
+++ b/src/CloudNative.CloudEvents/CloudNative.CloudEvents.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <Description>CNCF CloudEvents SDK</Description>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/CloudNative.CloudEvents/Core/MimeUtilities.cs
+++ b/src/CloudNative.CloudEvents/Core/MimeUtilities.cs
@@ -1,8 +1,9 @@
-﻿// Copyright 2021 Cloud Native Foundation.
+// Copyright 2021 Cloud Native Foundation.
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http.Headers;
 using System.Net.Mime;
 using System.Text;
@@ -57,7 +58,7 @@ namespace CloudNative.CloudEvents.Core
             var header = new MediaTypeHeaderValue(contentType.MediaType);
             foreach (string parameterName in contentType.Parameters.Keys)
             {
-                header.Parameters.Add(new NameValueHeaderValue(parameterName, contentType.Parameters[parameterName].ToString()));
+                header.Parameters.Add(new NameValueHeaderValue(parameterName, contentType.Parameters[parameterName]));
             }
             return header;
         }
@@ -76,7 +77,7 @@ namespace CloudNative.CloudEvents.Core
         /// </summary>
         /// <param name="contentType">The content type to check. May be null, in which case the result is false.</param>
         /// <returns>true if the given content type denotes a (non-batch) CloudEvent; false otherwise</returns>
-        public static bool IsCloudEventsContentType(string? contentType) =>
+        public static bool IsCloudEventsContentType([NotNullWhen(true)] string? contentType) =>
             contentType is string &&
             contentType.StartsWith(MediaType, StringComparison.InvariantCultureIgnoreCase) &&
             !contentType.StartsWith(BatchMediaType, StringComparison.InvariantCultureIgnoreCase);
@@ -86,7 +87,7 @@ namespace CloudNative.CloudEvents.Core
         /// </summary>
         /// <param name="contentType">The content type to check. May be null, in which case the result is false.</param>
         /// <returns>true if the given content type represents a CloudEvent batch; false otherwise</returns>
-        public static bool IsCloudEventsBatchContentType(string? contentType) =>
+        public static bool IsCloudEventsBatchContentType([NotNullWhen(true)] string? contentType) =>
             contentType is string && contentType.StartsWith(BatchMediaType, StringComparison.InvariantCultureIgnoreCase);
     }
 }

--- a/src/CloudNative.CloudEvents/Http/HttpListenerExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpListenerExtensions.cs
@@ -179,7 +179,7 @@ namespace CloudNative.CloudEvents.Http
             }
             else
             {
-                string versionId = httpListenerRequest.Headers[HttpUtilities.SpecVersionHttpHeader];
+                string? versionId = httpListenerRequest.Headers[HttpUtilities.SpecVersionHttpHeader];
                 if (versionId is null)
                 {
                     throw new ArgumentException($"Request does not represent a CloudEvent. It has neither a {HttpUtilities.SpecVersionHttpHeader} header, nor a suitable content type.", nameof(httpListenerRequest));
@@ -191,12 +191,18 @@ namespace CloudNative.CloudEvents.Http
                 var headers = httpListenerRequest.Headers;
                 foreach (var key in headers.AllKeys)
                 {
+                    // It would be highly unusual for either the key or the value to be null, but
+                    // the contract claims it's possible. Skip it if so.
+                    if (key is null || headers[key] is not string headerValue)
+                    {
+                        continue;
+                    }
                     string? attributeName = HttpUtilities.GetAttributeNameFromHeaderName(key);
                     if (attributeName is null || attributeName == CloudEventsSpecVersion.SpecVersionAttribute.Name)
                     {
                         continue;
                     }
-                    string attributeValue = HttpUtilities.DecodeHeaderValue(headers[key]);
+                    string attributeValue = HttpUtilities.DecodeHeaderValue(headerValue);
                     cloudEvent.SetAttributeFromString(attributeName, attributeValue);
                 }
 

--- a/test/CloudNative.CloudEvents.IntegrationTests/CloudNative.CloudEvents.IntegrationTests.csproj
+++ b/test/CloudNative.CloudEvents.IntegrationTests/CloudNative.CloudEvents.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/CloudNative.CloudEvents.UnitTests/CloudNative.CloudEvents.UnitTests.csproj
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudNative.CloudEvents.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
I was originally intending *not* to actually target net8.0 in the nuget package itself, but given that it gets rid of the System.Memory dependency *and* it's much simpler in terms of not having to exclude it, I think this is the way to go.

No behavioral changes in this PR, except for some potentially pathological cases (where the new behavior is better).

This is one step towards #272.