### PR TITLE
Fix up null check in Timestamps.TryParse

### DIFF
--- a/src/CloudNative.CloudEvents/Timestamps.cs
+++ b/src/CloudNative.CloudEvents/Timestamps.cs
@@ -47,13 +47,9 @@ namespace CloudNative.CloudEvents
         /// <param name="input">A string to be parsed as a <see cref="DateTimeOffset"/>.</param>
         /// <param name="result">A <see cref="DateTimeOffset"/> parsed from the <paramref name="input"/>.</param>
         /// <returns><see langword="true"/> if <paramref name="input"/> was parsed successfully, <see langword="false"/> otherwise.</returns>
-        public static bool TryParse(string input, out DateTimeOffset result)
+        internal static bool TryParse(string input, out DateTimeOffset result)
         {
-            if (string.IsNullOrEmpty(input))
-            {
-                result = default;
-                return false;
-            }
+            Validation.CheckNotNull(input, nameof(input));
 
             if (input.Length < MinLength) // "yyyy-MM-ddTHH:mm:ssZ" is the shortest possible value.
             {

--- a/src/CloudNative.CloudEvents/Timestamps.cs
+++ b/src/CloudNative.CloudEvents/Timestamps.cs
@@ -44,13 +44,16 @@ namespace CloudNative.CloudEvents
         /// <summary>
         /// Attempts to parse a string as an RFC-3339-formatted date/time and UTC offset.
         /// </summary>
-        /// <param name="input"></param>
-        /// <param name="result"></param>
-        /// <returns></returns>
+        /// <param name="input">A string to be parsed as a <see cref="DateTimeOffset"/>.</param>
+        /// <param name="result">A <see cref="DateTimeOffset"/> parsed from the <paramref name="input"/>.</param>
+        /// <returns><see langword="true"/> if <paramref name="input"/> was parsed successfully, <see langword="false"/> otherwise.</returns>
         public static bool TryParse(string input, out DateTimeOffset result)
         {
-            // TODO: Check this and add a test
-            Validation.CheckNotNull(input, nameof(input));
+            if (string.IsNullOrEmpty(input))
+            {
+                result = default;
+                return false;
+            }
 
             if (input.Length < MinLength) // "yyyy-MM-ddTHH:mm:ssZ" is the shortest possible value.
             {

--- a/test/CloudNative.CloudEvents.UnitTests/TimestampsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/TimestampsTest.cs
@@ -89,7 +89,6 @@ namespace CloudNative.CloudEvents.UnitTests
         }
 
         [Theory]
-        [InlineData(null)]
         [InlineData("")]
         [InlineData("garbage")]
         [InlineData("garbage that is long enough")]
@@ -122,6 +121,13 @@ namespace CloudNative.CloudEvents.UnitTests
         {
             Assert.False(Timestamps.TryParse(text, out _));
             Assert.Throws<FormatException>(() => Timestamps.Parse(text));
+        }
+
+        [Fact]
+        public void Parse_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => Timestamps.TryParse(null!, out _));
+            Assert.Throws<ArgumentNullException>(() => Timestamps.Parse(null!));
         }
 
         /// <summary>

--- a/test/CloudNative.CloudEvents.UnitTests/TimestampsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/TimestampsTest.cs
@@ -1,4 +1,4 @@
-// Copyright 2021 Cloud Native Foundation. 
+// Copyright 2021 Cloud Native Foundation.
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
@@ -89,6 +89,7 @@ namespace CloudNative.CloudEvents.UnitTests
         }
 
         [Theory]
+        [InlineData(null)]
         [InlineData("")]
         [InlineData("garbage")]
         [InlineData("garbage that is long enough")]


### PR DESCRIPTION
Spotted this while working my way through TODOs in the codebase.

I think the right approach is to return false and set the result to default if the input is null. AFAIK, this is in line with null-handling behavior in `TryParse` methods in the BCL.

Is there a particular reason we threw an exception here previously? Happy to adjust the PR as needed.