### PR TITLE
Update the minor version we check against for compatibility

### DIFF
--- a/src/CloudNative.CloudEvents.Mqtt/CloudNative.CloudEvents.Mqtt.csproj
+++ b/src/CloudNative.CloudEvents.Mqtt/CloudNative.CloudEvents.Mqtt.csproj
@@ -6,8 +6,7 @@
     <PackageTags>cncf;cloudnative;cloudevents;events;mqtt</PackageTags>
     <LangVersion>8.0</LangVersion>
     <Version>3.$(MinorVersion).$(PatchVersion)</Version>
-    <!-- After the first release of v3, we'll change the major here to 3. -->
-    <PackageValidationBaselineVersion>2.$(PackageValidationMinor).0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>3.$(PackageValidationMinor).0</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,7 +8,7 @@
     <MajorVersion>2</MajorVersion>
     <MinorVersion>8</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <PackageValidationMinor>7</PackageValidationMinor>
+    <PackageValidationMinor>8</PackageValidationMinor>
     <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
     <!-- 
       - The version used for detecting breaking changes.


### PR DESCRIPTION
Additionally, this updates the major version of MQTT that we check against, now that 3.8.0 has been released.

cc @captainsafia 