### PR TITLE
Add recommended extensions and auto-sign-off for VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ bld/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
-.vscode/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "ms-dotnettools.csdevkit",
+        "humao.rest-client"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "git.alwaysSignOff": true
+}


### PR DESCRIPTION
This adds some QoL for VS Code users.

- Add the extensions for .NET and Rest client. 
- Automatically sign-off when using VS Code. 
- Allowed the VS Code folder in general by removing the entry from `gitignore`. Personally, I haven't encountered a file I wouldn't want to check in from that folder. Also, some files from that folder were already checked in, so that would make it more consistent with the current files anyway. 