### PR TITLE
Add a code of conduct document

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,6 @@
+# Code of Conduct
+
+The CloudEvents C# SDK is committed to the [CNCF Code of
+Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+Please refer to that document for details of the standards, reporting processes and
+enforcement.


### PR DESCRIPTION
This just refers to the CNCF code of conduct instead of containing the details directly, so that we don't need to change anything if the CNCF document changes.

cc @captainsafia