### PR TITLE
File-based namespaces modernization

### DIFF
--- a/src/CloudNative.CloudEvents.Amqp/AmqpExtensions.cs
+++ b/src/CloudNative.CloudEvents.Amqp/AmqpExtensions.cs
@@ -12,242 +12,241 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net.Mime;
 
-namespace CloudNative.CloudEvents.Amqp
+namespace CloudNative.CloudEvents.Amqp;
+
+/// <summary>
+/// Extension methods to convert between CloudEvents and AMQP messages.
+/// </summary>
+public static class AmqpExtensions
 {
+    // This is internal in CloudEventsSpecVersion.
+    private const string SpecVersionAttributeName = "specversion";
+
+    internal const string AmqpHeaderUnderscorePrefix = "cloudEvents_";
+    internal const string AmqpHeaderColonPrefix = "cloudEvents:";
+
+    internal const string SpecVersionAmqpHeaderWithUnderscore = AmqpHeaderUnderscorePrefix + SpecVersionAttributeName;
+    internal const string SpecVersionAmqpHeaderWithColon = AmqpHeaderColonPrefix + SpecVersionAttributeName;
+
     /// <summary>
-    /// Extension methods to convert between CloudEvents and AMQP messages.
+    /// Indicates whether this <see cref="Message"/> holds a single CloudEvent.
     /// </summary>
-    public static class AmqpExtensions
+    /// <remarks>
+    /// This method returns false for batch requests, as they need to be parsed differently.
+    /// </remarks>
+    /// <param name="message">The message to check for the presence of a CloudEvent. Must not be null.</param>
+    /// <returns>true, if the request is a CloudEvent</returns>
+    public static bool IsCloudEvent(this Message message) =>
+        HasCloudEventsContentType(Validation.CheckNotNull(message, nameof(message)), out _) ||
+        message.ApplicationProperties.Map.ContainsKey(SpecVersionAmqpHeaderWithUnderscore) ||
+        message.ApplicationProperties.Map.ContainsKey(SpecVersionAmqpHeaderWithColon);
+
+    /// <summary>
+    /// Converts this AMQP message into a CloudEvent object.
+    /// </summary>
+    /// <param name="message">The AMQP message to convert. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
+    /// <returns>A reference to a validated CloudEvent instance.</returns>
+    public static CloudEvent ToCloudEvent(
+        this Message message,
+        CloudEventFormatter formatter,
+        params CloudEventAttribute[]? extensionAttributes) =>
+        ToCloudEvent(message, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
+
+    /// <summary>
+    /// Converts this AMQP message into a CloudEvent object.
+    /// </summary>
+    /// <param name="message">The AMQP message to convert. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
+    /// <returns>A reference to a validated CloudEvent instance.</returns>
+    public static CloudEvent ToCloudEvent(
+        this Message message,
+        CloudEventFormatter formatter,
+        IEnumerable<CloudEventAttribute>? extensionAttributes)
     {
-        // This is internal in CloudEventsSpecVersion.
-        private const string SpecVersionAttributeName = "specversion";
+        Validation.CheckNotNull(message, nameof(message));
+        Validation.CheckNotNull(formatter, nameof(formatter));
 
-        internal const string AmqpHeaderUnderscorePrefix = "cloudEvents_";
-        internal const string AmqpHeaderColonPrefix = "cloudEvents:";
-
-        internal const string SpecVersionAmqpHeaderWithUnderscore = AmqpHeaderUnderscorePrefix + SpecVersionAttributeName;
-        internal const string SpecVersionAmqpHeaderWithColon = AmqpHeaderColonPrefix + SpecVersionAttributeName;
-
-        /// <summary>
-        /// Indicates whether this <see cref="Message"/> holds a single CloudEvent.
-        /// </summary>
-        /// <remarks>
-        /// This method returns false for batch requests, as they need to be parsed differently.
-        /// </remarks>
-        /// <param name="message">The message to check for the presence of a CloudEvent. Must not be null.</param>
-        /// <returns>true, if the request is a CloudEvent</returns>
-        public static bool IsCloudEvent(this Message message) =>
-            HasCloudEventsContentType(Validation.CheckNotNull(message, nameof(message)), out _) ||
-            message.ApplicationProperties.Map.ContainsKey(SpecVersionAmqpHeaderWithUnderscore) ||
-            message.ApplicationProperties.Map.ContainsKey(SpecVersionAmqpHeaderWithColon);
-
-        /// <summary>
-        /// Converts this AMQP message into a CloudEvent object.
-        /// </summary>
-        /// <param name="message">The AMQP message to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
-        /// <returns>A reference to a validated CloudEvent instance.</returns>
-        public static CloudEvent ToCloudEvent(
-            this Message message,
-            CloudEventFormatter formatter,
-            params CloudEventAttribute[]? extensionAttributes) =>
-            ToCloudEvent(message, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
-
-        /// <summary>
-        /// Converts this AMQP message into a CloudEvent object.
-        /// </summary>
-        /// <param name="message">The AMQP message to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
-        /// <returns>A reference to a validated CloudEvent instance.</returns>
-        public static CloudEvent ToCloudEvent(
-            this Message message,
-            CloudEventFormatter formatter,
-            IEnumerable<CloudEventAttribute>? extensionAttributes)
+        if (HasCloudEventsContentType(message, out var contentType))
         {
-            Validation.CheckNotNull(message, nameof(message));
-            Validation.CheckNotNull(formatter, nameof(formatter));
-
-            if (HasCloudEventsContentType(message, out var contentType))
-            {
-                return formatter.DecodeStructuredModeMessage(new MemoryStream((byte[]) message.Body), new ContentType(contentType), extensionAttributes);
-            }
-            else
-            {
-                var propertyMap = message.ApplicationProperties.Map;
-                if (!propertyMap.TryGetValue(SpecVersionAmqpHeaderWithUnderscore, out var versionId) &&
-                    !propertyMap.TryGetValue(SpecVersionAmqpHeaderWithColon, out versionId))
-                {
-                    throw new ArgumentException("Request is not a CloudEvent");
-                }
-
-                var version = CloudEventsSpecVersion.FromVersionId(versionId as string)
-                    ?? throw new ArgumentException($"Unknown CloudEvents spec version '{versionId}'", nameof(message));
-
-                var cloudEvent = new CloudEvent(version, extensionAttributes)
-                {
-                    DataContentType = message.Properties.ContentType
-                };
-
-                foreach (var property in propertyMap)
-                {
-                    if (!(property.Key is string key &&
-                        (key.StartsWith(AmqpHeaderColonPrefix) || key.StartsWith(AmqpHeaderUnderscorePrefix))))
-                    {
-                        continue;
-                    }
-                    // Note: both prefixes have the same length. If we ever need any prefixes with a different length, we'll need to know which
-                    // prefix we're looking at.
-                    string attributeName = key.Substring(AmqpHeaderUnderscorePrefix.Length).ToLowerInvariant();
-
-                    // We've already dealt with the spec version.
-                    if (attributeName == CloudEventsSpecVersion.SpecVersionAttribute.Name)
-                    {
-                        continue;
-                    }
-
-                    // Timestamps are serialized via DateTime instead of DateTimeOffset.
-                    if (property.Value is DateTime dt)
-                    {
-                        if (dt.Kind != DateTimeKind.Utc)
-                        {
-                            // This should only happen for MinValue and MaxValue...
-                            // just respecify as UTC. (We could add validation that it really
-                            // *is* MinValue or MaxValue if we wanted to.)
-                            dt = DateTime.SpecifyKind(dt, DateTimeKind.Utc);
-                        }
-                        cloudEvent[attributeName] = (DateTimeOffset) dt;
-                    }
-                    // URIs are serialized as strings, but we need to convert them back to URIs.
-                    // It's simplest to let CloudEvent do this for us.
-                    else if (property.Value is string text)
-                    {
-                        cloudEvent.SetAttributeFromString(attributeName, text);
-                    }
-                    else
-                    {
-                        cloudEvent[attributeName] = property.Value;
-                    }
-                }
-                // Populate the data after the rest of the CloudEvent
-                if (message.BodySection is Data data)
-                {
-                    // Note: Fetching the Binary property will always retrieve the data. It will
-                    // be copied from the Buffer property if necessary.
-                    formatter.DecodeBinaryModeEventData(data.Binary, cloudEvent);
-                }
-                else if (message.BodySection is object)
-                {
-                    throw new ArgumentException("Binary mode data in AMQP message must be in the application data section");
-                }
-
-                return Validation.CheckCloudEventArgument(cloudEvent, nameof(message));
-            }
+            return formatter.DecodeStructuredModeMessage(new MemoryStream((byte[]) message.Body), new ContentType(contentType), extensionAttributes);
         }
-
-        private static bool HasCloudEventsContentType(Message message, [NotNullWhen(true)] out string? contentType)
+        else
         {
-            contentType = message.Properties.ContentType?.ToString();
-            return MimeUtilities.IsCloudEventsContentType(contentType);
-        }
-
-        /// <summary>
-        /// Converts a CloudEvent to <see cref="Message"/> using the default property prefix. Versions released prior to March 2023
-        /// use a default property prefix of "cloudEvents:". Versions released from March 2023 onwards use a property prefix of "cloudEvents_".
-        /// Code wishing to express the prefix explicitly should use <see cref="ToAmqpMessageWithColonPrefix(CloudEvent, ContentMode, CloudEventFormatter)"/> or
-        /// <see cref="ToAmqpMessageWithUnderscorePrefix(CloudEvent, ContentMode, CloudEventFormatter)"/>.
-        /// </summary>
-        /// <param name="cloudEvent">The CloudEvent to convert. Must not be null, and must be a valid CloudEvent.</param>
-        /// <param name="contentMode">Content mode. Structured or binary.</param>
-        /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
-        public static Message ToAmqpMessage(this CloudEvent cloudEvent, ContentMode contentMode, CloudEventFormatter formatter) =>
-            ToAmqpMessage(cloudEvent, contentMode, formatter, AmqpHeaderColonPrefix);
-
-        /// <summary>
-        /// Converts a CloudEvent to <see cref="Message"/> using a property prefix of "cloudEvents_". This prefix was introduced as the preferred
-        /// prefix for the AMQP binding in August 2022.
-        /// </summary>
-        /// <param name="cloudEvent">The CloudEvent to convert. Must not be null, and must be a valid CloudEvent.</param>
-        /// <param name="contentMode">Content mode. Structured or binary.</param>
-        /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
-        public static Message ToAmqpMessageWithUnderscorePrefix(this CloudEvent cloudEvent, ContentMode contentMode, CloudEventFormatter formatter) =>
-            ToAmqpMessage(cloudEvent, contentMode, formatter, AmqpHeaderUnderscorePrefix);
-
-        /// <summary>
-        /// Converts a CloudEvent to <see cref="Message"/> using a property prefix of "cloudEvents:". This prefix
-        /// is a legacy retained only for compatibility purposes; it can't be used by JMS due to constraints in JMS property names.
-        /// </summary>
-        /// <param name="cloudEvent">The CloudEvent to convert. Must not be null, and must be a valid CloudEvent.</param>
-        /// <param name="contentMode">Content mode. Structured or binary.</param>
-        /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
-        public static Message ToAmqpMessageWithColonPrefix(this CloudEvent cloudEvent, ContentMode contentMode, CloudEventFormatter formatter) =>
-            ToAmqpMessage(cloudEvent, contentMode, formatter, AmqpHeaderColonPrefix);
-
-        private static Message ToAmqpMessage(CloudEvent cloudEvent, ContentMode contentMode, CloudEventFormatter formatter, string prefix)
-        {
-            Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
-            Validation.CheckNotNull(formatter, nameof(formatter));
-
-            var applicationProperties = MapHeaders(cloudEvent, prefix);
-            RestrictedDescribed bodySection;
-            Properties properties;
-
-            switch (contentMode)
+            var propertyMap = message.ApplicationProperties.Map;
+            if (!propertyMap.TryGetValue(SpecVersionAmqpHeaderWithUnderscore, out var versionId) &&
+                !propertyMap.TryGetValue(SpecVersionAmqpHeaderWithColon, out versionId))
             {
-                case ContentMode.Structured:
-                    bodySection = new Data
-                    {
-                        Binary = BinaryDataUtilities.AsArray(formatter.EncodeStructuredModeMessage(cloudEvent, out var contentType))
-                    };
-                    // TODO: What about the other parts of the content type?
-                    properties = new Properties { ContentType = contentType.MediaType };
-                    break;
-                case ContentMode.Binary:
-                    bodySection = new Data { Binary = BinaryDataUtilities.AsArray(formatter.EncodeBinaryModeEventData(cloudEvent)) };
-                    properties = new Properties { ContentType = formatter.GetOrInferDataContentType(cloudEvent) };
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(contentMode), $"Unsupported content mode: {contentMode}");
+                throw new ArgumentException("Request is not a CloudEvent");
             }
-            return new Message
+
+            var version = CloudEventsSpecVersion.FromVersionId(versionId as string)
+                ?? throw new ArgumentException($"Unknown CloudEvents spec version '{versionId}'", nameof(message));
+
+            var cloudEvent = new CloudEvent(version, extensionAttributes)
             {
-                ApplicationProperties = applicationProperties,
-                BodySection = bodySection,
-                Properties = properties
+                DataContentType = message.Properties.ContentType
             };
-        }
 
-        private static ApplicationProperties MapHeaders(CloudEvent cloudEvent, string prefix)
-        {
-            var applicationProperties = new ApplicationProperties();
-            var properties = applicationProperties.Map;
-            properties.Add(prefix + SpecVersionAttributeName, cloudEvent.SpecVersion.VersionId);
-
-            foreach (var pair in cloudEvent.GetPopulatedAttributes())
+            foreach (var property in propertyMap)
             {
-                var attribute = pair.Key;
+                if (!(property.Key is string key &&
+                    (key.StartsWith(AmqpHeaderColonPrefix) || key.StartsWith(AmqpHeaderUnderscorePrefix))))
+                {
+                    continue;
+                }
+                // Note: both prefixes have the same length. If we ever need any prefixes with a different length, we'll need to know which
+                // prefix we're looking at.
+                string attributeName = key.Substring(AmqpHeaderUnderscorePrefix.Length).ToLowerInvariant();
 
-                // The content type is specified elsewhere.
-                if (attribute == cloudEvent.SpecVersion.DataContentTypeAttribute)
+                // We've already dealt with the spec version.
+                if (attributeName == CloudEventsSpecVersion.SpecVersionAttribute.Name)
                 {
                     continue;
                 }
 
-                string propKey = prefix + attribute.Name;
-
-                // TODO: Check that AMQP can handle byte[], bool and int values
-                object propValue = pair.Value switch
+                // Timestamps are serialized via DateTime instead of DateTimeOffset.
+                if (property.Value is DateTime dt)
                 {
-                    Uri uri => uri.ToString(),
-                    // AMQPNetLite doesn't support DateTimeOffset values, so convert to UTC.
-                    // That means we can't roundtrip events with non-UTC timestamps, but that's not awful.
-                    DateTimeOffset dto => dto.UtcDateTime,
-                    _ => pair.Value
-                };
-                properties.Add(propKey, propValue);
+                    if (dt.Kind != DateTimeKind.Utc)
+                    {
+                        // This should only happen for MinValue and MaxValue...
+                        // just respecify as UTC. (We could add validation that it really
+                        // *is* MinValue or MaxValue if we wanted to.)
+                        dt = DateTime.SpecifyKind(dt, DateTimeKind.Utc);
+                    }
+                    cloudEvent[attributeName] = (DateTimeOffset) dt;
+                }
+                // URIs are serialized as strings, but we need to convert them back to URIs.
+                // It's simplest to let CloudEvent do this for us.
+                else if (property.Value is string text)
+                {
+                    cloudEvent.SetAttributeFromString(attributeName, text);
+                }
+                else
+                {
+                    cloudEvent[attributeName] = property.Value;
+                }
             }
-            return applicationProperties;
+            // Populate the data after the rest of the CloudEvent
+            if (message.BodySection is Data data)
+            {
+                // Note: Fetching the Binary property will always retrieve the data. It will
+                // be copied from the Buffer property if necessary.
+                formatter.DecodeBinaryModeEventData(data.Binary, cloudEvent);
+            }
+            else if (message.BodySection is object)
+            {
+                throw new ArgumentException("Binary mode data in AMQP message must be in the application data section");
+            }
+
+            return Validation.CheckCloudEventArgument(cloudEvent, nameof(message));
         }
+    }
+
+    private static bool HasCloudEventsContentType(Message message, [NotNullWhen(true)] out string? contentType)
+    {
+        contentType = message.Properties.ContentType?.ToString();
+        return MimeUtilities.IsCloudEventsContentType(contentType);
+    }
+
+    /// <summary>
+    /// Converts a CloudEvent to <see cref="Message"/> using the default property prefix. Versions released prior to March 2023
+    /// use a default property prefix of "cloudEvents:". Versions released from March 2023 onwards use a property prefix of "cloudEvents_".
+    /// Code wishing to express the prefix explicitly should use <see cref="ToAmqpMessageWithColonPrefix(CloudEvent, ContentMode, CloudEventFormatter)"/> or
+    /// <see cref="ToAmqpMessageWithUnderscorePrefix(CloudEvent, ContentMode, CloudEventFormatter)"/>.
+    /// </summary>
+    /// <param name="cloudEvent">The CloudEvent to convert. Must not be null, and must be a valid CloudEvent.</param>
+    /// <param name="contentMode">Content mode. Structured or binary.</param>
+    /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
+    public static Message ToAmqpMessage(this CloudEvent cloudEvent, ContentMode contentMode, CloudEventFormatter formatter) =>
+        ToAmqpMessage(cloudEvent, contentMode, formatter, AmqpHeaderColonPrefix);
+
+    /// <summary>
+    /// Converts a CloudEvent to <see cref="Message"/> using a property prefix of "cloudEvents_". This prefix was introduced as the preferred
+    /// prefix for the AMQP binding in August 2022.
+    /// </summary>
+    /// <param name="cloudEvent">The CloudEvent to convert. Must not be null, and must be a valid CloudEvent.</param>
+    /// <param name="contentMode">Content mode. Structured or binary.</param>
+    /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
+    public static Message ToAmqpMessageWithUnderscorePrefix(this CloudEvent cloudEvent, ContentMode contentMode, CloudEventFormatter formatter) =>
+        ToAmqpMessage(cloudEvent, contentMode, formatter, AmqpHeaderUnderscorePrefix);
+
+    /// <summary>
+    /// Converts a CloudEvent to <see cref="Message"/> using a property prefix of "cloudEvents:". This prefix
+    /// is a legacy retained only for compatibility purposes; it can't be used by JMS due to constraints in JMS property names.
+    /// </summary>
+    /// <param name="cloudEvent">The CloudEvent to convert. Must not be null, and must be a valid CloudEvent.</param>
+    /// <param name="contentMode">Content mode. Structured or binary.</param>
+    /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
+    public static Message ToAmqpMessageWithColonPrefix(this CloudEvent cloudEvent, ContentMode contentMode, CloudEventFormatter formatter) =>
+        ToAmqpMessage(cloudEvent, contentMode, formatter, AmqpHeaderColonPrefix);
+
+    private static Message ToAmqpMessage(CloudEvent cloudEvent, ContentMode contentMode, CloudEventFormatter formatter, string prefix)
+    {
+        Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
+        Validation.CheckNotNull(formatter, nameof(formatter));
+
+        var applicationProperties = MapHeaders(cloudEvent, prefix);
+        RestrictedDescribed bodySection;
+        Properties properties;
+
+        switch (contentMode)
+        {
+            case ContentMode.Structured:
+                bodySection = new Data
+                {
+                    Binary = BinaryDataUtilities.AsArray(formatter.EncodeStructuredModeMessage(cloudEvent, out var contentType))
+                };
+                // TODO: What about the other parts of the content type?
+                properties = new Properties { ContentType = contentType.MediaType };
+                break;
+            case ContentMode.Binary:
+                bodySection = new Data { Binary = BinaryDataUtilities.AsArray(formatter.EncodeBinaryModeEventData(cloudEvent)) };
+                properties = new Properties { ContentType = formatter.GetOrInferDataContentType(cloudEvent) };
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(contentMode), $"Unsupported content mode: {contentMode}");
+        }
+        return new Message
+        {
+            ApplicationProperties = applicationProperties,
+            BodySection = bodySection,
+            Properties = properties
+        };
+    }
+
+    private static ApplicationProperties MapHeaders(CloudEvent cloudEvent, string prefix)
+    {
+        var applicationProperties = new ApplicationProperties();
+        var properties = applicationProperties.Map;
+        properties.Add(prefix + SpecVersionAttributeName, cloudEvent.SpecVersion.VersionId);
+
+        foreach (var pair in cloudEvent.GetPopulatedAttributes())
+        {
+            var attribute = pair.Key;
+
+            // The content type is specified elsewhere.
+            if (attribute == cloudEvent.SpecVersion.DataContentTypeAttribute)
+            {
+                continue;
+            }
+
+            string propKey = prefix + attribute.Name;
+
+            // TODO: Check that AMQP can handle byte[], bool and int values
+            object propValue = pair.Value switch
+            {
+                Uri uri => uri.ToString(),
+                // AMQPNetLite doesn't support DateTimeOffset values, so convert to UTC.
+                // That means we can't roundtrip events with non-UTC timestamps, but that's not awful.
+                DateTimeOffset dto => dto.UtcDateTime,
+                _ => pair.Value
+            };
+            properties.Add(propKey, propValue);
+        }
+        return applicationProperties;
     }
 }

--- a/src/CloudNative.CloudEvents.Amqp/CloudNative.CloudEvents.Amqp.csproj
+++ b/src/CloudNative.CloudEvents.Amqp/CloudNative.CloudEvents.Amqp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <Description>AMQP extensions for CloudNative.CloudEvents</Description>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <PackageTags>cncf;cloudnative;cloudevents;events;amqp</PackageTags>
   </PropertyGroup>

--- a/src/CloudNative.CloudEvents.AspNetCore/CloudNative.CloudEvents.AspNetCore.csproj
+++ b/src/CloudNative.CloudEvents.AspNetCore/CloudNative.CloudEvents.AspNetCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <Description>ASP.Net Core extensions for CloudNative.CloudEvents</Description>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <PackageTags>cncf;cloudnative;cloudevents;events;aspnetcore;aspnet</PackageTags>
   </PropertyGroup>

--- a/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtensions.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtensions.cs
@@ -11,154 +11,153 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace CloudNative.CloudEvents.AspNetCore
+namespace CloudNative.CloudEvents.AspNetCore;
+
+/// <summary>
+/// Extension methods to convert between HTTP requests and CloudEvents.
+/// </summary>
+public static class HttpRequestExtensions
 {
+    // TODO: CopyToHttpRequest, and deal with HttpResponse as well.
+
     /// <summary>
-    /// Extension methods to convert between HTTP requests and CloudEvents.
+    /// Indicates whether this <see cref="HttpRequest"/> holds a single CloudEvent.
     /// </summary>
-    public static class HttpRequestExtensions
+    /// <remarks>
+    /// This method returns false for batch requests, as they need to be parsed differently.
+    /// </remarks>
+    /// <param name="httpRequest">The request to check for the presence of a CloudEvent. Must not be null.</param>
+    /// <returns>true, if the request is a CloudEvent</returns>
+    public static bool IsCloudEvent(this HttpRequest httpRequest) =>
+        httpRequest.Headers.ContainsKey(HttpUtilities.SpecVersionHttpHeader) ||
+        HasCloudEventsContentType(httpRequest);
+
+    /// <summary>
+    /// Indicates whether this <see cref="HttpRequest"/> holds a batch of CloudEvents.
+    /// </summary>
+    /// <param name="httpRequest">The request to check for the presence of a CloudEvent batch. Must not be null.</param>
+    /// <returns>true, if the request is a CloudEvent batch</returns>
+    public static bool IsCloudEventBatch(this HttpRequest httpRequest) =>
+        HasCloudEventsBatchContentType(httpRequest);
+
+    /// <summary>
+    /// Converts this HTTP request into a CloudEvent object.
+    /// </summary>
+    /// <param name="httpRequest">The HTTP request to decode. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to process the request body. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
+    /// <returns>The decoded CloudEvent.</returns>
+    /// <exception cref="ArgumentException">The request does not contain a CloudEvent.</exception>
+    public static Task<CloudEvent> ToCloudEventAsync(
+        this HttpRequest httpRequest,
+        CloudEventFormatter formatter,
+        params CloudEventAttribute[]? extensionAttributes) =>
+        ToCloudEventAsync(httpRequest, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
+
+    /// <summary>
+    /// Converts this HTTP request into a CloudEvent object.
+    /// </summary>
+    /// <param name="httpRequest">The HTTP request to decode. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to process the request body. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
+    /// <returns>The decoded CloudEvent.</returns>
+    /// <exception cref="ArgumentException">The request does not contain a CloudEvent.</exception>
+    public static async Task<CloudEvent> ToCloudEventAsync(
+        this HttpRequest httpRequest,
+        CloudEventFormatter formatter,
+        IEnumerable<CloudEventAttribute>? extensionAttributes)
     {
-        // TODO: CopyToHttpRequest, and deal with HttpResponse as well.
-
-        /// <summary>
-        /// Indicates whether this <see cref="HttpRequest"/> holds a single CloudEvent.
-        /// </summary>
-        /// <remarks>
-        /// This method returns false for batch requests, as they need to be parsed differently.
-        /// </remarks>
-        /// <param name="httpRequest">The request to check for the presence of a CloudEvent. Must not be null.</param>
-        /// <returns>true, if the request is a CloudEvent</returns>
-        public static bool IsCloudEvent(this HttpRequest httpRequest) =>
-            httpRequest.Headers.ContainsKey(HttpUtilities.SpecVersionHttpHeader) ||
-            HasCloudEventsContentType(httpRequest);
-
-        /// <summary>
-        /// Indicates whether this <see cref="HttpRequest"/> holds a batch of CloudEvents.
-        /// </summary>
-        /// <param name="httpRequest">The request to check for the presence of a CloudEvent batch. Must not be null.</param>
-        /// <returns>true, if the request is a CloudEvent batch</returns>
-        public static bool IsCloudEventBatch(this HttpRequest httpRequest) =>
-            HasCloudEventsBatchContentType(httpRequest);
-
-        /// <summary>
-        /// Converts this HTTP request into a CloudEvent object.
-        /// </summary>
-        /// <param name="httpRequest">The HTTP request to decode. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to process the request body. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
-        /// <returns>The decoded CloudEvent.</returns>
-        /// <exception cref="ArgumentException">The request does not contain a CloudEvent.</exception>
-        public static Task<CloudEvent> ToCloudEventAsync(
-            this HttpRequest httpRequest,
-            CloudEventFormatter formatter,
-            params CloudEventAttribute[]? extensionAttributes) =>
-            ToCloudEventAsync(httpRequest, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
-
-        /// <summary>
-        /// Converts this HTTP request into a CloudEvent object.
-        /// </summary>
-        /// <param name="httpRequest">The HTTP request to decode. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to process the request body. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
-        /// <returns>The decoded CloudEvent.</returns>
-        /// <exception cref="ArgumentException">The request does not contain a CloudEvent.</exception>
-        public static async Task<CloudEvent> ToCloudEventAsync(
-            this HttpRequest httpRequest,
-            CloudEventFormatter formatter,
-            IEnumerable<CloudEventAttribute>? extensionAttributes)
+        Validation.CheckNotNull(httpRequest, nameof(httpRequest));
+        Validation.CheckNotNull(formatter, nameof(formatter));
+        if (HasCloudEventsContentType(httpRequest))
         {
-            Validation.CheckNotNull(httpRequest, nameof(httpRequest));
-            Validation.CheckNotNull(formatter, nameof(formatter));
-            if (HasCloudEventsContentType(httpRequest))
-            {
-                var contentType = MimeUtilities.CreateContentTypeOrNull(httpRequest.ContentType);
-                return await formatter.DecodeStructuredModeMessageAsync(httpRequest.Body, contentType, extensionAttributes).ConfigureAwait(false);
-            }
-            else
-            {
-                var headers = httpRequest.Headers;
-                headers.TryGetValue(HttpUtilities.SpecVersionHttpHeader, out var versionId);
-                if (versionId.Count == 0)
-                {
-                    throw new ArgumentException($"Request does not represent a CloudEvent. It has neither a {HttpUtilities.SpecVersionHttpHeader} header, nor a suitable content type.", nameof(httpRequest));
-                }
-                var version = CloudEventsSpecVersion.FromVersionId(versionId.FirstOrDefault())
-                    ?? throw new ArgumentException($"Unknown CloudEvents spec version '{versionId}'", nameof(httpRequest));
-
-                if (version is null)
-                {
-                    throw new ArgumentException($"Unsupported CloudEvents spec version '{versionId.First()}'");
-                }
-
-                var cloudEvent = new CloudEvent(version, extensionAttributes);
-                foreach (var header in headers)
-                {
-                    string? attributeName = HttpUtilities.GetAttributeNameFromHeaderName(header.Key);
-                    string? headerValue = header.Value.First();
-                    if (attributeName is null || attributeName == CloudEventsSpecVersion.SpecVersionAttribute.Name || headerValue is null)
-                    {
-                        continue;
-                    }
-                    string attributeValue = HttpUtilities.DecodeHeaderValue(headerValue);
-
-                    cloudEvent.SetAttributeFromString(attributeName, attributeValue);
-                }
-
-                cloudEvent.DataContentType = httpRequest.ContentType;
-                if (httpRequest.Body is Stream body)
-                {
-                    ReadOnlyMemory<byte> data = await BinaryDataUtilities.ToReadOnlyMemoryAsync(body).ConfigureAwait(false);
-                    formatter.DecodeBinaryModeEventData(data, cloudEvent);
-                }
-                return Validation.CheckCloudEventArgument(cloudEvent, nameof(httpRequest));
-            }
+            var contentType = MimeUtilities.CreateContentTypeOrNull(httpRequest.ContentType);
+            return await formatter.DecodeStructuredModeMessageAsync(httpRequest.Body, contentType, extensionAttributes).ConfigureAwait(false);
         }
-
-        /// <summary>
-        /// Converts this HTTP request into a batch of CloudEvents.
-        /// </summary>
-        /// <param name="httpRequest">The HTTP request to decode. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to process the request body. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvents. May be null.</param>
-        /// <returns>The decoded batch of CloudEvents.</returns>
-        /// <exception cref="ArgumentException">The request does not contain a CloudEvent batch.</exception>
-        public static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
-            this HttpRequest httpRequest,
-            CloudEventFormatter formatter,
-            params CloudEventAttribute[]? extensionAttributes) =>
-            ToCloudEventBatchAsync(httpRequest, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
-
-        /// <summary>
-        /// Converts this HTTP request into a batch of CloudEvents.
-        /// </summary>
-        /// <param name="httpRequest">The HTTP request to decode. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to process the request body. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvents. May be null.</param>
-        /// <returns>The decoded batch of CloudEvents.</returns>
-        /// <exception cref="ArgumentException">The request does not contain a CloudEvent batch.</exception>
-        public static async Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
-            this HttpRequest httpRequest,
-            CloudEventFormatter formatter,
-            IEnumerable<CloudEventAttribute>? extensionAttributes)
+        else
         {
-            Validation.CheckNotNull(httpRequest, nameof(httpRequest));
-            Validation.CheckNotNull(formatter, nameof(formatter));
+            var headers = httpRequest.Headers;
+            headers.TryGetValue(HttpUtilities.SpecVersionHttpHeader, out var versionId);
+            if (versionId.Count == 0)
+            {
+                throw new ArgumentException($"Request does not represent a CloudEvent. It has neither a {HttpUtilities.SpecVersionHttpHeader} header, nor a suitable content type.", nameof(httpRequest));
+            }
+            var version = CloudEventsSpecVersion.FromVersionId(versionId.FirstOrDefault())
+                ?? throw new ArgumentException($"Unknown CloudEvents spec version '{versionId}'", nameof(httpRequest));
 
-            if (HasCloudEventsBatchContentType(httpRequest))
+            if (version is null)
             {
-                var contentType = MimeUtilities.CreateContentTypeOrNull(httpRequest.ContentType);
-                return await formatter.DecodeBatchModeMessageAsync(httpRequest.Body, contentType, extensionAttributes).ConfigureAwait(false);
+                throw new ArgumentException($"Unsupported CloudEvents spec version '{versionId.First()}'");
             }
-            else
+
+            var cloudEvent = new CloudEvent(version, extensionAttributes);
+            foreach (var header in headers)
             {
-                throw new ArgumentException("HTTP message does not represent a CloudEvents batch.", nameof(httpRequest));
+                string? attributeName = HttpUtilities.GetAttributeNameFromHeaderName(header.Key);
+                string? headerValue = header.Value.First();
+                if (attributeName is null || attributeName == CloudEventsSpecVersion.SpecVersionAttribute.Name || headerValue is null)
+                {
+                    continue;
+                }
+                string attributeValue = HttpUtilities.DecodeHeaderValue(headerValue);
+
+                cloudEvent.SetAttributeFromString(attributeName, attributeValue);
             }
+
+            cloudEvent.DataContentType = httpRequest.ContentType;
+            if (httpRequest.Body is Stream body)
+            {
+                ReadOnlyMemory<byte> data = await BinaryDataUtilities.ToReadOnlyMemoryAsync(body).ConfigureAwait(false);
+                formatter.DecodeBinaryModeEventData(data, cloudEvent);
+            }
+            return Validation.CheckCloudEventArgument(cloudEvent, nameof(httpRequest));
         }
-
-        private static bool HasCloudEventsContentType(HttpRequest request) =>
-            MimeUtilities.IsCloudEventsContentType(request?.ContentType);
-
-        private static bool HasCloudEventsBatchContentType(HttpRequest request) =>
-            MimeUtilities.IsCloudEventsBatchContentType(request?.ContentType);
     }
+
+    /// <summary>
+    /// Converts this HTTP request into a batch of CloudEvents.
+    /// </summary>
+    /// <param name="httpRequest">The HTTP request to decode. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to process the request body. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvents. May be null.</param>
+    /// <returns>The decoded batch of CloudEvents.</returns>
+    /// <exception cref="ArgumentException">The request does not contain a CloudEvent batch.</exception>
+    public static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
+        this HttpRequest httpRequest,
+        CloudEventFormatter formatter,
+        params CloudEventAttribute[]? extensionAttributes) =>
+        ToCloudEventBatchAsync(httpRequest, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
+
+    /// <summary>
+    /// Converts this HTTP request into a batch of CloudEvents.
+    /// </summary>
+    /// <param name="httpRequest">The HTTP request to decode. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to process the request body. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvents. May be null.</param>
+    /// <returns>The decoded batch of CloudEvents.</returns>
+    /// <exception cref="ArgumentException">The request does not contain a CloudEvent batch.</exception>
+    public static async Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
+        this HttpRequest httpRequest,
+        CloudEventFormatter formatter,
+        IEnumerable<CloudEventAttribute>? extensionAttributes)
+    {
+        Validation.CheckNotNull(httpRequest, nameof(httpRequest));
+        Validation.CheckNotNull(formatter, nameof(formatter));
+
+        if (HasCloudEventsBatchContentType(httpRequest))
+        {
+            var contentType = MimeUtilities.CreateContentTypeOrNull(httpRequest.ContentType);
+            return await formatter.DecodeBatchModeMessageAsync(httpRequest.Body, contentType, extensionAttributes).ConfigureAwait(false);
+        }
+        else
+        {
+            throw new ArgumentException("HTTP message does not represent a CloudEvents batch.", nameof(httpRequest));
+        }
+    }
+
+    private static bool HasCloudEventsContentType(HttpRequest request) =>
+        MimeUtilities.IsCloudEventsContentType(request?.ContentType);
+
+    private static bool HasCloudEventsBatchContentType(HttpRequest request) =>
+        MimeUtilities.IsCloudEventsBatchContentType(request?.ContentType);
 }

--- a/src/CloudNative.CloudEvents.AspNetCore/HttpResponseExtensions.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/HttpResponseExtensions.cs
@@ -10,92 +10,91 @@ using System.Collections.Generic;
 using System.Net.Mime;
 using System.Threading.Tasks;
 
-namespace CloudNative.CloudEvents.AspNetCore
+namespace CloudNative.CloudEvents.AspNetCore;
+
+/// <summary>
+/// Extension methods to convert between HTTP responses and CloudEvents.
+/// </summary>
+public static class HttpResponseExtensions
 {
     /// <summary>
-    /// Extension methods to convert between HTTP responses and CloudEvents.
+    /// Copies a <see cref="CloudEvent"/> into an <see cref="HttpResponse" />.
     /// </summary>
-    public static class HttpResponseExtensions
+    /// <param name="cloudEvent">The CloudEvent to copy. Must not be null, and must be a valid CloudEvent.</param>
+    /// <param name="destination">The response to copy the CloudEvent to. Must not be null.</param>
+    /// <param name="contentMode">Content mode (structured or binary)</param>
+    /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task CopyToHttpResponseAsync(this CloudEvent cloudEvent, HttpResponse destination,
+        ContentMode contentMode, CloudEventFormatter formatter)
     {
-        /// <summary>
-        /// Copies a <see cref="CloudEvent"/> into an <see cref="HttpResponse" />.
-        /// </summary>
-        /// <param name="cloudEvent">The CloudEvent to copy. Must not be null, and must be a valid CloudEvent.</param>
-        /// <param name="destination">The response to copy the CloudEvent to. Must not be null.</param>
-        /// <param name="contentMode">Content mode (structured or binary)</param>
-        /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        public static async Task CopyToHttpResponseAsync(this CloudEvent cloudEvent, HttpResponse destination,
-            ContentMode contentMode, CloudEventFormatter formatter)
+        Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
+        Validation.CheckNotNull(destination, nameof(destination));
+        Validation.CheckNotNull(formatter, nameof(formatter));
+
+        ReadOnlyMemory<byte> content;
+        ContentType? contentType;
+        switch (contentMode)
         {
-            Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
-            Validation.CheckNotNull(destination, nameof(destination));
-            Validation.CheckNotNull(formatter, nameof(formatter));
-
-            ReadOnlyMemory<byte> content;
-            ContentType? contentType;
-            switch (contentMode)
-            {
-                case ContentMode.Structured:
-                    content = formatter.EncodeStructuredModeMessage(cloudEvent, out contentType);
-                    break;
-                case ContentMode.Binary:
-                    content = formatter.EncodeBinaryModeEventData(cloudEvent);
-                    contentType = MimeUtilities.CreateContentTypeOrNull(formatter.GetOrInferDataContentType(cloudEvent));
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(contentMode), $"Unsupported content mode: {contentMode}");
-            }
-            if (contentType is object)
-            {
-                destination.ContentType = contentType.ToString();
-            }
-            else if (content.Length != 0)
-            {
-                throw new ArgumentException("The 'datacontenttype' attribute value must be specified", nameof(cloudEvent));
-            }
-
-            // Map headers in either mode.
-            // Including the headers in structured mode is optional in the spec (as they're already within the body) but
-            // can be useful.
-            destination.Headers.Append(HttpUtilities.SpecVersionHttpHeader, HttpUtilities.EncodeHeaderValue(cloudEvent.SpecVersion.VersionId));
-            foreach (var attributeAndValue in cloudEvent.GetPopulatedAttributes())
-            {
-                var attribute = attributeAndValue.Key;
-                var value = attributeAndValue.Value;
-                // The content type is already handled based on the content mode.
-                if (attribute != cloudEvent.SpecVersion.DataContentTypeAttribute)
-                {
-                    string headerValue = HttpUtilities.EncodeHeaderValue(attribute.Format(value));
-                    destination.Headers.Append(HttpUtilities.HttpHeaderPrefix + attribute.Name, headerValue);
-                }
-            }
-
-            destination.ContentLength = content.Length;
-            await BinaryDataUtilities.CopyToStreamAsync(content, destination.Body).ConfigureAwait(false);
+            case ContentMode.Structured:
+                content = formatter.EncodeStructuredModeMessage(cloudEvent, out contentType);
+                break;
+            case ContentMode.Binary:
+                content = formatter.EncodeBinaryModeEventData(cloudEvent);
+                contentType = MimeUtilities.CreateContentTypeOrNull(formatter.GetOrInferDataContentType(cloudEvent));
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(contentMode), $"Unsupported content mode: {contentMode}");
         }
-
-        /// <summary>
-        /// Copies a <see cref="CloudEvent"/> batch into an <see cref="HttpResponse" />.
-        /// </summary>
-        /// <param name="cloudEvents">The CloudEvent batch to copy. Must not be null, and must be a valid CloudEvent.</param>
-        /// <param name="destination">The response to copy the CloudEvent to. Must not be null.</param>
-        /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        public static async Task CopyToHttpResponseAsync(this IReadOnlyList<CloudEvent> cloudEvents,
-            HttpResponse destination, CloudEventFormatter formatter)
+        if (contentType is object)
         {
-            Validation.CheckCloudEventBatchArgument(cloudEvents, nameof(cloudEvents));
-            Validation.CheckNotNull(destination, nameof(destination));
-            Validation.CheckNotNull(formatter, nameof(formatter));
-
-            // TODO: Validate that all events in the batch have the same version?
-            // See https://github.com/cloudevents/spec/issues/807
-
-            ReadOnlyMemory<byte> content = formatter.EncodeBatchModeMessage(cloudEvents, out var contentType);
             destination.ContentType = contentType.ToString();
-            destination.ContentLength = content.Length;
-            await BinaryDataUtilities.CopyToStreamAsync(content, destination.Body).ConfigureAwait(false);
         }
+        else if (content.Length != 0)
+        {
+            throw new ArgumentException("The 'datacontenttype' attribute value must be specified", nameof(cloudEvent));
+        }
+
+        // Map headers in either mode.
+        // Including the headers in structured mode is optional in the spec (as they're already within the body) but
+        // can be useful.
+        destination.Headers.Append(HttpUtilities.SpecVersionHttpHeader, HttpUtilities.EncodeHeaderValue(cloudEvent.SpecVersion.VersionId));
+        foreach (var attributeAndValue in cloudEvent.GetPopulatedAttributes())
+        {
+            var attribute = attributeAndValue.Key;
+            var value = attributeAndValue.Value;
+            // The content type is already handled based on the content mode.
+            if (attribute != cloudEvent.SpecVersion.DataContentTypeAttribute)
+            {
+                string headerValue = HttpUtilities.EncodeHeaderValue(attribute.Format(value));
+                destination.Headers.Append(HttpUtilities.HttpHeaderPrefix + attribute.Name, headerValue);
+            }
+        }
+
+        destination.ContentLength = content.Length;
+        await BinaryDataUtilities.CopyToStreamAsync(content, destination.Body).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Copies a <see cref="CloudEvent"/> batch into an <see cref="HttpResponse" />.
+    /// </summary>
+    /// <param name="cloudEvents">The CloudEvent batch to copy. Must not be null, and must be a valid CloudEvent.</param>
+    /// <param name="destination">The response to copy the CloudEvent to. Must not be null.</param>
+    /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task CopyToHttpResponseAsync(this IReadOnlyList<CloudEvent> cloudEvents,
+        HttpResponse destination, CloudEventFormatter formatter)
+    {
+        Validation.CheckCloudEventBatchArgument(cloudEvents, nameof(cloudEvents));
+        Validation.CheckNotNull(destination, nameof(destination));
+        Validation.CheckNotNull(formatter, nameof(formatter));
+
+        // TODO: Validate that all events in the batch have the same version?
+        // See https://github.com/cloudevents/spec/issues/807
+
+        ReadOnlyMemory<byte> content = formatter.EncodeBatchModeMessage(cloudEvents, out var contentType);
+        destination.ContentType = contentType.ToString();
+        destination.ContentLength = content.Length;
+        await BinaryDataUtilities.CopyToStreamAsync(content, destination.Body).ConfigureAwait(false);
     }
 }

--- a/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
@@ -11,183 +11,182 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Mime;
 
-namespace CloudNative.CloudEvents.Avro
+namespace CloudNative.CloudEvents.Avro;
+
+/// <summary>
+/// Formatter that implements the Avro Event Format.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This event formatter currently only supports structured-mode messages.
+/// </para>
+/// <para>
+/// When encoding a CloudEvent, the data must be serializable as described in the
+/// <a href="https://github.com/cloudevents/spec/blob/v1.0.1/avro-format.md#3-data">CloudEvents Avro Event
+/// Format specification</a>.
+/// </para>
+/// <para>
+/// When decoding a CloudEvent, the <see cref="CloudEvent.Data"/> property is populated directly from the
+/// Avro record, so the value will have the natural Avro deserialization type for that data (which may
+/// not be exactly the same as the type that was serialized).
+/// </para>
+/// <para>
+/// This event formatter does not infer any data content type.
+/// </para>
+/// </remarks>
+public class AvroEventFormatter : CloudEventFormatter
 {
+    private const string MediaTypeSuffix = "+avro";
+    private const string AttributeName = "attribute";
+    private const string DataName = "data";
+
+    private static readonly string CloudEventAvroMediaType = MimeUtilities.MediaType + MediaTypeSuffix;
+    private readonly IGenericRecordSerializer serializer;
+
     /// <summary>
-    /// Formatter that implements the Avro Event Format.
+    /// Creates an AvroEventFormatter using the default serializer.
+    /// </summary>
+    public AvroEventFormatter() : this(new BasicGenericRecordSerializer()) { }
+
+    /// <summary>
+    /// Creates an AvroEventFormatter that uses a custom <see cref="IGenericRecordSerializer"/>.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// This event formatter currently only supports structured-mode messages.
-    /// </para>
-    /// <para>
-    /// When encoding a CloudEvent, the data must be serializable as described in the
-    /// <a href="https://github.com/cloudevents/spec/blob/v1.0.1/avro-format.md#3-data">CloudEvents Avro Event
-    /// Format specification</a>.
-    /// </para>
-    /// <para>
-    /// When decoding a CloudEvent, the <see cref="CloudEvent.Data"/> property is populated directly from the
-    /// Avro record, so the value will have the natural Avro deserialization type for that data (which may
-    /// not be exactly the same as the type that was serialized).
-    /// </para>
-    /// <para>
-    /// This event formatter does not infer any data content type.
-    /// </para>
+    /// It is recommended to use the default serializer before defining your own wherever possible.
     /// </remarks>
-    public class AvroEventFormatter : CloudEventFormatter
+    public AvroEventFormatter(IGenericRecordSerializer genericRecordSerializer)
     {
-        private const string MediaTypeSuffix = "+avro";
-        private const string AttributeName = "attribute";
-        private const string DataName = "data";
+        serializer = genericRecordSerializer;
+    }
 
-        private static readonly string CloudEventAvroMediaType = MimeUtilities.MediaType + MediaTypeSuffix;
-        private readonly IGenericRecordSerializer serializer;
+    /// <summary>
+    /// Avro schema used to serialize and deserialize the CloudEvent.
+    /// </summary>
+    public static RecordSchema AvroSchema { get; } = ParseEmbeddedSchema();
 
-        /// <summary>
-        /// Creates an AvroEventFormatter using the default serializer.
-        /// </summary>
-        public AvroEventFormatter() : this(new BasicGenericRecordSerializer()) { }
+    /// <inheritdoc />
+    public override CloudEvent DecodeStructuredModeMessage(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
+    {
+        Validation.CheckNotNull(body, nameof(body));
+        var rawEvent = serializer.Deserialize(body);
+        return DecodeGenericRecord(rawEvent, extensionAttributes);
+    }
 
-        /// <summary>
-        /// Creates an AvroEventFormatter that uses a custom <see cref="IGenericRecordSerializer"/>.
-        /// </summary>
-        /// <remarks>
-        /// It is recommended to use the default serializer before defining your own wherever possible.
-        /// </remarks>
-        public AvroEventFormatter(IGenericRecordSerializer genericRecordSerializer)
+    /// <inheritdoc />
+    public override CloudEvent DecodeStructuredModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
+    {
+        return DecodeStructuredModeMessage(BinaryDataUtilities.AsStream(body), contentType, extensionAttributes);
+    }
+
+    /// <inheritdoc />
+    public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
+        throw new NotSupportedException("The Avro event formatter does not support batch content mode");
+
+    /// <inheritdoc />
+    public override ReadOnlyMemory<byte> EncodeBatchModeMessage(IEnumerable<CloudEvent> cloudEvent, out ContentType contentType) =>
+        throw new NotSupportedException("The Avro event formatter does not support batch content mode");
+
+    private CloudEvent DecodeGenericRecord(GenericRecord record, IEnumerable<CloudEventAttribute>? extensionAttributes)
+    {
+        if (!record.TryGetValue(AttributeName, out var attrObj))
         {
-            serializer = genericRecordSerializer;
+            throw new ArgumentException($"Record has no '{AttributeName}' field");
+        }
+        IDictionary<string, object> recordAttributes = (IDictionary<string, object>) attrObj;
+
+        if (!recordAttributes.TryGetValue(CloudEventsSpecVersion.SpecVersionAttribute.Name, out var versionId) ||
+            !(versionId is string versionIdString))
+        {
+            throw new ArgumentException("Specification version attribute is missing");
+        }
+        CloudEventsSpecVersion? version = CloudEventsSpecVersion.FromVersionId(versionIdString);
+        if (version is null)
+        {
+            throw new ArgumentException($"Unsupported CloudEvents spec version '{versionIdString}'");
         }
 
-        /// <summary>
-        /// Avro schema used to serialize and deserialize the CloudEvent.
-        /// </summary>
-        public static RecordSchema AvroSchema { get; } = ParseEmbeddedSchema();
+        var cloudEvent = new CloudEvent(version, extensionAttributes);
+        cloudEvent.Data = record.TryGetValue(DataName, out var data) ? data : null;
 
-        /// <inheritdoc />
-        public override CloudEvent DecodeStructuredModeMessage(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
+        foreach (var keyValuePair in recordAttributes)
         {
-            Validation.CheckNotNull(body, nameof(body));
-            var rawEvent = serializer.Deserialize(body);
-            return DecodeGenericRecord(rawEvent, extensionAttributes);
-        }
-
-        /// <inheritdoc />
-        public override CloudEvent DecodeStructuredModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
-        {
-            return DecodeStructuredModeMessage(BinaryDataUtilities.AsStream(body), contentType, extensionAttributes);
-        }
-
-        /// <inheritdoc />
-        public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
-            throw new NotSupportedException("The Avro event formatter does not support batch content mode");
-
-        /// <inheritdoc />
-        public override ReadOnlyMemory<byte> EncodeBatchModeMessage(IEnumerable<CloudEvent> cloudEvent, out ContentType contentType) =>
-            throw new NotSupportedException("The Avro event formatter does not support batch content mode");
-
-        private CloudEvent DecodeGenericRecord(GenericRecord record, IEnumerable<CloudEventAttribute>? extensionAttributes)
-        {
-            if (!record.TryGetValue(AttributeName, out var attrObj))
+            string key = keyValuePair.Key;
+            object value = keyValuePair.Value;
+            if (value is null)
             {
-                throw new ArgumentException($"Record has no '{AttributeName}' field");
-            }
-            IDictionary<string, object> recordAttributes = (IDictionary<string, object>) attrObj;
-
-            if (!recordAttributes.TryGetValue(CloudEventsSpecVersion.SpecVersionAttribute.Name, out var versionId) ||
-                !(versionId is string versionIdString))
-            {
-                throw new ArgumentException("Specification version attribute is missing");
-            }
-            CloudEventsSpecVersion? version = CloudEventsSpecVersion.FromVersionId(versionIdString);
-            if (version is null)
-            {
-                throw new ArgumentException($"Unsupported CloudEvents spec version '{versionIdString}'");
+                continue;
             }
 
-            var cloudEvent = new CloudEvent(version, extensionAttributes);
-            cloudEvent.Data = record.TryGetValue(DataName, out var data) ? data : null;
-
-            foreach (var keyValuePair in recordAttributes)
+            if (key == CloudEventsSpecVersion.SpecVersionAttribute.Name || key == DataName)
             {
-                string key = keyValuePair.Key;
-                object value = keyValuePair.Value;
-                if (value is null)
-                {
-                    continue;
-                }
-
-                if (key == CloudEventsSpecVersion.SpecVersionAttribute.Name || key == DataName)
-                {
-                    continue;
-                }
-
-                // The Avro schema allows the value to be a Boolean, integer, string or bytes.
-                // Timestamps and URIs are represented as strings, so we just use SetAttributeFromString to handle those.
-                // TODO: This does mean that any extensions of these types must have been registered beforehand.
-                if (value is bool || value is int || value is byte[])
-                {
-                    cloudEvent[key] = value;
-                }
-                else if (value is string)
-                {
-                    cloudEvent.SetAttributeFromString(key, (string) value);
-                }
-                else
-                {
-                    throw new ArgumentException($"Invalid value type from Avro record: {value.GetType()}");
-                }
+                continue;
             }
 
-            return Validation.CheckCloudEventArgument(cloudEvent, nameof(record));
-        }
-
-        /// <inheritdoc />
-        public override ReadOnlyMemory<byte> EncodeStructuredModeMessage(CloudEvent cloudEvent, out ContentType contentType)
-        {
-            Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
-
-            contentType = new ContentType(CloudEventAvroMediaType);
-
-            // We expect the Avro encoded to detect data types that can't be represented in the schema.
-            GenericRecord record = new GenericRecord(AvroSchema);
-            record.Add(DataName, cloudEvent.Data);
-            var recordAttributes = new Dictionary<string, object>();
-            recordAttributes[CloudEventsSpecVersion.SpecVersionAttribute.Name] = cloudEvent.SpecVersion.VersionId;
-
-            foreach (var keyValuePair in cloudEvent.GetPopulatedAttributes())
+            // The Avro schema allows the value to be a Boolean, integer, string or bytes.
+            // Timestamps and URIs are represented as strings, so we just use SetAttributeFromString to handle those.
+            // TODO: This does mean that any extensions of these types must have been registered beforehand.
+            if (value is bool || value is int || value is byte[])
             {
-                var attribute = keyValuePair.Key;
-                var value = keyValuePair.Value;
-                // TODO: Create a mapping method in each direction, to have this logic more clearly separated.
-                var avroValue = value is bool || value is int || value is byte[] || value is string
-                    ? value
-                    : attribute.Format(value);
-                recordAttributes[attribute.Name] = avroValue;
+                cloudEvent[key] = value;
             }
-            record.Add(AttributeName, recordAttributes);
-            var memStream = serializer.Serialize(record);
-            return memStream.ToArray();
+            else if (value is string)
+            {
+                cloudEvent.SetAttributeFromString(key, (string) value);
+            }
+            else
+            {
+                throw new ArgumentException($"Invalid value type from Avro record: {value.GetType()}");
+            }
         }
 
-        // TODO: Validate that this is correct...
-        /// <inheritdoc />
-        public override ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent) =>
-            throw new NotSupportedException("The Avro event formatter does not support binary content mode");
+        return Validation.CheckCloudEventArgument(cloudEvent, nameof(record));
+    }
 
-        /// <inheritdoc />
-        public override void DecodeBinaryModeEventData(ReadOnlyMemory<byte> body, CloudEvent cloudEvent) =>
-            throw new NotSupportedException("The Avro event formatter does not support binary content mode");
+    /// <inheritdoc />
+    public override ReadOnlyMemory<byte> EncodeStructuredModeMessage(CloudEvent cloudEvent, out ContentType contentType)
+    {
+        Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
 
-        private static RecordSchema ParseEmbeddedSchema()
+        contentType = new ContentType(CloudEventAvroMediaType);
+
+        // We expect the Avro encoded to detect data types that can't be represented in the schema.
+        GenericRecord record = new GenericRecord(AvroSchema);
+        record.Add(DataName, cloudEvent.Data);
+        var recordAttributes = new Dictionary<string, object>();
+        recordAttributes[CloudEventsSpecVersion.SpecVersionAttribute.Name] = cloudEvent.SpecVersion.VersionId;
+
+        foreach (var keyValuePair in cloudEvent.GetPopulatedAttributes())
         {
-            // We're going to confidently assume that the embedded schema works. If not, type initialization
-            // will fail and that's okay since the type is useless without the proper schema.
-            using var sr = new StreamReader(typeof(AvroEventFormatter)
-                .Assembly
-                .GetManifestResourceStream("CloudNative.CloudEvents.Avro.AvroSchema.json")!);
-
-            return (RecordSchema) Schema.Parse(sr.ReadToEnd());
+            var attribute = keyValuePair.Key;
+            var value = keyValuePair.Value;
+            // TODO: Create a mapping method in each direction, to have this logic more clearly separated.
+            var avroValue = value is bool || value is int || value is byte[] || value is string
+                ? value
+                : attribute.Format(value);
+            recordAttributes[attribute.Name] = avroValue;
         }
+        record.Add(AttributeName, recordAttributes);
+        var memStream = serializer.Serialize(record);
+        return memStream.ToArray();
+    }
+
+    // TODO: Validate that this is correct...
+    /// <inheritdoc />
+    public override ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent) =>
+        throw new NotSupportedException("The Avro event formatter does not support binary content mode");
+
+    /// <inheritdoc />
+    public override void DecodeBinaryModeEventData(ReadOnlyMemory<byte> body, CloudEvent cloudEvent) =>
+        throw new NotSupportedException("The Avro event formatter does not support binary content mode");
+
+    private static RecordSchema ParseEmbeddedSchema()
+    {
+        // We're going to confidently assume that the embedded schema works. If not, type initialization
+        // will fail and that's okay since the type is useless without the proper schema.
+        using var sr = new StreamReader(typeof(AvroEventFormatter)
+            .Assembly
+            .GetManifestResourceStream("CloudNative.CloudEvents.Avro.AvroSchema.json")!);
+
+        return (RecordSchema) Schema.Parse(sr.ReadToEnd());
     }
 }

--- a/src/CloudNative.CloudEvents.Kafka/CloudNative.CloudEvents.Kafka.csproj
+++ b/src/CloudNative.CloudEvents.Kafka/CloudNative.CloudEvents.Kafka.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <Description>Kafka extensions for CloudNative.CloudEvents</Description>
     <PackageTags>cncf;cloudnative;cloudevents;events;kafka</PackageTags>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/CloudNative.CloudEvents.Kafka/KafkaExtensions.cs
+++ b/src/CloudNative.CloudEvents.Kafka/KafkaExtensions.cs
@@ -11,184 +11,183 @@ using System.Linq;
 using System.Net.Mime;
 using System.Text;
 
-namespace CloudNative.CloudEvents.Kafka
+namespace CloudNative.CloudEvents.Kafka;
+
+/// <summary>
+/// Extension methods to convert between CloudEvents and Kafka messages.
+/// </summary>
+public static class KafkaExtensions
 {
+    private const string KafkaHeaderPrefix = "ce_";
+
+    // Visible for testing
+    internal const string KafkaContentTypeAttributeName = "content-type";
+    private const string SpecVersionKafkaHeader = KafkaHeaderPrefix + "specversion";
+
     /// <summary>
-    /// Extension methods to convert between CloudEvents and Kafka messages.
+    /// Indicates whether this message holds a single CloudEvent.
     /// </summary>
-    public static class KafkaExtensions
+    /// <remarks>
+    /// This method returns false for batch requests, as they need to be parsed differently.
+    /// </remarks>
+    /// <param name="message">The message to check for the presence of a CloudEvent. Must not be null.</param>
+    /// <returns>true, if the request is a CloudEvent</returns>
+    public static bool IsCloudEvent(this Message<string?, byte[]> message) =>
+        GetHeaderValue(message, SpecVersionKafkaHeader) is object ||
+        MimeUtilities.IsCloudEventsContentType(GetHeaderValue(message, KafkaContentTypeAttributeName));
+
+    /// <summary>
+    /// Converts this Kafka message into a CloudEvent object.
+    /// </summary>
+    /// <param name="message">The Kafka message to convert. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
+    /// <returns>A reference to a validated CloudEvent instance.</returns>
+    public static CloudEvent ToCloudEvent(this Message<string?, byte[]> message,
+        CloudEventFormatter formatter, params CloudEventAttribute[]? extensionAttributes) =>
+        ToCloudEvent(message, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
+
+    /// <summary>
+    /// Converts this Kafka message into a CloudEvent object.
+    /// </summary>
+    /// <param name="message">The Kafka message to convert. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
+    /// <returns>A reference to a validated CloudEvent instance.</returns>
+    public static CloudEvent ToCloudEvent(this Message<string?, byte[]> message,
+        CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes)
     {
-        private const string KafkaHeaderPrefix = "ce_";
+        Validation.CheckNotNull(message, nameof(message));
+        Validation.CheckNotNull(formatter, nameof(formatter));
 
-        // Visible for testing
-        internal const string KafkaContentTypeAttributeName = "content-type";
-        private const string SpecVersionKafkaHeader = KafkaHeaderPrefix + "specversion";
-
-        /// <summary>
-        /// Indicates whether this message holds a single CloudEvent.
-        /// </summary>
-        /// <remarks>
-        /// This method returns false for batch requests, as they need to be parsed differently.
-        /// </remarks>
-        /// <param name="message">The message to check for the presence of a CloudEvent. Must not be null.</param>
-        /// <returns>true, if the request is a CloudEvent</returns>
-        public static bool IsCloudEvent(this Message<string?, byte[]> message) =>
-            GetHeaderValue(message, SpecVersionKafkaHeader) is object ||
-            MimeUtilities.IsCloudEventsContentType(GetHeaderValue(message, KafkaContentTypeAttributeName));
-
-        /// <summary>
-        /// Converts this Kafka message into a CloudEvent object.
-        /// </summary>
-        /// <param name="message">The Kafka message to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
-        /// <returns>A reference to a validated CloudEvent instance.</returns>
-        public static CloudEvent ToCloudEvent(this Message<string?, byte[]> message,
-            CloudEventFormatter formatter, params CloudEventAttribute[]? extensionAttributes) =>
-            ToCloudEvent(message, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
-
-        /// <summary>
-        /// Converts this Kafka message into a CloudEvent object.
-        /// </summary>
-        /// <param name="message">The Kafka message to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
-        /// <returns>A reference to a validated CloudEvent instance.</returns>
-        public static CloudEvent ToCloudEvent(this Message<string?, byte[]> message,
-            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes)
+        if (!IsCloudEvent(message))
         {
-            Validation.CheckNotNull(message, nameof(message));
-            Validation.CheckNotNull(formatter, nameof(formatter));
-
-            if (!IsCloudEvent(message))
-            {
-                throw new InvalidOperationException();
-            }
-
-            var contentType = GetHeaderValue(message, KafkaContentTypeAttributeName);
-
-            CloudEvent cloudEvent;
-
-            // Structured mode
-            if (MimeUtilities.IsCloudEventsContentType(contentType))
-            {
-                cloudEvent = formatter.DecodeStructuredModeMessage(message.Value, new ContentType(contentType), extensionAttributes);
-            }
-            else
-            {
-                // Binary mode
-                if (!(GetHeaderValue(message, SpecVersionKafkaHeader) is string versionId))
-                {
-                    throw new ArgumentException("Request is not a CloudEvent");
-                }
-                CloudEventsSpecVersion version = CloudEventsSpecVersion.FromVersionId(versionId)
-                    ?? throw new ArgumentException($"Unknown CloudEvents spec version '{versionId}'", nameof(message));
-
-                cloudEvent = new CloudEvent(version, extensionAttributes)
-                {
-                    DataContentType = contentType
-                };
-
-                foreach (var header in message.Headers.Where(h => h.Key.StartsWith(KafkaHeaderPrefix)))
-                {
-                    var attributeName = header.Key.Substring(KafkaHeaderPrefix.Length).ToLowerInvariant();
-                    if (attributeName == CloudEventsSpecVersion.SpecVersionAttribute.Name)
-                    {
-                        continue;
-                    }
-                    // TODO: Is this feasible?
-                    var headerValue = header.GetValueBytes();
-                    if (headerValue is null)
-                    {
-                        continue;
-                    }
-                    string attributeValue = Encoding.UTF8.GetString(headerValue);
-
-                    cloudEvent.SetAttributeFromString(attributeName, attributeValue);
-                }
-                formatter.DecodeBinaryModeEventData(message.Value, cloudEvent);
-            }
-
-            InitPartitioningKey(message, cloudEvent);
-            return Validation.CheckCloudEventArgument(cloudEvent, nameof(message));
+            throw new InvalidOperationException();
         }
 
-        private static void InitPartitioningKey(Message<string?, byte[]> message, CloudEvent cloudEvent)
+        var contentType = GetHeaderValue(message, KafkaContentTypeAttributeName);
+
+        CloudEvent cloudEvent;
+
+        // Structured mode
+        if (MimeUtilities.IsCloudEventsContentType(contentType))
         {
-            if (!string.IsNullOrEmpty(message.Key))
-            {
-                cloudEvent[Partitioning.PartitionKeyAttribute] = message.Key;
-            }
+            cloudEvent = formatter.DecodeStructuredModeMessage(message.Value, new ContentType(contentType), extensionAttributes);
         }
-
-        /// <summary>
-        /// Returns the last header value with the given name, decoded using UTF-8, or null if there is no such header.
-        /// </summary>
-        private static string? GetHeaderValue(MessageMetadata message, string headerName) =>
-            Validation.CheckNotNull(message, nameof(message)).Headers is null
-            ? null
-            : message.Headers.TryGetLastBytes(headerName, out var bytes) ? Encoding.UTF8.GetString(bytes) : null;
-
-        /// <summary>
-        /// Converts a CloudEvent to a Kafka message.
-        /// </summary>
-        /// <param name="cloudEvent">The CloudEvent to convert. Must not be null, and must be a valid CloudEvent.</param>
-        /// <param name="contentMode">Content mode. Structured or binary.</param>
-        /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
-        public static Message<string?, byte[]> ToKafkaMessage(this CloudEvent cloudEvent, ContentMode contentMode, CloudEventFormatter formatter)
+        else
         {
-            Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
-            Validation.CheckNotNull(formatter, nameof(formatter));
-
-            var headers = MapHeaders(cloudEvent);
-            string? key = (string?) cloudEvent[Partitioning.PartitionKeyAttribute];
-            byte[] value;
-            string? contentTypeHeaderValue;
-
-            switch (contentMode)
+            // Binary mode
+            if (!(GetHeaderValue(message, SpecVersionKafkaHeader) is string versionId))
             {
-                case ContentMode.Structured:
-                    value = BinaryDataUtilities.AsArray(formatter.EncodeStructuredModeMessage(cloudEvent, out var contentType));
-                    // TODO: What about the non-media type parts?
-                    contentTypeHeaderValue = contentType.MediaType;
-                    break;
-                case ContentMode.Binary:
-                    value = BinaryDataUtilities.AsArray(formatter.EncodeBinaryModeEventData(cloudEvent));
-                    contentTypeHeaderValue = formatter.GetOrInferDataContentType(cloudEvent);
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(contentMode), $"Unsupported content mode: {contentMode}");
+                throw new ArgumentException("Request is not a CloudEvent");
             }
-            if (contentTypeHeaderValue is object)
+            CloudEventsSpecVersion version = CloudEventsSpecVersion.FromVersionId(versionId)
+                ?? throw new ArgumentException($"Unknown CloudEvents spec version '{versionId}'", nameof(message));
+
+            cloudEvent = new CloudEvent(version, extensionAttributes)
             {
-                headers.Add(KafkaContentTypeAttributeName, Encoding.UTF8.GetBytes(contentTypeHeaderValue));
-            }
-            return new Message<string?, byte[]>
-            {
-                Headers = headers,
-                Value = value,
-                Key = key
+                DataContentType = contentType
             };
-        }
 
-        private static Headers MapHeaders(CloudEvent cloudEvent)
-        {
-            var headers = new Headers
+            foreach (var header in message.Headers.Where(h => h.Key.StartsWith(KafkaHeaderPrefix)))
             {
-                { SpecVersionKafkaHeader, Encoding.UTF8.GetBytes(cloudEvent.SpecVersion.VersionId) }
-            };
-            foreach (var pair in cloudEvent.GetPopulatedAttributes())
-            {
-                var attribute = pair.Key;
-                if (attribute == cloudEvent.SpecVersion.DataContentTypeAttribute ||
-                    attribute.Name == Partitioning.PartitionKeyAttribute.Name)
+                var attributeName = header.Key.Substring(KafkaHeaderPrefix.Length).ToLowerInvariant();
+                if (attributeName == CloudEventsSpecVersion.SpecVersionAttribute.Name)
                 {
                     continue;
                 }
-                var value = attribute.Format(pair.Value);
-                headers.Add(KafkaHeaderPrefix + attribute.Name, Encoding.UTF8.GetBytes(value));
+                // TODO: Is this feasible?
+                var headerValue = header.GetValueBytes();
+                if (headerValue is null)
+                {
+                    continue;
+                }
+                string attributeValue = Encoding.UTF8.GetString(headerValue);
+
+                cloudEvent.SetAttributeFromString(attributeName, attributeValue);
             }
-            return headers;
+            formatter.DecodeBinaryModeEventData(message.Value, cloudEvent);
         }
+
+        InitPartitioningKey(message, cloudEvent);
+        return Validation.CheckCloudEventArgument(cloudEvent, nameof(message));
+    }
+
+    private static void InitPartitioningKey(Message<string?, byte[]> message, CloudEvent cloudEvent)
+    {
+        if (!string.IsNullOrEmpty(message.Key))
+        {
+            cloudEvent[Partitioning.PartitionKeyAttribute] = message.Key;
+        }
+    }
+
+    /// <summary>
+    /// Returns the last header value with the given name, decoded using UTF-8, or null if there is no such header.
+    /// </summary>
+    private static string? GetHeaderValue(MessageMetadata message, string headerName) =>
+        Validation.CheckNotNull(message, nameof(message)).Headers is null
+        ? null
+        : message.Headers.TryGetLastBytes(headerName, out var bytes) ? Encoding.UTF8.GetString(bytes) : null;
+
+    /// <summary>
+    /// Converts a CloudEvent to a Kafka message.
+    /// </summary>
+    /// <param name="cloudEvent">The CloudEvent to convert. Must not be null, and must be a valid CloudEvent.</param>
+    /// <param name="contentMode">Content mode. Structured or binary.</param>
+    /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
+    public static Message<string?, byte[]> ToKafkaMessage(this CloudEvent cloudEvent, ContentMode contentMode, CloudEventFormatter formatter)
+    {
+        Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
+        Validation.CheckNotNull(formatter, nameof(formatter));
+
+        var headers = MapHeaders(cloudEvent);
+        string? key = (string?) cloudEvent[Partitioning.PartitionKeyAttribute];
+        byte[] value;
+        string? contentTypeHeaderValue;
+
+        switch (contentMode)
+        {
+            case ContentMode.Structured:
+                value = BinaryDataUtilities.AsArray(formatter.EncodeStructuredModeMessage(cloudEvent, out var contentType));
+                // TODO: What about the non-media type parts?
+                contentTypeHeaderValue = contentType.MediaType;
+                break;
+            case ContentMode.Binary:
+                value = BinaryDataUtilities.AsArray(formatter.EncodeBinaryModeEventData(cloudEvent));
+                contentTypeHeaderValue = formatter.GetOrInferDataContentType(cloudEvent);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(contentMode), $"Unsupported content mode: {contentMode}");
+        }
+        if (contentTypeHeaderValue is object)
+        {
+            headers.Add(KafkaContentTypeAttributeName, Encoding.UTF8.GetBytes(contentTypeHeaderValue));
+        }
+        return new Message<string?, byte[]>
+        {
+            Headers = headers,
+            Value = value,
+            Key = key
+        };
+    }
+
+    private static Headers MapHeaders(CloudEvent cloudEvent)
+    {
+        var headers = new Headers
+            {
+                { SpecVersionKafkaHeader, Encoding.UTF8.GetBytes(cloudEvent.SpecVersion.VersionId) }
+            };
+        foreach (var pair in cloudEvent.GetPopulatedAttributes())
+        {
+            var attribute = pair.Key;
+            if (attribute == cloudEvent.SpecVersion.DataContentTypeAttribute ||
+                attribute.Name == Partitioning.PartitionKeyAttribute.Name)
+            {
+                continue;
+            }
+            var value = attribute.Format(pair.Value);
+            headers.Add(KafkaHeaderPrefix + attribute.Name, Encoding.UTF8.GetBytes(value));
+        }
+        return headers;
     }
 }

--- a/src/CloudNative.CloudEvents.Mqtt/CloudNative.CloudEvents.Mqtt.csproj
+++ b/src/CloudNative.CloudEvents.Mqtt/CloudNative.CloudEvents.Mqtt.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <Description>MQTT extensions for CloudNative.CloudEvents</Description>
     <PackageTags>cncf;cloudnative;cloudevents;events;mqtt</PackageTags>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Version>3.$(MinorVersion).$(PatchVersion)</Version>
     <PackageValidationBaselineVersion>3.$(PackageValidationMinor).0</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>

--- a/src/CloudNative.CloudEvents.Mqtt/MqttExtensions.cs
+++ b/src/CloudNative.CloudEvents.Mqtt/MqttExtensions.cs
@@ -7,65 +7,64 @@ using MQTTnet;
 using System;
 using System.Collections.Generic;
 
-namespace CloudNative.CloudEvents.Mqtt
+namespace CloudNative.CloudEvents.Mqtt;
+
+/// <summary>
+/// Extension methods to convert between CloudEvents and MQTT messages.
+/// </summary>
+public static class MqttExtensions
 {
     /// <summary>
-    /// Extension methods to convert between CloudEvents and MQTT messages.
+    /// Converts this MQTT message into a CloudEvent object.
     /// </summary>
-    public static class MqttExtensions
+    /// <param name="message">The MQTT message to convert. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
+    /// <returns>A reference to a validated CloudEvent instance.</returns>
+    public static CloudEvent ToCloudEvent(this MqttApplicationMessage message,
+        CloudEventFormatter formatter, params CloudEventAttribute[]? extensionAttributes) =>
+        ToCloudEvent(message, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
+
+    /// <summary>
+    /// Converts this MQTT message into a CloudEvent object.
+    /// </summary>
+    /// <param name="message">The MQTT message to convert. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
+    /// <returns>A reference to a validated CloudEvent instance.</returns>
+    public static CloudEvent ToCloudEvent(this MqttApplicationMessage message,
+        CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes)
     {
-        /// <summary>
-        /// Converts this MQTT message into a CloudEvent object.
-        /// </summary>
-        /// <param name="message">The MQTT message to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
-        /// <returns>A reference to a validated CloudEvent instance.</returns>
-        public static CloudEvent ToCloudEvent(this MqttApplicationMessage message,
-            CloudEventFormatter formatter, params CloudEventAttribute[]? extensionAttributes) =>
-            ToCloudEvent(message, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
+        Validation.CheckNotNull(formatter, nameof(formatter));
+        Validation.CheckNotNull(message, nameof(message));
 
-        /// <summary>
-        /// Converts this MQTT message into a CloudEvent object.
-        /// </summary>
-        /// <param name="message">The MQTT message to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
-        /// <returns>A reference to a validated CloudEvent instance.</returns>
-        public static CloudEvent ToCloudEvent(this MqttApplicationMessage message,
-            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes)
+        // TODO: Determine if there's a sensible content type we should apply.
+        return formatter.DecodeStructuredModeMessage(message.PayloadSegment, contentType: null, extensionAttributes);
+    }
+
+    // TODO: Support both binary and structured mode.
+    /// <summary>
+    /// Converts a CloudEvent to <see cref="MqttApplicationMessage"/>.
+    /// </summary>
+    /// <param name="cloudEvent">The CloudEvent to convert. Must not be null, and must be a valid CloudEvent.</param>
+    /// <param name="contentMode">Content mode. Currently only structured mode is supported.</param>
+    /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
+    /// <param name="topic">The MQTT topic for the message. May be null.</param>
+    public static MqttApplicationMessage ToMqttApplicationMessage(this CloudEvent cloudEvent, ContentMode contentMode, CloudEventFormatter formatter, string? topic)
+    {
+        Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
+        Validation.CheckNotNull(formatter, nameof(formatter));
+
+        switch (contentMode)
         {
-            Validation.CheckNotNull(formatter, nameof(formatter));
-            Validation.CheckNotNull(message, nameof(message));
-
-            // TODO: Determine if there's a sensible content type we should apply.
-            return formatter.DecodeStructuredModeMessage(message.PayloadSegment, contentType: null, extensionAttributes);
-        }
-
-        // TODO: Support both binary and structured mode.
-        /// <summary>
-        /// Converts a CloudEvent to <see cref="MqttApplicationMessage"/>.
-        /// </summary>
-        /// <param name="cloudEvent">The CloudEvent to convert. Must not be null, and must be a valid CloudEvent.</param>
-        /// <param name="contentMode">Content mode. Currently only structured mode is supported.</param>
-        /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
-        /// <param name="topic">The MQTT topic for the message. May be null.</param>
-        public static MqttApplicationMessage ToMqttApplicationMessage(this CloudEvent cloudEvent, ContentMode contentMode, CloudEventFormatter formatter, string? topic)
-        {
-            Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
-            Validation.CheckNotNull(formatter, nameof(formatter));
-
-            switch (contentMode)
-            {
-                case ContentMode.Structured:
-                    return new MqttApplicationMessage
-                    {
-                        Topic = topic,
-                        PayloadSegment = BinaryDataUtilities.GetArraySegment(formatter.EncodeStructuredModeMessage(cloudEvent, out _))
-                    };
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(contentMode), $"Unsupported content mode: {contentMode}");
-            }
+            case ContentMode.Structured:
+                return new MqttApplicationMessage
+                {
+                    Topic = topic,
+                    PayloadSegment = BinaryDataUtilities.GetArraySegment(formatter.EncodeStructuredModeMessage(cloudEvent, out _))
+                };
+            default:
+                throw new ArgumentOutOfRangeException(nameof(contentMode), $"Unsupported content mode: {contentMode}");
         }
     }
 }

--- a/src/CloudNative.CloudEvents.NewtonsoftJson/CloudNative.CloudEvents.NewtonsoftJson.csproj
+++ b/src/CloudNative.CloudEvents.NewtonsoftJson/CloudNative.CloudEvents.NewtonsoftJson.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <Description>JSON support for the CNCF CloudEvents SDK, based on Newtonsoft.Json.</Description>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <PackageTags>cncf;cloudnative;cloudevents;events;json;newtonsoft</PackageTags>
   </PropertyGroup>

--- a/src/CloudNative.CloudEvents.NewtonsoftJson/JsonEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.NewtonsoftJson/JsonEventFormatter.cs
@@ -12,77 +12,77 @@ using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace CloudNative.CloudEvents.NewtonsoftJson
+namespace CloudNative.CloudEvents.NewtonsoftJson;
+
+/// <summary>
+/// Formatter that implements the JSON Event Format, using Newtonsoft.Json (also known as Json.NET) for JSON serialization and deserialization.
+/// </summary>
+/// <remarks>
+/// <para>
+/// When encoding CloudEvent data, the behavior of this implementation depends on the data
+/// content type of the CloudEvent and the type of the <see cref="CloudEvent.Data"/> property value,
+/// following the rules below. Derived classes can specialize this behavior by overriding
+/// <see cref="EncodeStructuredModeData(CloudEvent, JsonWriter)"/> or <see cref="EncodeBinaryModeEventData(CloudEvent)"/>.
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// If the data value is null, the content is empty for a binary mode message, and neither the "data"
+/// nor "data_base64" property is populated in a structured mode message.
+/// </description></item>
+/// <item><description>
+/// If the data value is a byte array, it is serialized either directly as binary data
+/// (for binary mode messages) or as base64 data (for structured mode messages).
+/// </description></item>
+/// <item><description>
+/// Otherwise, if the data content type is absent or has a media type indicating JSON, the data is encoded as JSON.
+/// If the data is already a <see cref="JToken"/>, that is serialized directly as JSON. Otherwise, the data
+/// is converted using the <see cref="JsonSerializer"/> passed into the constructor, or a
+/// default serializer.
+/// </description></item>
+/// <item><description>
+/// Otherwise, if the data content type has a media type beginning with "text/" and the data value is a string,
+/// the data is serialized as a string.
+/// </description></item>
+/// <item><description>
+/// Otherwise, the encoding operation fails.
+/// </description></item>
+/// </list>
+/// <para>
+/// When decoding structured mode CloudEvent data, this implementation uses the following rules,
+/// which can be modified by overriding <see cref="DecodeStructuredModeDataBase64Property(JToken, CloudEvent)"/>
+/// and <see cref="DecodeStructuredModeDataProperty(JToken, CloudEvent)"/>.
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// If the "data_base64" property is present, its value is decoded as a byte array.
+/// </description></item>
+/// <item><description>
+/// If the "data" property is present (and non-null) and the content type is absent or indicates a JSON media type,
+/// the JSON token present in the property is preserved as a <see cref="JToken"/> that can be used for further
+/// deserialization (e.g. to a specific CLR type).
+/// </description></item>
+/// <item><description>
+/// If the "data" property has a string value and a non-JSON content type has been specified, the data is
+/// deserialized as a string.
+/// </description></item>
+/// <item><description>
+/// If the "data" property has a non-null, non-string value and a non-JSON content type has been specified,
+/// the deserialization operation fails.
+/// </description></item>
+/// </list>
+/// <para>
+/// In a binary mode message, the data is parsed based on the content type of the message. When the content
+/// type is absent or has a JSON media type, the data is parsed as JSON, with the result as
+/// a <see cref="JToken"/> (or null if the data is empty). When the content type has a media type beginning
+/// with "text/", the data is parsed as a string. In all other cases, the data is left as a byte array.
+/// This behavior can be specialized by overriding <see cref="DecodeBinaryModeEventData(ReadOnlyMemory{byte}, CloudEvent)"/>.
+/// </para>
+/// </remarks>
+public class JsonEventFormatter : CloudEventFormatter
 {
-    /// <summary>
-    /// Formatter that implements the JSON Event Format, using Newtonsoft.Json (also known as Json.NET) for JSON serialization and deserialization.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// When encoding CloudEvent data, the behavior of this implementation depends on the data
-    /// content type of the CloudEvent and the type of the <see cref="CloudEvent.Data"/> property value,
-    /// following the rules below. Derived classes can specialize this behavior by overriding
-    /// <see cref="EncodeStructuredModeData(CloudEvent, JsonWriter)"/> or <see cref="EncodeBinaryModeEventData(CloudEvent)"/>.
-    /// </para>
-    /// <list type="bullet">
-    /// <item><description>
-    /// If the data value is null, the content is empty for a binary mode message, and neither the "data"
-    /// nor "data_base64" property is populated in a structured mode message.
-    /// </description></item>
-    /// <item><description>
-    /// If the data value is a byte array, it is serialized either directly as binary data
-    /// (for binary mode messages) or as base64 data (for structured mode messages).
-    /// </description></item>
-    /// <item><description>
-    /// Otherwise, if the data content type is absent or has a media type indicating JSON, the data is encoded as JSON.
-    /// If the data is already a <see cref="JToken"/>, that is serialized directly as JSON. Otherwise, the data
-    /// is converted using the <see cref="JsonSerializer"/> passed into the constructor, or a
-    /// default serializer.
-    /// </description></item>
-    /// <item><description>
-    /// Otherwise, if the data content type has a media type beginning with "text/" and the data value is a string,
-    /// the data is serialized as a string.
-    /// </description></item>
-    /// <item><description>
-    /// Otherwise, the encoding operation fails.
-    /// </description></item>
-    /// </list>
-    /// <para>
-    /// When decoding structured mode CloudEvent data, this implementation uses the following rules,
-    /// which can be modified by overriding <see cref="DecodeStructuredModeDataBase64Property(JToken, CloudEvent)"/>
-    /// and <see cref="DecodeStructuredModeDataProperty(JToken, CloudEvent)"/>.
-    /// </para>
-    /// <list type="bullet">
-    /// <item><description>
-    /// If the "data_base64" property is present, its value is decoded as a byte array.
-    /// </description></item>
-    /// <item><description>
-    /// If the "data" property is present (and non-null) and the content type is absent or indicates a JSON media type,
-    /// the JSON token present in the property is preserved as a <see cref="JToken"/> that can be used for further
-    /// deserialization (e.g. to a specific CLR type).
-    /// </description></item>
-    /// <item><description>
-    /// If the "data" property has a string value and a non-JSON content type has been specified, the data is
-    /// deserialized as a string.
-    /// </description></item>
-    /// <item><description>
-    /// If the "data" property has a non-null, non-string value and a non-JSON content type has been specified,
-    /// the deserialization operation fails.
-    /// </description></item>
-    /// </list>
-    /// <para>
-    /// In a binary mode message, the data is parsed based on the content type of the message. When the content
-    /// type is absent or has a JSON media type, the data is parsed as JSON, with the result as
-    /// a <see cref="JToken"/> (or null if the data is empty). When the content type has a media type beginning
-    /// with "text/", the data is parsed as a string. In all other cases, the data is left as a byte array.
-    /// This behavior can be specialized by overriding <see cref="DecodeBinaryModeEventData(ReadOnlyMemory{byte}, CloudEvent)"/>.
-    /// </para>
-    /// </remarks>
-    public class JsonEventFormatter : CloudEventFormatter
-    {
-        private static readonly IReadOnlyDictionary<CloudEventAttributeType, JTokenType> expectedTokenTypesForReservedAttributes =
-            new Dictionary<CloudEventAttributeType, JTokenType>
-            {
+    private static readonly IReadOnlyDictionary<CloudEventAttributeType, JTokenType> expectedTokenTypesForReservedAttributes =
+        new Dictionary<CloudEventAttributeType, JTokenType>
+        {
                 { CloudEventAttributeType.Binary, JTokenType.String },
                 { CloudEventAttributeType.Boolean, JTokenType.Boolean },
                 { CloudEventAttributeType.Integer, JTokenType.Integer },
@@ -90,631 +90,630 @@ namespace CloudNative.CloudEvents.NewtonsoftJson
                 { CloudEventAttributeType.Timestamp, JTokenType.String },
                 { CloudEventAttributeType.Uri, JTokenType.String },
                 { CloudEventAttributeType.UriReference, JTokenType.String }
-            };
+        };
 
-        private const string JsonMediaType = "application/json";
-        private const string MediaTypeSuffix = "+json";
+    private const string JsonMediaType = "application/json";
+    private const string MediaTypeSuffix = "+json";
 
-        private static readonly string StructuredMediaType = MimeUtilities.MediaType + MediaTypeSuffix;
-        private static readonly string BatchMediaType = MimeUtilities.BatchMediaType + MediaTypeSuffix;
+    private static readonly string StructuredMediaType = MimeUtilities.MediaType + MediaTypeSuffix;
+    private static readonly string BatchMediaType = MimeUtilities.BatchMediaType + MediaTypeSuffix;
 
-        /// <summary>
-        /// The property name to use for base64-encoded binary data in a structured-mode message.
-        /// </summary>
-        protected const string DataBase64PropertyName = "data_base64";
+    /// <summary>
+    /// The property name to use for base64-encoded binary data in a structured-mode message.
+    /// </summary>
+    protected const string DataBase64PropertyName = "data_base64";
 
-        /// <summary>
-        /// The property name to use for general data in a structured-mode message.
-        /// </summary>
-        protected const string DataPropertyName = "data";
+    /// <summary>
+    /// The property name to use for general data in a structured-mode message.
+    /// </summary>
+    protected const string DataPropertyName = "data";
 
-        /// <summary>
-        /// The serializer to use when performing JSON conversions.
-        /// </summary>
-        protected JsonSerializer Serializer { get; }
+    /// <summary>
+    /// The serializer to use when performing JSON conversions.
+    /// </summary>
+    protected JsonSerializer Serializer { get; }
 
-        /// <summary>
-        /// Creates a JsonEventFormatter that uses a default <see cref="JsonSerializer"/>.
-        /// </summary>
-        public JsonEventFormatter() : this(JsonSerializer.CreateDefault())
-        {
-        }
-
-        /// <summary>
-        /// Creates a JsonEventFormatter that uses the specified <see cref="JsonSerializer"/>
-        /// to serialize objects as JSON.
-        /// </summary>
-        public JsonEventFormatter(JsonSerializer serializer)
-        {
-            Serializer = Validation.CheckNotNull(serializer, nameof(serializer));
-        }
-
-        /// <inheritdoc />
-        public override async Task<CloudEvent> DecodeStructuredModeMessageAsync(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
-        {
-            Validation.CheckNotNull(body, nameof(body));
-
-            var jsonReader = CreateJsonReader(body, MimeUtilities.GetEncoding(contentType));
-            var jObject = await JObject.LoadAsync(jsonReader).ConfigureAwait(false);
-            return DecodeJObject(jObject, extensionAttributes, nameof(body));
-        }
-
-        /// <inheritdoc />
-        public override CloudEvent DecodeStructuredModeMessage(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
-        {
-            Validation.CheckNotNull(body, nameof(body));
-
-            var jsonReader = CreateJsonReader(body, MimeUtilities.GetEncoding(contentType));
-            var jObject = JObject.Load(jsonReader);
-            return DecodeJObject(jObject, extensionAttributes, nameof(body));
-        }
-
-        /// <inheritdoc />
-        public override CloudEvent DecodeStructuredModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
-            DecodeStructuredModeMessage(BinaryDataUtilities.AsStream(body), contentType, extensionAttributes);
-
-        /// <inheritdoc />
-        public override async Task<IReadOnlyList<CloudEvent>> DecodeBatchModeMessageAsync(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
-        {
-            Validation.CheckNotNull(body, nameof(body));
-
-            var jsonReader = CreateJsonReader(body, MimeUtilities.GetEncoding(contentType));
-            var array = await JArray.LoadAsync(jsonReader).ConfigureAwait(false);
-            return DecodeJArray(array, extensionAttributes, nameof(body));
-        }
-
-        /// <inheritdoc />
-        public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
-        {
-            Validation.CheckNotNull(body, nameof(body));
-
-            var jsonReader = CreateJsonReader(body, MimeUtilities.GetEncoding(contentType));
-            var array = JArray.Load(jsonReader);
-            return DecodeJArray(array, extensionAttributes, nameof(body));
-        }
-
-        /// <inheritdoc />
-        public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
-            DecodeBatchModeMessage(BinaryDataUtilities.AsStream(body), contentType, extensionAttributes);
-
-        /// <summary>
-        /// Converts the given <see cref="JObject"/> into a <see cref="CloudEvent"/>.
-        /// </summary>
-        /// <param name="jObject">The JSON representation of a CloudEvent. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
-        /// <returns>The SDK representation of the CloudEvent.</returns>
-        public CloudEvent ConvertFromJObject(JObject jObject, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
-            DecodeJObject(Validation.CheckNotNull(jObject, nameof(jObject)), extensionAttributes, nameof(jObject));
-
-        private IReadOnlyList<CloudEvent> DecodeJArray(JArray jArray, IEnumerable<CloudEventAttribute>? extensionAttributes, string paramName)
-        {
-            List<CloudEvent> events = new List<CloudEvent>(jArray.Count);
-            foreach (var token in jArray)
-            {
-                if (token is JObject obj)
-                {
-                    events.Add(DecodeJObject(obj, extensionAttributes, paramName));
-                }
-                else
-                {
-                    throw new ArgumentException($"Invalid array element index {events.Count} within batch; expected an object, but token type was '{token?.Type}'", paramName);
-                }
-            }
-            return events;
-        }
-
-        private CloudEvent DecodeJObject(JObject jObject, IEnumerable<CloudEventAttribute>? extensionAttributes, string paramName)
-        {
-            if (!jObject.TryGetValue(CloudEventsSpecVersion.SpecVersionAttribute.Name, out var specVersionToken)
-                || specVersionToken.Type != JTokenType.String)
-            {
-                throw new ArgumentException($"Structured mode content does not represent a CloudEvent");
-            }
-            var specVersion = CloudEventsSpecVersion.FromVersionId((string?) specVersionToken)
-                ?? throw new ArgumentException($"Unsupported CloudEvents spec version '{(string?) specVersionToken}'");
-
-            var cloudEvent = new CloudEvent(specVersion, extensionAttributes);
-            PopulateAttributesFromStructuredEvent(cloudEvent, jObject);
-            PopulateDataFromStructuredEvent(cloudEvent, jObject);
-            return Validation.CheckCloudEventArgument(cloudEvent, paramName);
-        }
-
-        private void PopulateAttributesFromStructuredEvent(CloudEvent cloudEvent, JObject jObject)
-        {
-            foreach (var keyValuePair in jObject)
-            {
-                var key = keyValuePair.Key;
-                JToken value = keyValuePair.Value!;
-
-                // Skip the spec version attribute, which we've already taken account of.
-                // Data is handled later, when everything else (importantly, the data content type)
-                // has been populated.
-                if (key == CloudEventsSpecVersion.SpecVersionAttribute.Name ||
-                    key == DataBase64PropertyName ||
-                    key == DataPropertyName)
-                {
-                    continue;
-                }
-
-                // For non-extension attributes, validate that the token type is as expected.
-                // We're more forgiving for extension attributes: if an integer-typed extension attribute
-                // has a value of "10" (i.e. as a string), that's fine. (If it has a value of "garbage",
-                // that will throw in SetAttributeFromString.)
-                ValidateTokenTypeForAttribute(cloudEvent.GetAttribute(key), value.Type);
-
-                // TODO: This currently performs more conversions than it really should, in the cause of simplicity.
-                // We basically need a matrix of "attribute type vs token type" but that's rather complicated.
-
-                string? attributeValue = value.Type switch
-                {
-                    JTokenType.String => (string?) value,
-                    JTokenType.Boolean => CloudEventAttributeType.Boolean.Format((bool) value),
-                    JTokenType.Null => null,
-                    JTokenType.Integer => CloudEventAttributeType.Integer.Format((int) value),
-                    _ => throw new ArgumentException($"Invalid token type '{value.Type}' for CloudEvent attribute")
-                };
-                if (attributeValue is null)
-                {
-                    continue;
-                }
-                // Note: we *could* infer an extension type of integer and Boolean, but not other extension types.
-                // (We don't want to assume that everything that looks like a timestamp is a timestamp, etc.)
-                // Stick to strings for consistency.
-                cloudEvent.SetAttributeFromString(key, attributeValue);
-            }
-        }
-
-        private void ValidateTokenTypeForAttribute(CloudEventAttribute? attribute, JTokenType tokenType)
-        {
-            // We can't validate unknown attributes, don't check for extension attributes,
-            // and null values will be ignored anyway.
-            if (attribute is null || attribute.IsExtension || tokenType == JTokenType.Null)
-            {
-                return;
-            }
-            // We use TryGetValue so that if a new attribute type is added without this being updated, we "fail valid".
-            // (That should only happen in major versions anyway, but it's worth being somewhat forgiving here.)
-            if (expectedTokenTypesForReservedAttributes.TryGetValue(attribute.Type, out JTokenType expectedTokenType) &&
-                tokenType != expectedTokenType)
-            {
-                throw new ArgumentException($"Invalid token type '{tokenType}' for CloudEvent attribute '{attribute.Name}' with type '{attribute.Type}'");
-            }
-        }
-
-        private void PopulateDataFromStructuredEvent(CloudEvent cloudEvent, JObject jObject)
-        {
-            // Fetch data and data_base64 tokens, and treat null as missing.
-            jObject.TryGetValue(DataPropertyName, out var dataToken);
-            if (dataToken is JToken { Type: JTokenType.Null })
-            {
-                dataToken = null;
-            }
-            jObject.TryGetValue(DataBase64PropertyName, out var dataBase64Token);
-            if (dataBase64Token is JToken { Type: JTokenType.Null })
-            {
-                dataBase64Token = null;
-            }
-
-            // If we don't have any data, we're done.
-            if (dataToken is null && dataBase64Token is null)
-            {
-                return;
-            }
-            // We can't handle both properties being set.
-            if (dataToken is object && dataBase64Token is object)
-            {
-                throw new ArgumentException($"Structured mode content cannot contain both '{DataPropertyName}' and '{DataBase64PropertyName}' properties.");
-            }
-            // Okay, we have exactly one non-null data/data_base64 property.
-            // Decode it, potentially using overridden methods for specialization.
-            if (dataBase64Token is object)
-            {
-                DecodeStructuredModeDataBase64Property(dataBase64Token, cloudEvent);
-            }
-            else
-            {
-                // If no content type has been specified, default to application/json
-                cloudEvent.DataContentType ??= JsonMediaType;
-
-                // We know that dataToken must be non-null here, due to the above conditions.
-                DecodeStructuredModeDataProperty(dataToken!, cloudEvent);
-            }
-        }
-
-        /// <summary>
-        /// Decodes the "data_base64" property provided within a structured-mode message,
-        /// populating the <see cref="CloudEvent.Data"/> property accordingly.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// This implementation converts JSON string tokens to byte arrays, and fails for any other token type.
-        /// </para>
-        /// <para>
-        /// Override this method to provide more specialized conversions.
-        /// </para>
-        /// </remarks>
-        /// <param name="dataBase64Token">The "data_base64" property value within the structured-mode message. Will not be null, and will
-        /// not have a null token type.</param>
-        /// <param name="cloudEvent">The event being decoded. This should not be modified except to
-        /// populate the <see cref="CloudEvent.Data"/> property, but may be used to provide extra
-        /// information such as the data content type. Will not be null.</param>
-        /// <returns>The data to populate in the <see cref="CloudEvent.Data"/> property.</returns>
-        protected virtual void DecodeStructuredModeDataBase64Property(JToken dataBase64Token, CloudEvent cloudEvent)
-        {
-            if (dataBase64Token.Type != JTokenType.String)
-            {
-                throw new ArgumentException($"Structured mode property '{DataBase64PropertyName}' must be a string, when present.");
-            }
-            cloudEvent.Data = Convert.FromBase64String((string) dataBase64Token!);
-        }
-
-        /// <summary>
-        /// Decodes the "data" property provided within a structured-mode message,
-        /// populating the <see cref="CloudEvent.Data"/> property accordingly.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// This implementation will populate the Data property with the verbatim <see cref="JToken"/> if
-        /// the content type is deemed to be JSON according to <see cref="IsJsonMediaType(string)"/>. Otherwise,
-        /// it validates that the token is a string, and the Data property is populated with that string.
-        /// </para>
-        /// <para>
-        /// Override this method to provide more specialized conversions.
-        /// </para>
-        /// </remarks>
-        /// <param name="dataToken">The "data" property value within the structured-mode message. Will not be null, and will
-        /// not have a null token type.</param>
-        /// <param name="cloudEvent">The event being decoded. This should not be modified except to
-        /// populate the <see cref="CloudEvent.Data"/> property, but may be used to provide extra
-        /// information such as the data content type. Will not be null, and the <see cref="CloudEvent.DataContentType"/>
-        /// property will be non-null.</param>
-        /// <returns>The data to populate in the <see cref="CloudEvent.Data"/> property.</returns>
-        protected virtual void DecodeStructuredModeDataProperty(JToken dataToken, CloudEvent cloudEvent)
-        {
-            if (IsJsonMediaType(new ContentType(cloudEvent.DataContentType!).MediaType))
-            {
-                cloudEvent.Data = dataToken;
-            }
-            else
-            {
-                if (dataToken.Type != JTokenType.String)
-                {
-                    throw new ArgumentException("CloudEvents with a non-JSON datacontenttype can only have string data values.");
-                }
-                cloudEvent.Data = (string?) dataToken;
-            }
-        }
-
-        /// <inheritdoc />
-        public override ReadOnlyMemory<byte> EncodeStructuredModeMessage(CloudEvent cloudEvent, out ContentType contentType)
-        {
-            // The cloudEvent parameter will be validated in WriteCloudEventForBatchOrStructuredMode
-
-            contentType = new ContentType(StructuredMediaType)
-            {
-                CharSet = Encoding.UTF8.WebName
-            };
-
-            var stream = new MemoryStream();
-            var writer = CreateJsonTextWriter(stream);
-            WriteCloudEventForBatchOrStructuredMode(writer, cloudEvent);
-            writer.Flush();
-            return stream.ToArray();
-        }
-
-        /// <summary>
-        /// Converts the given <see cref="CloudEvent"/> to a <see cref="JObject"/> containing the structured mode JSON format representation
-        /// of the event.
-        /// </summary>
-        /// <param name="cloudEvent">The event to convert. Must not be null.</param>
-        /// <returns>A <see cref="JObject"/> containing the structured mode JSON format representation of the event.</returns>
-        public JObject ConvertToJObject(CloudEvent cloudEvent)
-        {
-            var writer = new JTokenWriter();
-            WriteCloudEventForBatchOrStructuredMode(writer, cloudEvent);
-            return (JObject) writer.Token!;
-        }
-
-        /// <inheritdoc />
-        public override ReadOnlyMemory<byte> EncodeBatchModeMessage(IEnumerable<CloudEvent> cloudEvents, out ContentType contentType)
-        {
-            Validation.CheckNotNull(cloudEvents, nameof(cloudEvents));
-
-            contentType = new ContentType(BatchMediaType)
-            {
-                CharSet = Encoding.UTF8.WebName
-            };
-
-            var stream = new MemoryStream();
-            var writer = CreateJsonTextWriter(stream);
-            writer.WriteStartArray();
-            foreach (var cloudEvent in cloudEvents)
-            {
-                WriteCloudEventForBatchOrStructuredMode(writer, cloudEvent);
-            }
-            writer.WriteEndArray();
-            writer.Flush();
-            return stream.ToArray();
-        }
-
-        private JsonTextWriter CreateJsonTextWriter(Stream stream) =>
-            // TODO: Allow settings to be specified separately?
-            // JsonSerializer doesn't allow us to set the indentation or indentation character, for example.
-            new JsonTextWriter(new StreamWriter(stream))
-            {
-                Formatting = Serializer.Formatting,
-                DateFormatHandling = Serializer.DateFormatHandling,
-                DateFormatString = Serializer.DateFormatString,
-                DateTimeZoneHandling = Serializer.DateTimeZoneHandling,
-                FloatFormatHandling = Serializer.FloatFormatHandling,
-                Culture = Serializer.Culture,
-                StringEscapeHandling = Serializer.StringEscapeHandling,
-            };
-
-        private void WriteCloudEventForBatchOrStructuredMode(JsonWriter writer, CloudEvent cloudEvent)
-        {
-            Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
-
-            writer.WriteStartObject();
-            writer.WritePropertyName(CloudEventsSpecVersion.SpecVersionAttribute.Name);
-            writer.WriteValue(cloudEvent.SpecVersion.VersionId);
-            var attributes = cloudEvent.GetPopulatedAttributes();
-            foreach (var keyValuePair in attributes)
-            {
-                var attribute = keyValuePair.Key;
-                var value = keyValuePair.Value;
-                writer.WritePropertyName(attribute.Name);
-                switch (CloudEventAttributeTypes.GetOrdinal(attribute.Type))
-                {
-                    case CloudEventAttributeTypeOrdinal.Integer:
-                        writer.WriteValue((int) value);
-                        break;
-                    case CloudEventAttributeTypeOrdinal.Boolean:
-                        writer.WriteValue((bool) value);
-                        break;
-                    default:
-                        writer.WriteValue(attribute.Type.Format(value));
-                        break;
-                }
-            }
-
-            if (cloudEvent.Data is object)
-            {
-                if (cloudEvent.DataContentType is null && GetOrInferDataContentType(cloudEvent) is string inferredDataContentType)
-                {
-                    cloudEvent.SpecVersion.DataContentTypeAttribute.Validate(inferredDataContentType);
-                    writer.WritePropertyName(cloudEvent.SpecVersion.DataContentTypeAttribute.Name);
-                    writer.WriteValue(inferredDataContentType);
-                }
-                EncodeStructuredModeData(cloudEvent, writer);
-            }
-            writer.WriteEndObject();
-        }
-
-        /// <summary>
-        /// Infers the data content type of a CloudEvent based on its data. This implementation
-        /// infers a data content type of "application/json" for any non-binary data, and performs
-        /// no inference for binary data.
-        /// </summary>
-        /// <param name="data">The CloudEvent to infer the data content from. Must not be null.</param>
-        /// <returns>The inferred data content type, or null if no inference is performed.</returns>
-        protected override string? InferDataContentType(object data) => data is byte[] ? null : JsonMediaType;
-
-        /// <summary>
-        /// Encodes structured mode data within a CloudEvent, writing it to the specified <see cref="JsonWriter"/>.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// This implementation follows the rules listed in the class remarks. Override this method
-        /// to provide more specialized behavior, usually writing only <see cref="DataPropertyName"/> or
-        /// <see cref="DataBase64PropertyName"/> properties.
-        /// </para>
-        /// </remarks>
-        /// <param name="cloudEvent">The CloudEvent being encoded, which will have a non-null value for
-        /// its <see cref="CloudEvent.Data"/> property.
-        /// <param name="writer"/>The writer to serialize the data to. Will not be null.</param>
-        protected virtual void EncodeStructuredModeData(CloudEvent cloudEvent, JsonWriter writer)
-        {
-            // Binary data is encoded using the data_base64 property, regardless of content type.
-            // TODO: Support other forms of binary data, e.g. ReadOnlyMemory<byte>
-            if (cloudEvent.Data is byte[] binary)
-            {
-                writer.WritePropertyName(DataBase64PropertyName);
-                writer.WriteValue(Convert.ToBase64String(binary));
-            }
-            else
-            {
-                string? dataContentTypeText = GetOrInferDataContentType(cloudEvent);
-                // This would only happen in a derived class which overrides GetOrInferDataContentType further...
-                // This class infers application/json for anything other than byte arrays.
-                if (dataContentTypeText is null)
-                {
-                    throw new ArgumentException("Data content type cannot be inferred");
-                }
-                ContentType dataContentType = new ContentType(dataContentTypeText);
-                if (IsJsonMediaType(dataContentType.MediaType))
-                {
-                    writer.WritePropertyName(DataPropertyName);
-                    Serializer.Serialize(writer, cloudEvent.Data);
-                }
-                else if (cloudEvent.Data is string text && dataContentType.MediaType.StartsWith("text/"))
-                {
-                    writer.WritePropertyName(DataPropertyName);
-                    writer.WriteValue(text);
-                }
-                else
-                {
-                    // We assume CloudEvent.Data is not null due to the way this is called.
-                    throw new ArgumentException($"{nameof(JsonEventFormatter)} cannot serialize data of type {cloudEvent.Data!.GetType()} with content type '{cloudEvent.DataContentType}'");
-                }
-            }
-        }
-
-        /// <inheritdoc />
-        public override ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent)
-        {
-            Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
-
-            if (cloudEvent.Data is null)
-            {
-                return Array.Empty<byte>();
-            }
-            // Binary data is left alone, regardless of the content type.
-            // TODO: Support other forms of binary data, e.g. ReadOnlyMemory<byte>
-            if (cloudEvent.Data is byte[] bytes)
-            {
-                return bytes;
-            }
-            ContentType contentType = new ContentType(cloudEvent.DataContentType ?? JsonMediaType);
-            if (IsJsonMediaType(contentType.MediaType))
-            {
-                // TODO: Make this more efficient. We could write to a StreamWriter with a MemoryStream,
-                // but then we end up with a BOM in most cases, which I suspect we don't want.
-                // An alternative is to make sure that contentType.GetEncoding() always returns an encoding
-                // without a preamble (or rewrite StreamWriter...)
-                var stringWriter = new StringWriter();
-                Serializer.Serialize(stringWriter, cloudEvent.Data);
-                return MimeUtilities.GetEncoding(contentType).GetBytes(stringWriter.ToString());
-            }
-            if (contentType.MediaType.StartsWith("text/") && cloudEvent.Data is string text)
-            {
-                return MimeUtilities.GetEncoding(contentType).GetBytes(text);
-            }
-            throw new ArgumentException($"{nameof(JsonEventFormatter)} cannot serialize data of type {cloudEvent.Data.GetType()} with content type '{cloudEvent.DataContentType}'");
-        }
-
-        /// <inheritdoc />
-        public override void DecodeBinaryModeEventData(ReadOnlyMemory<byte> body, CloudEvent cloudEvent)
-        {
-            Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
-
-            ContentType contentType = new ContentType(cloudEvent.DataContentType ?? JsonMediaType);
-
-            Encoding encoding = MimeUtilities.GetEncoding(contentType);
-
-            if (IsJsonMediaType(contentType.MediaType))
-            {
-                if (body.Length > 0)
-                {
-                    var jsonReader = CreateJsonReader(BinaryDataUtilities.AsStream(body), encoding);
-                    cloudEvent.Data = JToken.Load(jsonReader);
-                }
-                else
-                {
-                    cloudEvent.Data = null;
-                }
-            }
-            else if (contentType.MediaType.StartsWith("text/") == true)
-            {
-                cloudEvent.Data = BinaryDataUtilities.GetString(body, encoding);
-            }
-            else
-            {
-                cloudEvent.Data = body.ToArray();
-            }
-        }
-
-        /// <summary>
-        /// Creates a <see cref="JsonReader"/> for the given stream. This may be overridden in derived classes to
-        /// customize the JSON parsing process, subject to the constraints listed in the remarks.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The default implementation always creates an instance of <see cref="JsonTextReader"/>, and derived classes
-        /// may assume that (calling this implementation and casting the result before modifying it).
-        /// </para>
-        /// <para>
-        /// Implementations should ensure that <see cref="JsonReader.DateParseHandling"/> is set to <see cref="DateParseHandling.None"/>,
-        /// as timestamp parsing is performed in a CloudEvent-specific way, and Json.NET's own implementation can obscure that.
-        /// </para>
-        /// </remarks>
-        /// <param name="stream">The stream to read from. Will not be null.</param>
-        /// <param name="encoding">The expected text encoding. May be null, in which case UTF-8 should be assumed.</param>
-        /// <returns>A JsonReader suitable for reading the </returns>
-        protected virtual JsonReader CreateJsonReader(Stream stream, Encoding? encoding) =>
-            new JsonTextReader(new StreamReader(stream, encoding ?? Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 8192, leaveOpen: true))
-            {
-                DateParseHandling = DateParseHandling.None
-            };
-
-        /// <summary>
-        /// Determines whether the given media type should be handled as JSON.
-        /// The default implementation treats anything ending with "/json" or "+json"
-        /// as JSON.
-        /// </summary>
-        /// <param name="mediaType">The media type to check for JSON. Will not be null.</param>
-        /// <returns>Whether or not <paramref name="mediaType"/> indicates JSON data.</returns>
-        protected virtual bool IsJsonMediaType(string mediaType) => mediaType.EndsWith("/json") || mediaType.EndsWith("+json");
+    /// <summary>
+    /// Creates a JsonEventFormatter that uses a default <see cref="JsonSerializer"/>.
+    /// </summary>
+    public JsonEventFormatter() : this(JsonSerializer.CreateDefault())
+    {
     }
 
     /// <summary>
-    /// CloudEvent formatter implementing the JSON Event Format, but with an expectation that
-    /// any CloudEvent with a data payload can be converted to <typeparamref name="T" /> using
-    /// the <see cref="JsonSerializer"/> associated with the formatter. The content type is ignored.
+    /// Creates a JsonEventFormatter that uses the specified <see cref="JsonSerializer"/>
+    /// to serialize objects as JSON.
     /// </summary>
-    /// <typeparam name="T">The type of data to serialize and deserialize.</typeparam>
-    public class JsonEventFormatter<T> : JsonEventFormatter
+    public JsonEventFormatter(JsonSerializer serializer)
     {
-        /// <summary>
-        /// Creates a JsonEventFormatter that uses a default <see cref="JsonSerializer"/>.
-        /// </summary>
-        public JsonEventFormatter()
-        {
-        }
+        Serializer = Validation.CheckNotNull(serializer, nameof(serializer));
+    }
 
-        /// <summary>
-        /// Creates a JsonEventFormatter that uses the specified <see cref="JsonSerializer"/>
-        /// to serialize objects as JSON and to deserialize them to <typeparamref name="T"/> values.
-        /// </summary>
-        public JsonEventFormatter(JsonSerializer serializer) : base(serializer)
-        {
-        }
+    /// <inheritdoc />
+    public override async Task<CloudEvent> DecodeStructuredModeMessageAsync(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
+    {
+        Validation.CheckNotNull(body, nameof(body));
 
-        /// <inheritdoc />
-        public override ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent)
-        {
-            Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
+        var jsonReader = CreateJsonReader(body, MimeUtilities.GetEncoding(contentType));
+        var jObject = await JObject.LoadAsync(jsonReader).ConfigureAwait(false);
+        return DecodeJObject(jObject, extensionAttributes, nameof(body));
+    }
 
-            if (cloudEvent.Data is null)
+    /// <inheritdoc />
+    public override CloudEvent DecodeStructuredModeMessage(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
+    {
+        Validation.CheckNotNull(body, nameof(body));
+
+        var jsonReader = CreateJsonReader(body, MimeUtilities.GetEncoding(contentType));
+        var jObject = JObject.Load(jsonReader);
+        return DecodeJObject(jObject, extensionAttributes, nameof(body));
+    }
+
+    /// <inheritdoc />
+    public override CloudEvent DecodeStructuredModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
+        DecodeStructuredModeMessage(BinaryDataUtilities.AsStream(body), contentType, extensionAttributes);
+
+    /// <inheritdoc />
+    public override async Task<IReadOnlyList<CloudEvent>> DecodeBatchModeMessageAsync(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
+    {
+        Validation.CheckNotNull(body, nameof(body));
+
+        var jsonReader = CreateJsonReader(body, MimeUtilities.GetEncoding(contentType));
+        var array = await JArray.LoadAsync(jsonReader).ConfigureAwait(false);
+        return DecodeJArray(array, extensionAttributes, nameof(body));
+    }
+
+    /// <inheritdoc />
+    public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
+    {
+        Validation.CheckNotNull(body, nameof(body));
+
+        var jsonReader = CreateJsonReader(body, MimeUtilities.GetEncoding(contentType));
+        var array = JArray.Load(jsonReader);
+        return DecodeJArray(array, extensionAttributes, nameof(body));
+    }
+
+    /// <inheritdoc />
+    public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
+        DecodeBatchModeMessage(BinaryDataUtilities.AsStream(body), contentType, extensionAttributes);
+
+    /// <summary>
+    /// Converts the given <see cref="JObject"/> into a <see cref="CloudEvent"/>.
+    /// </summary>
+    /// <param name="jObject">The JSON representation of a CloudEvent. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
+    /// <returns>The SDK representation of the CloudEvent.</returns>
+    public CloudEvent ConvertFromJObject(JObject jObject, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
+        DecodeJObject(Validation.CheckNotNull(jObject, nameof(jObject)), extensionAttributes, nameof(jObject));
+
+    private IReadOnlyList<CloudEvent> DecodeJArray(JArray jArray, IEnumerable<CloudEventAttribute>? extensionAttributes, string paramName)
+    {
+        List<CloudEvent> events = new List<CloudEvent>(jArray.Count);
+        foreach (var token in jArray)
+        {
+            if (token is JObject obj)
             {
-                return Array.Empty<byte>();
+                events.Add(DecodeJObject(obj, extensionAttributes, paramName));
             }
-            T data = (T) cloudEvent.Data;
-            // TODO: Make this more efficient. (See base class implementation for a more detailed comment.)
-            var stringWriter = new StringWriter();
-            Serializer.Serialize(stringWriter, data);
-            return Encoding.UTF8.GetBytes(stringWriter.ToString());
+            else
+            {
+                throw new ArgumentException($"Invalid array element index {events.Count} within batch; expected an object, but token type was '{token?.Type}'", paramName);
+            }
+        }
+        return events;
+    }
+
+    private CloudEvent DecodeJObject(JObject jObject, IEnumerable<CloudEventAttribute>? extensionAttributes, string paramName)
+    {
+        if (!jObject.TryGetValue(CloudEventsSpecVersion.SpecVersionAttribute.Name, out var specVersionToken)
+            || specVersionToken.Type != JTokenType.String)
+        {
+            throw new ArgumentException($"Structured mode content does not represent a CloudEvent");
+        }
+        var specVersion = CloudEventsSpecVersion.FromVersionId((string?) specVersionToken)
+            ?? throw new ArgumentException($"Unsupported CloudEvents spec version '{(string?) specVersionToken}'");
+
+        var cloudEvent = new CloudEvent(specVersion, extensionAttributes);
+        PopulateAttributesFromStructuredEvent(cloudEvent, jObject);
+        PopulateDataFromStructuredEvent(cloudEvent, jObject);
+        return Validation.CheckCloudEventArgument(cloudEvent, paramName);
+    }
+
+    private void PopulateAttributesFromStructuredEvent(CloudEvent cloudEvent, JObject jObject)
+    {
+        foreach (var keyValuePair in jObject)
+        {
+            var key = keyValuePair.Key;
+            JToken value = keyValuePair.Value!;
+
+            // Skip the spec version attribute, which we've already taken account of.
+            // Data is handled later, when everything else (importantly, the data content type)
+            // has been populated.
+            if (key == CloudEventsSpecVersion.SpecVersionAttribute.Name ||
+                key == DataBase64PropertyName ||
+                key == DataPropertyName)
+            {
+                continue;
+            }
+
+            // For non-extension attributes, validate that the token type is as expected.
+            // We're more forgiving for extension attributes: if an integer-typed extension attribute
+            // has a value of "10" (i.e. as a string), that's fine. (If it has a value of "garbage",
+            // that will throw in SetAttributeFromString.)
+            ValidateTokenTypeForAttribute(cloudEvent.GetAttribute(key), value.Type);
+
+            // TODO: This currently performs more conversions than it really should, in the cause of simplicity.
+            // We basically need a matrix of "attribute type vs token type" but that's rather complicated.
+
+            string? attributeValue = value.Type switch
+            {
+                JTokenType.String => (string?) value,
+                JTokenType.Boolean => CloudEventAttributeType.Boolean.Format((bool) value),
+                JTokenType.Null => null,
+                JTokenType.Integer => CloudEventAttributeType.Integer.Format((int) value),
+                _ => throw new ArgumentException($"Invalid token type '{value.Type}' for CloudEvent attribute")
+            };
+            if (attributeValue is null)
+            {
+                continue;
+            }
+            // Note: we *could* infer an extension type of integer and Boolean, but not other extension types.
+            // (We don't want to assume that everything that looks like a timestamp is a timestamp, etc.)
+            // Stick to strings for consistency.
+            cloudEvent.SetAttributeFromString(key, attributeValue);
+        }
+    }
+
+    private void ValidateTokenTypeForAttribute(CloudEventAttribute? attribute, JTokenType tokenType)
+    {
+        // We can't validate unknown attributes, don't check for extension attributes,
+        // and null values will be ignored anyway.
+        if (attribute is null || attribute.IsExtension || tokenType == JTokenType.Null)
+        {
+            return;
+        }
+        // We use TryGetValue so that if a new attribute type is added without this being updated, we "fail valid".
+        // (That should only happen in major versions anyway, but it's worth being somewhat forgiving here.)
+        if (expectedTokenTypesForReservedAttributes.TryGetValue(attribute.Type, out JTokenType expectedTokenType) &&
+            tokenType != expectedTokenType)
+        {
+            throw new ArgumentException($"Invalid token type '{tokenType}' for CloudEvent attribute '{attribute.Name}' with type '{attribute.Type}'");
+        }
+    }
+
+    private void PopulateDataFromStructuredEvent(CloudEvent cloudEvent, JObject jObject)
+    {
+        // Fetch data and data_base64 tokens, and treat null as missing.
+        jObject.TryGetValue(DataPropertyName, out var dataToken);
+        if (dataToken is JToken { Type: JTokenType.Null })
+        {
+            dataToken = null;
+        }
+        jObject.TryGetValue(DataBase64PropertyName, out var dataBase64Token);
+        if (dataBase64Token is JToken { Type: JTokenType.Null })
+        {
+            dataBase64Token = null;
         }
 
-        /// <inheritdoc />
-        public override void DecodeBinaryModeEventData(ReadOnlyMemory<byte> body, CloudEvent cloudEvent)
+        // If we don't have any data, we're done.
+        if (dataToken is null && dataBase64Token is null)
         {
-            Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
+            return;
+        }
+        // We can't handle both properties being set.
+        if (dataToken is object && dataBase64Token is object)
+        {
+            throw new ArgumentException($"Structured mode content cannot contain both '{DataPropertyName}' and '{DataBase64PropertyName}' properties.");
+        }
+        // Okay, we have exactly one non-null data/data_base64 property.
+        // Decode it, potentially using overridden methods for specialization.
+        if (dataBase64Token is object)
+        {
+            DecodeStructuredModeDataBase64Property(dataBase64Token, cloudEvent);
+        }
+        else
+        {
+            // If no content type has been specified, default to application/json
+            cloudEvent.DataContentType ??= JsonMediaType;
 
-            if (body.Length == 0)
+            // We know that dataToken must be non-null here, due to the above conditions.
+            DecodeStructuredModeDataProperty(dataToken!, cloudEvent);
+        }
+    }
+
+    /// <summary>
+    /// Decodes the "data_base64" property provided within a structured-mode message,
+    /// populating the <see cref="CloudEvent.Data"/> property accordingly.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This implementation converts JSON string tokens to byte arrays, and fails for any other token type.
+    /// </para>
+    /// <para>
+    /// Override this method to provide more specialized conversions.
+    /// </para>
+    /// </remarks>
+    /// <param name="dataBase64Token">The "data_base64" property value within the structured-mode message. Will not be null, and will
+    /// not have a null token type.</param>
+    /// <param name="cloudEvent">The event being decoded. This should not be modified except to
+    /// populate the <see cref="CloudEvent.Data"/> property, but may be used to provide extra
+    /// information such as the data content type. Will not be null.</param>
+    /// <returns>The data to populate in the <see cref="CloudEvent.Data"/> property.</returns>
+    protected virtual void DecodeStructuredModeDataBase64Property(JToken dataBase64Token, CloudEvent cloudEvent)
+    {
+        if (dataBase64Token.Type != JTokenType.String)
+        {
+            throw new ArgumentException($"Structured mode property '{DataBase64PropertyName}' must be a string, when present.");
+        }
+        cloudEvent.Data = Convert.FromBase64String((string) dataBase64Token!);
+    }
+
+    /// <summary>
+    /// Decodes the "data" property provided within a structured-mode message,
+    /// populating the <see cref="CloudEvent.Data"/> property accordingly.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This implementation will populate the Data property with the verbatim <see cref="JToken"/> if
+    /// the content type is deemed to be JSON according to <see cref="IsJsonMediaType(string)"/>. Otherwise,
+    /// it validates that the token is a string, and the Data property is populated with that string.
+    /// </para>
+    /// <para>
+    /// Override this method to provide more specialized conversions.
+    /// </para>
+    /// </remarks>
+    /// <param name="dataToken">The "data" property value within the structured-mode message. Will not be null, and will
+    /// not have a null token type.</param>
+    /// <param name="cloudEvent">The event being decoded. This should not be modified except to
+    /// populate the <see cref="CloudEvent.Data"/> property, but may be used to provide extra
+    /// information such as the data content type. Will not be null, and the <see cref="CloudEvent.DataContentType"/>
+    /// property will be non-null.</param>
+    /// <returns>The data to populate in the <see cref="CloudEvent.Data"/> property.</returns>
+    protected virtual void DecodeStructuredModeDataProperty(JToken dataToken, CloudEvent cloudEvent)
+    {
+        if (IsJsonMediaType(new ContentType(cloudEvent.DataContentType!).MediaType))
+        {
+            cloudEvent.Data = dataToken;
+        }
+        else
+        {
+            if (dataToken.Type != JTokenType.String)
+            {
+                throw new ArgumentException("CloudEvents with a non-JSON datacontenttype can only have string data values.");
+            }
+            cloudEvent.Data = (string?) dataToken;
+        }
+    }
+
+    /// <inheritdoc />
+    public override ReadOnlyMemory<byte> EncodeStructuredModeMessage(CloudEvent cloudEvent, out ContentType contentType)
+    {
+        // The cloudEvent parameter will be validated in WriteCloudEventForBatchOrStructuredMode
+
+        contentType = new ContentType(StructuredMediaType)
+        {
+            CharSet = Encoding.UTF8.WebName
+        };
+
+        var stream = new MemoryStream();
+        var writer = CreateJsonTextWriter(stream);
+        WriteCloudEventForBatchOrStructuredMode(writer, cloudEvent);
+        writer.Flush();
+        return stream.ToArray();
+    }
+
+    /// <summary>
+    /// Converts the given <see cref="CloudEvent"/> to a <see cref="JObject"/> containing the structured mode JSON format representation
+    /// of the event.
+    /// </summary>
+    /// <param name="cloudEvent">The event to convert. Must not be null.</param>
+    /// <returns>A <see cref="JObject"/> containing the structured mode JSON format representation of the event.</returns>
+    public JObject ConvertToJObject(CloudEvent cloudEvent)
+    {
+        var writer = new JTokenWriter();
+        WriteCloudEventForBatchOrStructuredMode(writer, cloudEvent);
+        return (JObject) writer.Token!;
+    }
+
+    /// <inheritdoc />
+    public override ReadOnlyMemory<byte> EncodeBatchModeMessage(IEnumerable<CloudEvent> cloudEvents, out ContentType contentType)
+    {
+        Validation.CheckNotNull(cloudEvents, nameof(cloudEvents));
+
+        contentType = new ContentType(BatchMediaType)
+        {
+            CharSet = Encoding.UTF8.WebName
+        };
+
+        var stream = new MemoryStream();
+        var writer = CreateJsonTextWriter(stream);
+        writer.WriteStartArray();
+        foreach (var cloudEvent in cloudEvents)
+        {
+            WriteCloudEventForBatchOrStructuredMode(writer, cloudEvent);
+        }
+        writer.WriteEndArray();
+        writer.Flush();
+        return stream.ToArray();
+    }
+
+    private JsonTextWriter CreateJsonTextWriter(Stream stream) =>
+        // TODO: Allow settings to be specified separately?
+        // JsonSerializer doesn't allow us to set the indentation or indentation character, for example.
+        new JsonTextWriter(new StreamWriter(stream))
+        {
+            Formatting = Serializer.Formatting,
+            DateFormatHandling = Serializer.DateFormatHandling,
+            DateFormatString = Serializer.DateFormatString,
+            DateTimeZoneHandling = Serializer.DateTimeZoneHandling,
+            FloatFormatHandling = Serializer.FloatFormatHandling,
+            Culture = Serializer.Culture,
+            StringEscapeHandling = Serializer.StringEscapeHandling,
+        };
+
+    private void WriteCloudEventForBatchOrStructuredMode(JsonWriter writer, CloudEvent cloudEvent)
+    {
+        Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
+
+        writer.WriteStartObject();
+        writer.WritePropertyName(CloudEventsSpecVersion.SpecVersionAttribute.Name);
+        writer.WriteValue(cloudEvent.SpecVersion.VersionId);
+        var attributes = cloudEvent.GetPopulatedAttributes();
+        foreach (var keyValuePair in attributes)
+        {
+            var attribute = keyValuePair.Key;
+            var value = keyValuePair.Value;
+            writer.WritePropertyName(attribute.Name);
+            switch (CloudEventAttributeTypes.GetOrdinal(attribute.Type))
+            {
+                case CloudEventAttributeTypeOrdinal.Integer:
+                    writer.WriteValue((int) value);
+                    break;
+                case CloudEventAttributeTypeOrdinal.Boolean:
+                    writer.WriteValue((bool) value);
+                    break;
+                default:
+                    writer.WriteValue(attribute.Type.Format(value));
+                    break;
+            }
+        }
+
+        if (cloudEvent.Data is object)
+        {
+            if (cloudEvent.DataContentType is null && GetOrInferDataContentType(cloudEvent) is string inferredDataContentType)
+            {
+                cloudEvent.SpecVersion.DataContentTypeAttribute.Validate(inferredDataContentType);
+                writer.WritePropertyName(cloudEvent.SpecVersion.DataContentTypeAttribute.Name);
+                writer.WriteValue(inferredDataContentType);
+            }
+            EncodeStructuredModeData(cloudEvent, writer);
+        }
+        writer.WriteEndObject();
+    }
+
+    /// <summary>
+    /// Infers the data content type of a CloudEvent based on its data. This implementation
+    /// infers a data content type of "application/json" for any non-binary data, and performs
+    /// no inference for binary data.
+    /// </summary>
+    /// <param name="data">The CloudEvent to infer the data content from. Must not be null.</param>
+    /// <returns>The inferred data content type, or null if no inference is performed.</returns>
+    protected override string? InferDataContentType(object data) => data is byte[]? null : JsonMediaType;
+
+    /// <summary>
+    /// Encodes structured mode data within a CloudEvent, writing it to the specified <see cref="JsonWriter"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This implementation follows the rules listed in the class remarks. Override this method
+    /// to provide more specialized behavior, usually writing only <see cref="DataPropertyName"/> or
+    /// <see cref="DataBase64PropertyName"/> properties.
+    /// </para>
+    /// </remarks>
+    /// <param name="cloudEvent">The CloudEvent being encoded, which will have a non-null value for
+    /// its <see cref="CloudEvent.Data"/> property.
+    /// <param name="writer"/>The writer to serialize the data to. Will not be null.</param>
+    protected virtual void EncodeStructuredModeData(CloudEvent cloudEvent, JsonWriter writer)
+    {
+        // Binary data is encoded using the data_base64 property, regardless of content type.
+        // TODO: Support other forms of binary data, e.g. ReadOnlyMemory<byte>
+        if (cloudEvent.Data is byte[] binary)
+        {
+            writer.WritePropertyName(DataBase64PropertyName);
+            writer.WriteValue(Convert.ToBase64String(binary));
+        }
+        else
+        {
+            string? dataContentTypeText = GetOrInferDataContentType(cloudEvent);
+            // This would only happen in a derived class which overrides GetOrInferDataContentType further...
+            // This class infers application/json for anything other than byte arrays.
+            if (dataContentTypeText is null)
+            {
+                throw new ArgumentException("Data content type cannot be inferred");
+            }
+            ContentType dataContentType = new ContentType(dataContentTypeText);
+            if (IsJsonMediaType(dataContentType.MediaType))
+            {
+                writer.WritePropertyName(DataPropertyName);
+                Serializer.Serialize(writer, cloudEvent.Data);
+            }
+            else if (cloudEvent.Data is string text && dataContentType.MediaType.StartsWith("text/"))
+            {
+                writer.WritePropertyName(DataPropertyName);
+                writer.WriteValue(text);
+            }
+            else
+            {
+                // We assume CloudEvent.Data is not null due to the way this is called.
+                throw new ArgumentException($"{nameof(JsonEventFormatter)} cannot serialize data of type {cloudEvent.Data!.GetType()} with content type '{cloudEvent.DataContentType}'");
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public override ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent)
+    {
+        Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
+
+        if (cloudEvent.Data is null)
+        {
+            return Array.Empty<byte>();
+        }
+        // Binary data is left alone, regardless of the content type.
+        // TODO: Support other forms of binary data, e.g. ReadOnlyMemory<byte>
+        if (cloudEvent.Data is byte[] bytes)
+        {
+            return bytes;
+        }
+        ContentType contentType = new ContentType(cloudEvent.DataContentType ?? JsonMediaType);
+        if (IsJsonMediaType(contentType.MediaType))
+        {
+            // TODO: Make this more efficient. We could write to a StreamWriter with a MemoryStream,
+            // but then we end up with a BOM in most cases, which I suspect we don't want.
+            // An alternative is to make sure that contentType.GetEncoding() always returns an encoding
+            // without a preamble (or rewrite StreamWriter...)
+            var stringWriter = new StringWriter();
+            Serializer.Serialize(stringWriter, cloudEvent.Data);
+            return MimeUtilities.GetEncoding(contentType).GetBytes(stringWriter.ToString());
+        }
+        if (contentType.MediaType.StartsWith("text/") && cloudEvent.Data is string text)
+        {
+            return MimeUtilities.GetEncoding(contentType).GetBytes(text);
+        }
+        throw new ArgumentException($"{nameof(JsonEventFormatter)} cannot serialize data of type {cloudEvent.Data.GetType()} with content type '{cloudEvent.DataContentType}'");
+    }
+
+    /// <inheritdoc />
+    public override void DecodeBinaryModeEventData(ReadOnlyMemory<byte> body, CloudEvent cloudEvent)
+    {
+        Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
+
+        ContentType contentType = new ContentType(cloudEvent.DataContentType ?? JsonMediaType);
+
+        Encoding encoding = MimeUtilities.GetEncoding(contentType);
+
+        if (IsJsonMediaType(contentType.MediaType))
+        {
+            if (body.Length > 0)
+            {
+                var jsonReader = CreateJsonReader(BinaryDataUtilities.AsStream(body), encoding);
+                cloudEvent.Data = JToken.Load(jsonReader);
+            }
+            else
             {
                 cloudEvent.Data = null;
-                return;
             }
-            using var jsonReader = CreateJsonReader(BinaryDataUtilities.AsStream(body), Encoding.UTF8);
-            cloudEvent.Data = Serializer.Deserialize<T>(jsonReader);
         }
-
-        /// <inheritdoc />
-        protected override void EncodeStructuredModeData(CloudEvent cloudEvent, JsonWriter writer)
+        else if (contentType.MediaType.StartsWith("text/") == true)
         {
-            T data = (T) cloudEvent.Data;
-            writer.WritePropertyName(DataPropertyName);
-            Serializer.Serialize(writer, data);
+            cloudEvent.Data = BinaryDataUtilities.GetString(body, encoding);
         }
-
-        /// <inheritdoc />
-        protected override void DecodeStructuredModeDataProperty(JToken dataToken, CloudEvent cloudEvent) =>
-            cloudEvent.Data = Serializer.Deserialize<T>(new JTokenReader(dataToken));
-
-        // TODO: Consider decoding the base64 data as a byte array, then using DecodeBinaryModeData.
-        /// <inheritdoc />
-        protected override void DecodeStructuredModeDataBase64Property(JToken dataBase64Token, CloudEvent cloudEvent) =>
-            throw new ArgumentException($"Data unexpectedly represented using '{DataBase64PropertyName}' within structured mode CloudEvent.");
+        else
+        {
+            cloudEvent.Data = body.ToArray();
+        }
     }
+
+    /// <summary>
+    /// Creates a <see cref="JsonReader"/> for the given stream. This may be overridden in derived classes to
+    /// customize the JSON parsing process, subject to the constraints listed in the remarks.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The default implementation always creates an instance of <see cref="JsonTextReader"/>, and derived classes
+    /// may assume that (calling this implementation and casting the result before modifying it).
+    /// </para>
+    /// <para>
+    /// Implementations should ensure that <see cref="JsonReader.DateParseHandling"/> is set to <see cref="DateParseHandling.None"/>,
+    /// as timestamp parsing is performed in a CloudEvent-specific way, and Json.NET's own implementation can obscure that.
+    /// </para>
+    /// </remarks>
+    /// <param name="stream">The stream to read from. Will not be null.</param>
+    /// <param name="encoding">The expected text encoding. May be null, in which case UTF-8 should be assumed.</param>
+    /// <returns>A JsonReader suitable for reading the </returns>
+    protected virtual JsonReader CreateJsonReader(Stream stream, Encoding? encoding) =>
+        new JsonTextReader(new StreamReader(stream, encoding ?? Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 8192, leaveOpen: true))
+        {
+            DateParseHandling = DateParseHandling.None
+        };
+
+    /// <summary>
+    /// Determines whether the given media type should be handled as JSON.
+    /// The default implementation treats anything ending with "/json" or "+json"
+    /// as JSON.
+    /// </summary>
+    /// <param name="mediaType">The media type to check for JSON. Will not be null.</param>
+    /// <returns>Whether or not <paramref name="mediaType"/> indicates JSON data.</returns>
+    protected virtual bool IsJsonMediaType(string mediaType) => mediaType.EndsWith("/json") || mediaType.EndsWith("+json");
+}
+
+/// <summary>
+/// CloudEvent formatter implementing the JSON Event Format, but with an expectation that
+/// any CloudEvent with a data payload can be converted to <typeparamref name="T" /> using
+/// the <see cref="JsonSerializer"/> associated with the formatter. The content type is ignored.
+/// </summary>
+/// <typeparam name="T">The type of data to serialize and deserialize.</typeparam>
+public class JsonEventFormatter<T> : JsonEventFormatter
+{
+    /// <summary>
+    /// Creates a JsonEventFormatter that uses a default <see cref="JsonSerializer"/>.
+    /// </summary>
+    public JsonEventFormatter()
+    {
+    }
+
+    /// <summary>
+    /// Creates a JsonEventFormatter that uses the specified <see cref="JsonSerializer"/>
+    /// to serialize objects as JSON and to deserialize them to <typeparamref name="T"/> values.
+    /// </summary>
+    public JsonEventFormatter(JsonSerializer serializer) : base(serializer)
+    {
+    }
+
+    /// <inheritdoc />
+    public override ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent)
+    {
+        Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
+
+        if (cloudEvent.Data is null)
+        {
+            return Array.Empty<byte>();
+        }
+        T data = (T) cloudEvent.Data;
+        // TODO: Make this more efficient. (See base class implementation for a more detailed comment.)
+        var stringWriter = new StringWriter();
+        Serializer.Serialize(stringWriter, data);
+        return Encoding.UTF8.GetBytes(stringWriter.ToString());
+    }
+
+    /// <inheritdoc />
+    public override void DecodeBinaryModeEventData(ReadOnlyMemory<byte> body, CloudEvent cloudEvent)
+    {
+        Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
+
+        if (body.Length == 0)
+        {
+            cloudEvent.Data = null;
+            return;
+        }
+        using var jsonReader = CreateJsonReader(BinaryDataUtilities.AsStream(body), Encoding.UTF8);
+        cloudEvent.Data = Serializer.Deserialize<T>(jsonReader);
+    }
+
+    /// <inheritdoc />
+    protected override void EncodeStructuredModeData(CloudEvent cloudEvent, JsonWriter writer)
+    {
+        T data = (T) cloudEvent.Data!;
+        writer.WritePropertyName(DataPropertyName);
+        Serializer.Serialize(writer, data);
+    }
+
+    /// <inheritdoc />
+    protected override void DecodeStructuredModeDataProperty(JToken dataToken, CloudEvent cloudEvent) =>
+        cloudEvent.Data = Serializer.Deserialize<T>(new JTokenReader(dataToken));
+
+    // TODO: Consider decoding the base64 data as a byte array, then using DecodeBinaryModeData.
+    /// <inheritdoc />
+    protected override void DecodeStructuredModeDataBase64Property(JToken dataBase64Token, CloudEvent cloudEvent) =>
+        throw new ArgumentException($"Data unexpectedly represented using '{DataBase64PropertyName}' within structured mode CloudEvent.");
 }

--- a/src/CloudNative.CloudEvents.Protobuf/ProtobufEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.Protobuf/ProtobufEventFormatter.cs
@@ -16,75 +16,75 @@ using static CloudNative.CloudEvents.V1.CloudEvent;
 using static CloudNative.CloudEvents.V1.CloudEvent.Types;
 using static CloudNative.CloudEvents.V1.CloudEvent.Types.CloudEventAttributeValue;
 
-namespace CloudNative.CloudEvents.Protobuf
+namespace CloudNative.CloudEvents.Protobuf;
+
+// TODO: Derived type which expects to only receive protobuf message data with a particular message type,
+// so is able to unpack it. 
+
+/// <summary>
+/// Formatter that implements the Protobuf Event Format, using the Google.Protobuf library for serialization.
+/// </summary>
+/// <remarks>
+/// <para>
+/// When encoding CloudEvents in structured mode, three kinds of data are supported, as indicated in the
+/// event format. Text is stored in the <see cref="V1.CloudEvent.TextData"/> field; binary data is stored
+/// in the <see cref="V1.CloudEvent.BinaryData"/> field; protobuf messages are stored in the
+/// <see cref="V1.CloudEvent.ProtoData"/> field. In the last case, the message is packed in an
+/// <see cref="Any"/> message, to preserve information about which message is encoded, unless the message
+/// is already an <see cref="Any"/> in which case it is stored directly. (This prevents "double-encoding"
+/// when a CloudEvent is decoded and then re-encoded.) Attempts to serialize CloudEvents with any other data type
+/// will fail. Derived classes can specialize all of this behavior by overriding
+/// <see cref="EncodeStructuredModeData(CloudEvent, V1.CloudEvent)"/>.
+/// </para>
+/// <para>
+/// When decoding CloudEvents in structured mode, text and binary data payloads are represented as strings and byte
+/// arrays respectively. Protobuf message payloads are represented using the <see cref="Any"/> wrapper, without
+/// attempting to "unpack" the message. This avoids any requirement for the underlying message type to be
+/// known by the application consuming the CloudEvent. (The data may be stored for later processing by another
+/// application with more awareness, for example.) Derived classes can specialize all of this behavior by
+/// overriding <see cref="DecodeStructuredModeData(V1.CloudEvent, CloudEvent)"/>.
+/// </para>
+/// <para>
+/// When encoding CloudEvent data in binary mode, this implementation only supports plain binary and text data.
+/// (Even text data is only supported when the <see cref="CloudEvent.DataContentType"/> begins with "text/".)
+/// While it might be expected that protobuf messages would be serialized into the binary mode data, there is
+/// no clear standard as to whether they should be directly serialized, or packed into an <see cref="Any"/>
+/// message first, and no standardized content type to use to distinguish these options. Users are encouraged
+/// to either use structured mode where possible, or explicitly encode the data as a byte array first. Derived
+/// classes can specialize this behavior by overriding <see cref="EncodeBinaryModeEventData(CloudEvent)"/>.
+/// </para>
+/// <para>
+/// When decoding CloudEvent data in binary mode, if the data content type begins with "text/" it is decoded as
+/// a string, otherwise it is left as a byte array. Derived classes can specialize this behavior by overriding
+/// <see cref="DecodeBinaryModeEventData(ReadOnlyMemory{byte}, CloudEvent)"/>.
+/// </para>
+/// <para>
+/// This event formatter does not infer any data content type.
+/// </para>
+/// </remarks>
+public class ProtobufEventFormatter : CloudEventFormatter
 {
-    // TODO: Derived type which expects to only receive protobuf message data with a particular message type,
-    // so is able to unpack it. 
+    /// <summary>
+    /// The default value for <see cref="TypeUrlPrefix"/>. This is the value used by Protobuf libraries
+    /// when no prefix is specifically provided.
+    /// </summary>
+    public const string DefaultTypeUrlPrefix = "type.googleapis.com";
+
+    private const string MediaTypeSuffix = "+protobuf";
+
+    private static readonly string StructuredMediaType = MimeUtilities.MediaType + MediaTypeSuffix;
+    private static readonly string BatchMediaType = MimeUtilities.BatchMediaType + MediaTypeSuffix;
 
     /// <summary>
-    /// Formatter that implements the Protobuf Event Format, using the Google.Protobuf library for serialization.
+    /// The type URL prefix this event formatter uses when packing messages into <see cref="Any"/>.
+    /// The value is never null. Note: the type URL prefix is not used when the data within a CloudEvent
+    /// is already an Any message, as the message is propagated directly.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// When encoding CloudEvents in structured mode, three kinds of data are supported, as indicated in the
-    /// event format. Text is stored in the <see cref="V1.CloudEvent.TextData"/> field; binary data is stored
-    /// in the <see cref="V1.CloudEvent.BinaryData"/> field; protobuf messages are stored in the
-    /// <see cref="V1.CloudEvent.ProtoData"/> field. In the last case, the message is packed in an
-    /// <see cref="Any"/> message, to preserve information about which message is encoded, unless the message
-    /// is already an <see cref="Any"/> in which case it is stored directly. (This prevents "double-encoding"
-    /// when a CloudEvent is decoded and then re-encoded.) Attempts to serialize CloudEvents with any other data type
-    /// will fail. Derived classes can specialize all of this behavior by overriding
-    /// <see cref="EncodeStructuredModeData(CloudEvent, V1.CloudEvent)"/>.
-    /// </para>
-    /// <para>
-    /// When decoding CloudEvents in structured mode, text and binary data payloads are represented as strings and byte
-    /// arrays respectively. Protobuf message payloads are represented using the <see cref="Any"/> wrapper, without
-    /// attempting to "unpack" the message. This avoids any requirement for the underlying message type to be
-    /// known by the application consuming the CloudEvent. (The data may be stored for later processing by another
-    /// application with more awareness, for example.) Derived classes can specialize all of this behavior by
-    /// overriding <see cref="DecodeStructuredModeData(V1.CloudEvent, CloudEvent)"/>.
-    /// </para>
-    /// <para>
-    /// When encoding CloudEvent data in binary mode, this implementation only supports plain binary and text data.
-    /// (Even text data is only supported when the <see cref="CloudEvent.DataContentType"/> begins with "text/".)
-    /// While it might be expected that protobuf messages would be serialized into the binary mode data, there is
-    /// no clear standard as to whether they should be directly serialized, or packed into an <see cref="Any"/>
-    /// message first, and no standardized content type to use to distinguish these options. Users are encouraged
-    /// to either use structured mode where possible, or explicitly encode the data as a byte array first. Derived
-    /// classes can specialize this behavior by overriding <see cref="EncodeBinaryModeEventData(CloudEvent)"/>.
-    /// </para>
-    /// <para>
-    /// When decoding CloudEvent data in binary mode, if the data content type begins with "text/" it is decoded as
-    /// a string, otherwise it is left as a byte array. Derived classes can specialize this behavior by overriding
-    /// <see cref="DecodeBinaryModeEventData(ReadOnlyMemory{byte}, CloudEvent)"/>.
-    /// </para>
-    /// <para>
-    /// This event formatter does not infer any data content type.
-    /// </para>
-    /// </remarks>
-    public class ProtobufEventFormatter : CloudEventFormatter
-    {
-        /// <summary>
-        /// The default value for <see cref="TypeUrlPrefix"/>. This is the value used by Protobuf libraries
-        /// when no prefix is specifically provided.
-        /// </summary>
-        public const string DefaultTypeUrlPrefix = "type.googleapis.com";
+    public string TypeUrlPrefix { get; }
 
-        private const string MediaTypeSuffix = "+protobuf";
-
-        private static readonly string StructuredMediaType = MimeUtilities.MediaType + MediaTypeSuffix;
-        private static readonly string BatchMediaType = MimeUtilities.BatchMediaType + MediaTypeSuffix;
-
-        /// <summary>
-        /// The type URL prefix this event formatter uses when packing messages into <see cref="Any"/>.
-        /// The value is never null. Note: the type URL prefix is not used when the data within a CloudEvent
-        /// is already an Any message, as the message is propagated directly.
-        /// </summary>
-        public string TypeUrlPrefix { get; }
-
-        private static readonly Dictionary<AttrOneofCase, CloudEventAttributeType> protoToCloudEventAttributeType =
-            new Dictionary<AttrOneofCase, CloudEventAttributeType>
-            {
+    private static readonly Dictionary<AttrOneofCase, CloudEventAttributeType> protoToCloudEventAttributeType =
+        new Dictionary<AttrOneofCase, CloudEventAttributeType>
+        {
                 { AttrOneofCase.CeBoolean, CloudEventAttributeType.Boolean },
                 { AttrOneofCase.CeBytes, CloudEventAttributeType.Binary },
                 { AttrOneofCase.CeInteger, CloudEventAttributeType.Integer },
@@ -92,311 +92,310 @@ namespace CloudNative.CloudEvents.Protobuf
                 { AttrOneofCase.CeTimestamp, CloudEventAttributeType.Timestamp },
                 { AttrOneofCase.CeUri, CloudEventAttributeType.Uri },
                 { AttrOneofCase.CeUriRef, CloudEventAttributeType.UriReference }
-            };
+        };
 
-        /// <summary>
-        /// Constructs an instance of the formatter, using a type URL prefix of
-        /// "type.googleapis.com" (the default for <see cref="Any.Pack(IMessage)"/>).
-        /// </summary>
-        public ProtobufEventFormatter() : this(DefaultTypeUrlPrefix)
+    /// <summary>
+    /// Constructs an instance of the formatter, using a type URL prefix of
+    /// "type.googleapis.com" (the default for <see cref="Any.Pack(IMessage)"/>).
+    /// </summary>
+    public ProtobufEventFormatter() : this(DefaultTypeUrlPrefix)
+    {
+    }
+
+    /// <summary>
+    /// Constructs an instance of the formatter, using the specified type URL prefix
+    /// when packing messages.
+    /// </summary>
+    /// <param name="typeUrlPrefix">The type URL prefix to use when packing messages
+    /// into <see cref="Any"/>. Must not be null.</param>
+    public ProtobufEventFormatter(string typeUrlPrefix)
+    {
+        TypeUrlPrefix = Validation.CheckNotNull(typeUrlPrefix, nameof(typeUrlPrefix));
+    }
+
+    /// <inheritdoc />
+    public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
+        DecodeBatchModeMessage(BinaryDataUtilities.AsStream(body), contentType, extensionAttributes);
+
+    /// <inheritdoc />
+    public override void DecodeBinaryModeEventData(ReadOnlyMemory<byte> body, CloudEvent cloudEvent)
+    {
+        Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
+        if (cloudEvent.DataContentType is string dataContentType && dataContentType.StartsWith("text/"))
         {
+            Encoding encoding = MimeUtilities.GetEncoding(new ContentType(dataContentType));
+            cloudEvent.Data = BinaryDataUtilities.GetString(body, encoding);
         }
-
-        /// <summary>
-        /// Constructs an instance of the formatter, using the specified type URL prefix
-        /// when packing messages.
-        /// </summary>
-        /// <param name="typeUrlPrefix">The type URL prefix to use when packing messages
-        /// into <see cref="Any"/>. Must not be null.</param>
-        public ProtobufEventFormatter(string typeUrlPrefix)
+        else
         {
-            TypeUrlPrefix = Validation.CheckNotNull(typeUrlPrefix, nameof(typeUrlPrefix));
+            cloudEvent.Data = body.ToArray();
         }
+    }
 
-        /// <inheritdoc />
-        public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
-            DecodeBatchModeMessage(BinaryDataUtilities.AsStream(body), contentType, extensionAttributes);
+    /// <inheritdoc />
+    public override CloudEvent DecodeStructuredModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
+        DecodeStructuredModeMessage(BinaryDataUtilities.AsStream(body), contentType, extensionAttributes);
 
-        /// <inheritdoc />
-        public override void DecodeBinaryModeEventData(ReadOnlyMemory<byte> body, CloudEvent cloudEvent)
+    /// <inheritdoc />
+    public override ReadOnlyMemory<byte> EncodeBatchModeMessage(IEnumerable<CloudEvent> cloudEvents, out ContentType contentType)
+    {
+        Validation.CheckNotNull(cloudEvents, nameof(cloudEvents));
+
+        contentType = new ContentType(BatchMediaType)
         {
-            Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
-            if (cloudEvent.DataContentType is string dataContentType && dataContentType.StartsWith("text/"))
-            {
-                Encoding encoding = MimeUtilities.GetEncoding(new ContentType(dataContentType));
-                cloudEvent.Data = BinaryDataUtilities.GetString(body, encoding);
-            }
-            else
-            {
-                cloudEvent.Data = body.ToArray();
-            }
-        }
+            CharSet = Encoding.UTF8.WebName
+        };
 
-        /// <inheritdoc />
-        public override CloudEvent DecodeStructuredModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
-            DecodeStructuredModeMessage(BinaryDataUtilities.AsStream(body), contentType, extensionAttributes);
-
-        /// <inheritdoc />
-        public override ReadOnlyMemory<byte> EncodeBatchModeMessage(IEnumerable<CloudEvent> cloudEvents, out ContentType contentType)
+        var batch = new CloudEventBatch
         {
-            Validation.CheckNotNull(cloudEvents, nameof(cloudEvents));
+            Events = { cloudEvents.Select(cloudEvent => ConvertToProto(cloudEvent, nameof(cloudEvents))) }
+        };
+        return batch.ToByteArray();
+    }
 
-            contentType = new ContentType(BatchMediaType)
-            {
-                CharSet = Encoding.UTF8.WebName
-            };
+    // TODO: Put the boiler-plate code here into CloudEventFormatter
 
-            var batch = new CloudEventBatch
-            {
-                Events = { cloudEvents.Select(cloudEvent => ConvertToProto(cloudEvent, nameof(cloudEvents))) }
-            };
-            return batch.ToByteArray();
-        }
+    /// <inheritdoc />
+    public override ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent)
+    {
+        Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
 
-        // TODO: Put the boiler-plate code here into CloudEventFormatter
-
-        /// <inheritdoc />
-        public override ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent)
+        if (cloudEvent.Data is null)
         {
-            Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
-
-            if (cloudEvent.Data is null)
-            {
-                return Array.Empty<byte>();
-            }
-            if (cloudEvent.DataContentType is string dataContentType && dataContentType.StartsWith("text/") && cloudEvent.Data is string text)
-            {
-                ContentType contentType = new ContentType(dataContentType);
-                return MimeUtilities.GetEncoding(contentType).GetBytes(text);
-            }
-            if (cloudEvent.Data is byte[] bytes)
-            {
-                return bytes;
-            }
-            throw new ArgumentException($"{nameof(ProtobufEventFormatter)} cannot serialize data of type {cloudEvent.Data.GetType()} with content type '{cloudEvent.DataContentType}'");
+            return Array.Empty<byte>();
         }
-
-        /// <inheritdoc />
-        public override ReadOnlyMemory<byte> EncodeStructuredModeMessage(CloudEvent cloudEvent, out ContentType contentType)
+        if (cloudEvent.DataContentType is string dataContentType && dataContentType.StartsWith("text/") && cloudEvent.Data is string text)
         {
-            var proto = ConvertToProto(cloudEvent, nameof(cloudEvent));
-            contentType = new ContentType(StructuredMediaType)
-            {
-                CharSet = Encoding.UTF8.WebName
-            };
-            return proto.ToByteArray();
+            ContentType contentType = new ContentType(dataContentType);
+            return MimeUtilities.GetEncoding(contentType).GetBytes(text);
         }
-
-        /// <inheritdoc />
-        public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
+        if (cloudEvent.Data is byte[] bytes)
         {
-            Validation.CheckNotNull(body, nameof(body));
-            var batchProto = CloudEventBatch.Parser.ParseFrom(body);
-            return batchProto.Events.Select(proto => ConvertFromProto(proto, extensionAttributes, nameof(body))).ToList();
+            return bytes;
         }
+        throw new ArgumentException($"{nameof(ProtobufEventFormatter)} cannot serialize data of type {cloudEvent.Data.GetType()} with content type '{cloudEvent.DataContentType}'");
+    }
 
-        /// <inheritdoc />
-        public override CloudEvent DecodeStructuredModeMessage(Stream messageBody, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
+    /// <inheritdoc />
+    public override ReadOnlyMemory<byte> EncodeStructuredModeMessage(CloudEvent cloudEvent, out ContentType contentType)
+    {
+        var proto = ConvertToProto(cloudEvent, nameof(cloudEvent));
+        contentType = new ContentType(StructuredMediaType)
         {
-            Validation.CheckNotNull(messageBody, nameof(messageBody));
-            return ConvertFromProto(V1.CloudEvent.Parser.ParseFrom(messageBody), extensionAttributes, nameof(messageBody));
-        }
+            CharSet = Encoding.UTF8.WebName
+        };
+        return proto.ToByteArray();
+    }
 
-        /// <summary>
-        /// Converts the given protobuf representation of a CloudEvent into an SDK representation.
-        /// </summary>
-        /// <param name="proto">The protobuf representation of a CloudEvent. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
-        /// <returns>The SDK representation of the CloudEvent.</returns>
-        public CloudEvent ConvertFromProto(V1.CloudEvent proto, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
-            ConvertFromProto(Validation.CheckNotNull(proto, nameof(proto)), extensionAttributes, nameof(proto));
+    /// <inheritdoc />
+    public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
+    {
+        Validation.CheckNotNull(body, nameof(body));
+        var batchProto = CloudEventBatch.Parser.ParseFrom(body);
+        return batchProto.Events.Select(proto => ConvertFromProto(proto, extensionAttributes, nameof(body))).ToList();
+    }
 
-        private CloudEvent ConvertFromProto(V1.CloudEvent proto, IEnumerable<CloudEventAttribute>? extensionAttributes, string paramName)
+    /// <inheritdoc />
+    public override CloudEvent DecodeStructuredModeMessage(Stream messageBody, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
+    {
+        Validation.CheckNotNull(messageBody, nameof(messageBody));
+        return ConvertFromProto(V1.CloudEvent.Parser.ParseFrom(messageBody), extensionAttributes, nameof(messageBody));
+    }
+
+    /// <summary>
+    /// Converts the given protobuf representation of a CloudEvent into an SDK representation.
+    /// </summary>
+    /// <param name="proto">The protobuf representation of a CloudEvent. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
+    /// <returns>The SDK representation of the CloudEvent.</returns>
+    public CloudEvent ConvertFromProto(V1.CloudEvent proto, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
+        ConvertFromProto(Validation.CheckNotNull(proto, nameof(proto)), extensionAttributes, nameof(proto));
+
+    private CloudEvent ConvertFromProto(V1.CloudEvent proto, IEnumerable<CloudEventAttribute>? extensionAttributes, string paramName)
+    {
+        var specVersion = CloudEventsSpecVersion.FromVersionId(proto.SpecVersion)
+            ?? throw new ArgumentException($"Unsupported CloudEvents spec version '{proto.SpecVersion}'", paramName);
+
+        var cloudEvent = new CloudEvent(specVersion, extensionAttributes)
         {
-            var specVersion = CloudEventsSpecVersion.FromVersionId(proto.SpecVersion)
-                ?? throw new ArgumentException($"Unsupported CloudEvents spec version '{proto.SpecVersion}'", paramName);
-
-            var cloudEvent = new CloudEvent(specVersion, extensionAttributes)
+            Id = proto.Id,
+            Source = (Uri) specVersion.SourceAttribute.Parse(proto.Source),
+            Type = proto.Type
+        };
+        foreach (var pair in proto.Attributes)
+        {
+            if (!protoToCloudEventAttributeType.TryGetValue(pair.Value.AttrCase, out var attrTypeFromProto))
             {
-                Id = proto.Id,
-                Source = (Uri) specVersion.SourceAttribute.Parse(proto.Source),
-                Type = proto.Type
-            };
-            foreach (var pair in proto.Attributes)
-            {
-                if (!protoToCloudEventAttributeType.TryGetValue(pair.Value.AttrCase, out var attrTypeFromProto))
-                {
-                    // Note: impossible to cover in tests
-                    throw new ArgumentException($"Unhandled protobuf attribute case: {pair.Value.AttrCase}", paramName);
-                }
-
-                // If we've already got an extension attribute specified for this name,
-                // we validate against it and require the value in the proto to have the right
-                // type. Otherwise, we create a new extension attribute of the correct type.
-                var attr = cloudEvent.GetAttribute(pair.Key);
-                if (attr is null)
-                {
-                    attr = CloudEventAttribute.CreateExtension(pair.Key, attrTypeFromProto);
-                }
-                // Note: if CloudEvents spec version 2.0 contains different required attributes, we may want to
-                // change exactly how this is specified. For the moment, this is the simplest way of implementing the requirement.
-                else if (attr.IsRequired)
-                {
-                    // The required attributes are all specified as proto fields.
-                    // They can't appear in the Attributes repeated field as well.
-                    throw new ArgumentException(
-                        $"Attribute '{attr.Name}' is a required attribute, and must only be specified via the top-level proto field.");
-                }
-                else if (attr.Type != attrTypeFromProto)
-                {
-                    // This prevents any type changes, even those which might validate correctly
-                    // otherwise (e.g. between Uri and UriRef).
-                    throw new ArgumentException(
-                        $"Attribute '{attr.Name}' was specified with type '{attr.Type}', but has type '{attrTypeFromProto}' in the protobuf representation.");
-                }
-
-                // Note: the indexer performs validation.
-                cloudEvent[attr] = pair.Value.AttrCase switch
-                {
-                    AttrOneofCase.CeBoolean => pair.Value.CeBoolean,
-                    AttrOneofCase.CeBytes => pair.Value.CeBytes.ToByteArray(),
-                    AttrOneofCase.CeInteger => pair.Value.CeInteger,
-                    AttrOneofCase.CeString => pair.Value.CeString,
-                    AttrOneofCase.CeTimestamp => pair.Value.CeTimestamp.ToDateTimeOffset(),
-                    AttrOneofCase.CeUri => CloudEventAttributeType.Uri.Parse(pair.Value.CeUri),
-                    AttrOneofCase.CeUriRef => CloudEventAttributeType.UriReference.Parse(pair.Value.CeUriRef),
-                    _ => throw new ArgumentException($"Unhandled protobuf attribute case: {pair.Value.AttrCase}")
-                };
-            }
-
-            DecodeStructuredModeData(proto, cloudEvent);
-
-            return Validation.CheckCloudEventArgument(cloudEvent, paramName);
-        }
-
-        /// <summary>
-        /// Decodes the "data" property provided within a structured-mode message,
-        /// populating the <see cref="CloudEvents.CloudEvent.Data"/> property accordingly.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// This implementation simply converts binary data to a byte array, leaves proto data
-        /// as an <see cref="Google.Protobuf.WellKnownTypes.Any"/>, and converts text data to a string.
-        /// </para>
-        /// <para>
-        /// Override this method to provide more specialized conversions, such as to use <see cref="ByteString"/>
-        /// instead of a byte array, or to "unwrap" the proto data to generated code.
-        /// </para>
-        /// </remarks>
-        /// <param name="proto">The protobuf representation of the CloudEvent. Will not be null.</param>
-        /// <param name="cloudEvent">The event being decoded. This should not be modified except to
-        /// populate the <see cref="CloudEvents.CloudEvent.Data"/> property, but may be used to provide extra
-        /// information such as the data content type. Will not be null.</param>
-        /// <returns>The data to populate in the <see cref="CloudEvents.CloudEvent.Data"/> property.</returns>
-        protected virtual void DecodeStructuredModeData(V1.CloudEvent proto, CloudEvent cloudEvent) =>
-            cloudEvent.Data = proto.DataCase switch
-            {
-                DataOneofCase.BinaryData => proto.BinaryData.ToByteArray(),
-                DataOneofCase.ProtoData => proto.ProtoData,
-                DataOneofCase.TextData => proto.TextData,
-                DataOneofCase.None => null,
                 // Note: impossible to cover in tests
-                _ => throw new ArgumentException($"Unhandled protobuf data case: {proto.DataCase}")
-            };
+                throw new ArgumentException($"Unhandled protobuf attribute case: {pair.Value.AttrCase}", paramName);
+            }
 
-        /// <summary>
-        /// Encodes structured (or batch) mode data within a CloudEvent, storing it in the specified <see cref="CloudEvents.CloudEvent"/>.
-        /// </summary>
-        /// <param name="cloudEvent">The CloudEvent being encoded, which will have a non-null value for
-        /// its <see cref="CloudEvents.CloudEvent.Data"/> property.</param>
-        /// <param name="proto">The protobuf representation of the CloudEvent, which will be non-null.</param>
-        protected virtual void EncodeStructuredModeData(CloudEvent cloudEvent, V1.CloudEvent proto)
-        {
-            switch (cloudEvent.Data)
+            // If we've already got an extension attribute specified for this name,
+            // we validate against it and require the value in the proto to have the right
+            // type. Otherwise, we create a new extension attribute of the correct type.
+            var attr = cloudEvent.GetAttribute(pair.Key);
+            if (attr is null)
             {
-                case IMessage message:
-                    proto.ProtoData = message is Any any ? any : Any.Pack(message, TypeUrlPrefix);
+                attr = CloudEventAttribute.CreateExtension(pair.Key, attrTypeFromProto);
+            }
+            // Note: if CloudEvents spec version 2.0 contains different required attributes, we may want to
+            // change exactly how this is specified. For the moment, this is the simplest way of implementing the requirement.
+            else if (attr.IsRequired)
+            {
+                // The required attributes are all specified as proto fields.
+                // They can't appear in the Attributes repeated field as well.
+                throw new ArgumentException(
+                    $"Attribute '{attr.Name}' is a required attribute, and must only be specified via the top-level proto field.");
+            }
+            else if (attr.Type != attrTypeFromProto)
+            {
+                // This prevents any type changes, even those which might validate correctly
+                // otherwise (e.g. between Uri and UriRef).
+                throw new ArgumentException(
+                    $"Attribute '{attr.Name}' was specified with type '{attr.Type}', but has type '{attrTypeFromProto}' in the protobuf representation.");
+            }
+
+            // Note: the indexer performs validation.
+            cloudEvent[attr] = pair.Value.AttrCase switch
+            {
+                AttrOneofCase.CeBoolean => pair.Value.CeBoolean,
+                AttrOneofCase.CeBytes => pair.Value.CeBytes.ToByteArray(),
+                AttrOneofCase.CeInteger => pair.Value.CeInteger,
+                AttrOneofCase.CeString => pair.Value.CeString,
+                AttrOneofCase.CeTimestamp => pair.Value.CeTimestamp.ToDateTimeOffset(),
+                AttrOneofCase.CeUri => CloudEventAttributeType.Uri.Parse(pair.Value.CeUri),
+                AttrOneofCase.CeUriRef => CloudEventAttributeType.UriReference.Parse(pair.Value.CeUriRef),
+                _ => throw new ArgumentException($"Unhandled protobuf attribute case: {pair.Value.AttrCase}")
+            };
+        }
+
+        DecodeStructuredModeData(proto, cloudEvent);
+
+        return Validation.CheckCloudEventArgument(cloudEvent, paramName);
+    }
+
+    /// <summary>
+    /// Decodes the "data" property provided within a structured-mode message,
+    /// populating the <see cref="CloudEvents.CloudEvent.Data"/> property accordingly.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This implementation simply converts binary data to a byte array, leaves proto data
+    /// as an <see cref="Google.Protobuf.WellKnownTypes.Any"/>, and converts text data to a string.
+    /// </para>
+    /// <para>
+    /// Override this method to provide more specialized conversions, such as to use <see cref="ByteString"/>
+    /// instead of a byte array, or to "unwrap" the proto data to generated code.
+    /// </para>
+    /// </remarks>
+    /// <param name="proto">The protobuf representation of the CloudEvent. Will not be null.</param>
+    /// <param name="cloudEvent">The event being decoded. This should not be modified except to
+    /// populate the <see cref="CloudEvents.CloudEvent.Data"/> property, but may be used to provide extra
+    /// information such as the data content type. Will not be null.</param>
+    /// <returns>The data to populate in the <see cref="CloudEvents.CloudEvent.Data"/> property.</returns>
+    protected virtual void DecodeStructuredModeData(V1.CloudEvent proto, CloudEvent cloudEvent) =>
+        cloudEvent.Data = proto.DataCase switch
+        {
+            DataOneofCase.BinaryData => proto.BinaryData.ToByteArray(),
+            DataOneofCase.ProtoData => proto.ProtoData,
+            DataOneofCase.TextData => proto.TextData,
+            DataOneofCase.None => null,
+            // Note: impossible to cover in tests
+            _ => throw new ArgumentException($"Unhandled protobuf data case: {proto.DataCase}")
+        };
+
+    /// <summary>
+    /// Encodes structured (or batch) mode data within a CloudEvent, storing it in the specified <see cref="CloudEvents.CloudEvent"/>.
+    /// </summary>
+    /// <param name="cloudEvent">The CloudEvent being encoded, which will have a non-null value for
+    /// its <see cref="CloudEvents.CloudEvent.Data"/> property.</param>
+    /// <param name="proto">The protobuf representation of the CloudEvent, which will be non-null.</param>
+    protected virtual void EncodeStructuredModeData(CloudEvent cloudEvent, V1.CloudEvent proto)
+    {
+        switch (cloudEvent.Data)
+        {
+            case IMessage message:
+                proto.ProtoData = message is Any any ? any : Any.Pack(message, TypeUrlPrefix);
+                break;
+            case string text:
+                proto.TextData = text;
+                break;
+            case byte[] binary:
+                proto.BinaryData = ByteString.CopyFrom(binary);
+                break;
+            default:
+                throw new ArgumentException($"{nameof(ProtobufEventFormatter)} cannot serialize data of type {cloudEvent.Data!.GetType()}");
+        }
+    }
+
+    /// <summary>
+    /// Converts the given SDK representation of a CloudEvent to a protobuf representation.
+    /// </summary>
+    /// <param name="cloudEvent">The CloudEvent to convert. Must not be null, and must be a valid CloudEvent.</param>
+    /// <returns>The protobuf representation of the CloudEvent.</returns>
+    public V1.CloudEvent ConvertToProto(CloudEvent cloudEvent) => ConvertToProto(cloudEvent, nameof(cloudEvent));
+
+    private V1.CloudEvent ConvertToProto(CloudEvent cloudEvent, string paramName)
+    {
+        Validation.CheckCloudEventArgument(cloudEvent, paramName);
+        var specVersion = cloudEvent.SpecVersion;
+        var proto = new V1.CloudEvent
+        {
+            Id = cloudEvent.Id,
+            // Source is a required attribute, and we've validated the CloudEvent,
+            // so it really should be non-null.
+            Source = specVersion.SourceAttribute.Format(cloudEvent.Source!),
+            Type = cloudEvent.Type,
+            SpecVersion = cloudEvent.SpecVersion.VersionId
+        };
+
+        foreach (var pair in cloudEvent.GetPopulatedAttributes())
+        {
+            var attr = pair.Key;
+            // Skip attributes already handled above.
+            if (attr == specVersion.IdAttribute ||
+                attr == specVersion.SourceAttribute ||
+                attr == specVersion.TypeAttribute)
+            {
+                continue;
+            }
+
+            var value = new CloudEventAttributeValue();
+            switch (CloudEventAttributeTypes.GetOrdinal(attr.Type))
+            {
+                case CloudEventAttributeTypeOrdinal.Binary:
+                    value.CeBytes = ByteString.CopyFrom((byte[]) pair.Value);
                     break;
-                case string text:
-                    proto.TextData = text;
+                case CloudEventAttributeTypeOrdinal.Boolean:
+                    value.CeBoolean = (bool) pair.Value;
                     break;
-                case byte[] binary:
-                    proto.BinaryData = ByteString.CopyFrom(binary);
+                case CloudEventAttributeTypeOrdinal.Integer:
+                    value.CeInteger = (int) pair.Value;
+                    break;
+                case CloudEventAttributeTypeOrdinal.String:
+                    value.CeString = (string) pair.Value;
+                    break;
+                case CloudEventAttributeTypeOrdinal.Timestamp:
+                    value.CeTimestamp = Timestamp.FromDateTimeOffset((DateTimeOffset) pair.Value);
+                    break;
+                case CloudEventAttributeTypeOrdinal.Uri:
+                    value.CeUri = attr.Format(pair.Value);
+                    break;
+                case CloudEventAttributeTypeOrdinal.UriReference:
+                    value.CeUriRef = attr.Format(pair.Value);
                     break;
                 default:
-                    throw new ArgumentException($"{nameof(ProtobufEventFormatter)} cannot serialize data of type {cloudEvent.Data!.GetType()}");
+                    // Note: impossible to cover in tests
+                    throw new ArgumentException($"Unhandled attribute type: {attr.Type}");
             }
+            proto.Attributes.Add(attr.Name, value);
         }
 
-        /// <summary>
-        /// Converts the given SDK representation of a CloudEvent to a protobuf representation.
-        /// </summary>
-        /// <param name="cloudEvent">The CloudEvent to convert. Must not be null, and must be a valid CloudEvent.</param>
-        /// <returns>The protobuf representation of the CloudEvent.</returns>
-        public V1.CloudEvent ConvertToProto(CloudEvent cloudEvent) => ConvertToProto(cloudEvent, nameof(cloudEvent));
-
-        private V1.CloudEvent ConvertToProto(CloudEvent cloudEvent, string paramName)
+        if (cloudEvent.Data is object)
         {
-            Validation.CheckCloudEventArgument(cloudEvent, paramName);
-            var specVersion = cloudEvent.SpecVersion;
-            var proto = new V1.CloudEvent
-            {
-                Id = cloudEvent.Id,
-                // Source is a required attribute, and we've validated the CloudEvent,
-                // so it really should be non-null.
-                Source = specVersion.SourceAttribute.Format(cloudEvent.Source!),
-                Type = cloudEvent.Type,
-                SpecVersion = cloudEvent.SpecVersion.VersionId
-            };
-
-            foreach (var pair in cloudEvent.GetPopulatedAttributes())
-            {
-                var attr = pair.Key;
-                // Skip attributes already handled above.
-                if (attr == specVersion.IdAttribute ||
-                    attr == specVersion.SourceAttribute ||
-                    attr == specVersion.TypeAttribute)
-                {
-                    continue;
-                }
-
-                var value = new CloudEventAttributeValue();
-                switch (CloudEventAttributeTypes.GetOrdinal(attr.Type))
-                {
-                    case CloudEventAttributeTypeOrdinal.Binary:
-                        value.CeBytes = ByteString.CopyFrom((byte[]) pair.Value);
-                        break;
-                    case CloudEventAttributeTypeOrdinal.Boolean:
-                        value.CeBoolean = (bool) pair.Value;
-                        break;
-                    case CloudEventAttributeTypeOrdinal.Integer:
-                        value.CeInteger = (int) pair.Value;
-                        break;
-                    case CloudEventAttributeTypeOrdinal.String:
-                        value.CeString = (string) pair.Value;
-                        break;
-                    case CloudEventAttributeTypeOrdinal.Timestamp:
-                        value.CeTimestamp = Timestamp.FromDateTimeOffset((DateTimeOffset) pair.Value);
-                        break;
-                    case CloudEventAttributeTypeOrdinal.Uri:
-                        value.CeUri = attr.Format(pair.Value);
-                        break;
-                    case CloudEventAttributeTypeOrdinal.UriReference:
-                        value.CeUriRef = attr.Format(pair.Value);
-                        break;
-                    default:
-                        // Note: impossible to cover in tests
-                        throw new ArgumentException($"Unhandled attribute type: {attr.Type}");
-                }
-                proto.Attributes.Add(attr.Name, value);
-            }
-
-            if (cloudEvent.Data is object)
-            {
-                EncodeStructuredModeData(cloudEvent, proto);
-            }
-
-            return proto;
+            EncodeStructuredModeData(cloudEvent, proto);
         }
+
+        return proto;
     }
 }

--- a/src/CloudNative.CloudEvents.SystemTextJson/CloudNative.CloudEvents.SystemTextJson.csproj
+++ b/src/CloudNative.CloudEvents.SystemTextJson/CloudNative.CloudEvents.SystemTextJson.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <Description>JSON support for the CNCF CloudEvents SDK, based on System.Text.Json.</Description>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <PackageTags>cncf;cloudnative;cloudevents;events;json;systemtextjson</PackageTags>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/CloudNative.CloudEvents.SystemTextJson/JsonEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.SystemTextJson/JsonEventFormatter.cs
@@ -11,706 +11,705 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 
-namespace CloudNative.CloudEvents.SystemTextJson
+namespace CloudNative.CloudEvents.SystemTextJson;
+
+/// <summary>
+/// Formatter that implements the JSON Event Format, using System.Text.Json for JSON serialization and deserialization.
+/// </summary>
+/// <remarks>
+/// <para>
+/// When encoding CloudEvent data, the behavior of this implementation depends on the data
+/// content type of the CloudEvent and the type of the <see cref="CloudEvent.Data"/> property value,
+/// following the rules below. Derived classes can specialize this behavior by overriding
+/// <see cref="EncodeStructuredModeData(CloudEvent, Utf8JsonWriter)"/> or <see cref="EncodeBinaryModeEventData(CloudEvent)"/>.
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// If the data value is null, the content is empty for a binary mode message, and neither the "data"
+/// nor "data_base64" property is populated in a structured mode message.
+/// </description></item>
+/// <item><description>
+/// If the data value is a byte array, it is serialized either directly as binary data
+/// (for binary mode messages) or as base64 data (for structured mode messages).
+/// </description></item>
+/// <item><description>
+/// Otherwise, if the data content type is absent or has a media type indicating JSON, the data is encoded as JSON,
+/// using the <see cref="JsonSerializerOptions"/> passed into the constructor, or the default options.
+/// </description></item>
+/// <item><description>
+/// Otherwise, if the data content type has a media type beginning with "text/" and the data value is a string,
+/// the data is serialized as a string.
+/// </description></item>
+/// <item><description>
+/// Otherwise, the encoding operation fails.
+/// </description></item>
+/// </list>
+/// <para>
+/// When decoding structured mode CloudEvent data, this implementation uses the following rules,
+/// which can be modified by overriding <see cref="DecodeStructuredModeDataBase64Property(JsonElement, CloudEvent)"/>
+/// and <see cref="DecodeStructuredModeDataProperty(JsonElement, CloudEvent)"/>.
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// If the "data_base64" property is present, its value is decoded as a byte array.
+/// </description></item>
+/// <item><description>
+/// If the "data" property is present (and non-null) and the content type is absent or indicates a JSON media type,
+/// the JSON token present in the property is preserved as a <see cref="JsonElement"/> that can be used for further
+/// deserialization (e.g. to a specific CLR type).
+/// </description></item>
+/// <item><description>
+/// If the "data" property has a string value and a non-JSON content type has been specified, the data is
+/// deserialized as a string.
+/// </description></item>
+/// <item><description>
+/// If the "data" property has a non-null, non-string value and a non-JSON content type has been specified,
+/// the deserialization operation fails.
+/// </description></item>
+/// </list>
+/// <para>
+/// In a binary mode message, the data is parsed based on the content type of the message. When the content
+/// type is absent or has a media type of "application/json", the data is parsed as JSON, with the result as
+/// a <see cref="JsonElement"/> (or null if the data is empty). When the content type has a media type beginning
+/// with "text/", the data is parsed as a string. In all other cases, the data is left as a byte array.
+/// This behavior can be specialized by overriding <see cref="DecodeBinaryModeEventData(ReadOnlyMemory{byte}, CloudEvent)"/>.
+/// </para>
+/// </remarks>
+public class JsonEventFormatter : CloudEventFormatter
 {
+    private const string JsonMediaType = "application/json";
+    private const string MediaTypeSuffix = "+json";
+
+    private static readonly string StructuredMediaType = MimeUtilities.MediaType + MediaTypeSuffix;
+    private static readonly string BatchMediaType = MimeUtilities.BatchMediaType + MediaTypeSuffix;
+
     /// <summary>
-    /// Formatter that implements the JSON Event Format, using System.Text.Json for JSON serialization and deserialization.
+    /// The property name to use for base64-encoded binary data in a structured-mode message.
+    /// </summary>
+    protected const string DataBase64PropertyName = "data_base64";
+
+    /// <summary>
+    /// The property name to use for general data in a structured-mode message.
+    /// </summary>
+    protected const string DataPropertyName = "data";
+
+    /// <summary>
+    /// The options to use when serializing objects to JSON.
+    /// </summary>
+    protected JsonSerializerOptions? SerializerOptions { get; }
+
+    /// <summary>
+    /// The options to use when parsing JSON documents.
+    /// </summary>
+    protected JsonDocumentOptions DocumentOptions { get; }
+
+    /// <summary>
+    /// Creates a JsonEventFormatter that uses the default <see cref="JsonSerializerOptions"/>
+    /// and <see cref="JsonDocumentOptions"/> for serializing and parsing.
+    /// </summary>
+    public JsonEventFormatter() : this(null, default)
+    {
+    }
+
+    /// <summary>
+    /// Creates a JsonEventFormatter that uses the specified <see cref="JsonSerializerOptions"/>
+    /// and <see cref="JsonDocumentOptions"/> for serializing and parsing.
+    /// </summary>
+    /// <param name="serializerOptions">The options to use when serializing objects to JSON. May be null.</param>
+    /// <param name="documentOptions">The options to use when parsing JSON documents.</param>
+    public JsonEventFormatter(JsonSerializerOptions? serializerOptions, JsonDocumentOptions documentOptions)
+    {
+        SerializerOptions = serializerOptions;
+        DocumentOptions = documentOptions;
+    }
+
+    /// <inheritdoc />
+    public override async Task<CloudEvent> DecodeStructuredModeMessageAsync(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
+        await DecodeStructuredModeMessageImpl(body, contentType, extensionAttributes, true).ConfigureAwait(false);
+
+    /// <inheritdoc />
+    public override CloudEvent DecodeStructuredModeMessage(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
+        DecodeStructuredModeMessageImpl(body, contentType, extensionAttributes, false).GetAwaiter().GetResult();
+
+    /// <inheritdoc />
+    public override CloudEvent DecodeStructuredModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
+        DecodeStructuredModeMessageImpl(BinaryDataUtilities.AsStream(body), contentType, extensionAttributes, false).GetAwaiter().GetResult();
+
+    private async Task<CloudEvent> DecodeStructuredModeMessageImpl(Stream data, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes, bool async)
+    {
+        Validation.CheckNotNull(data, nameof(data));
+        JsonDocument document = await ReadDocumentAsync(data, contentType, async).ConfigureAwait(false);
+        using (document)
+        {
+            return DecodeJsonElement(document.RootElement, extensionAttributes, nameof(data));
+        }
+    }
+
+    /// <inheritdoc />
+    public override Task<IReadOnlyList<CloudEvent>> DecodeBatchModeMessageAsync(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
+        DecodeBatchModeMessageImpl(body, contentType, extensionAttributes, true);
+
+    /// <inheritdoc />
+    public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
+        DecodeBatchModeMessageImpl(body, contentType, extensionAttributes, false).GetAwaiter().GetResult();
+
+    /// <inheritdoc />
+    public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
+        DecodeBatchModeMessageImpl(BinaryDataUtilities.AsStream(body), contentType, extensionAttributes, false).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Converts the given <see cref="JsonElement"/> into a <see cref="CloudEvent"/>.
+    /// </summary>
+    /// <param name="element">The JSON representation of a CloudEvent. Must have a <see cref="JsonElement.ValueKind"/> of <see cref="JsonValueKind.Object"/>.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
+    /// <returns>The SDK representation of the CloudEvent.</returns>
+    public CloudEvent ConvertFromJsonElement(JsonElement element, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
+        DecodeJsonElement(element, extensionAttributes, nameof(element));
+
+    private async Task<IReadOnlyList<CloudEvent>> DecodeBatchModeMessageImpl(Stream data, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes, bool async)
+    {
+        Validation.CheckNotNull(data, nameof(data));
+        var document = await ReadDocumentAsync(data, contentType, async).ConfigureAwait(false);
+        using (document)
+        {
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Array)
+            {
+                throw new ArgumentException($"Cannot decode JSON element of kind '{root.ValueKind}' as batch CloudEvent");
+            }
+            // Avoiding LINQ to avoid extraneous allocations etc.
+            List<CloudEvent> events = new List<CloudEvent>(root.GetArrayLength());
+            foreach (var element in root.EnumerateArray())
+            {
+                events.Add(DecodeJsonElement(element, extensionAttributes, nameof(data)));
+            }
+            return events;
+        }
+    }
+
+    private async Task<JsonDocument> ReadDocumentAsync(Stream data, ContentType? contentType, bool async)
+    {
+        var encoding = MimeUtilities.GetEncoding(contentType);
+        if (encoding is UTF8Encoding)
+        {
+            return async
+                ? await JsonDocument.ParseAsync(data, DocumentOptions).ConfigureAwait(false)
+                : JsonDocument.Parse(data, DocumentOptions);
+        }
+        else
+        {
+            using var reader = new StreamReader(data, encoding);
+            var json = async
+                ? await reader.ReadToEndAsync().ConfigureAwait(false)
+                : reader.ReadToEnd();
+            return JsonDocument.Parse(json, DocumentOptions);
+        }
+    }
+
+    private CloudEvent DecodeJsonElement(JsonElement element, IEnumerable<CloudEventAttribute>? extensionAttributes, string paramName)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            throw new ArgumentException($"Cannot decode JSON element of kind '{element.ValueKind}' as CloudEvent");
+        }
+
+        if (!element.TryGetProperty(CloudEventsSpecVersion.SpecVersionAttribute.Name, out var specVersionProperty)
+            || specVersionProperty.ValueKind != JsonValueKind.String)
+        {
+            throw new ArgumentException($"Structured mode content does not represent a CloudEvent");
+        }
+        var specVersion = CloudEventsSpecVersion.FromVersionId(specVersionProperty.GetString())
+            ?? throw new ArgumentException($"Unsupported CloudEvents spec version '{specVersionProperty.GetString()}'");
+
+        var cloudEvent = new CloudEvent(specVersion, extensionAttributes);
+        PopulateAttributesFromStructuredEvent(cloudEvent, element);
+        PopulateDataFromStructuredEvent(cloudEvent, element);
+        return Validation.CheckCloudEventArgument(cloudEvent, paramName);
+    }
+
+    private void PopulateAttributesFromStructuredEvent(CloudEvent cloudEvent, JsonElement element)
+    {
+        foreach (var jsonProperty in element.EnumerateObject())
+        {
+            var name = jsonProperty.Name;
+            var value = jsonProperty.Value;
+
+            // Skip the spec version attribute, which we've already taken account of.
+            // Data is handled later, when everything else (importantly, the data content type)
+            // has been populated.
+            if (name == CloudEventsSpecVersion.SpecVersionAttribute.Name ||
+                name == DataBase64PropertyName ||
+                name == DataPropertyName)
+            {
+                continue;
+            }
+
+            // For non-extension attributes, validate that the token type is as expected.
+            // We're more forgiving for extension attributes: if an integer-typed extension attribute
+            // has a value of "10" (i.e. as a string), that's fine. (If it has a value of "garbage",
+            // that will throw in SetAttributeFromString.)
+            ValidateTokenTypeForAttribute(cloudEvent.GetAttribute(name), value.ValueKind);
+
+            // TODO: This currently performs more conversions than it really should, in the cause of simplicity.
+            // We basically need a matrix of "attribute type vs token type" but that's rather complicated.
+
+            string? attributeValue = value.ValueKind switch
+            {
+                JsonValueKind.String => value.GetString(),
+                JsonValueKind.True => CloudEventAttributeType.Boolean.Format(true),
+                JsonValueKind.False => CloudEventAttributeType.Boolean.Format(false),
+                JsonValueKind.Null => null,
+                // Note: this will fail if the value isn't an integer, or is out of range for Int32.
+                JsonValueKind.Number => CloudEventAttributeType.Integer.Format(value.GetInt32()),
+                _ => throw new ArgumentException($"Invalid token type '{value.ValueKind}' for CloudEvent attribute")
+            };
+            if (attributeValue is null)
+            {
+                continue;
+            }
+            // Note: we *could* infer an extension type of integer and Boolean, but not other extension types.
+            // (We don't want to assume that everything that looks like a timestamp is a timestamp, etc.)
+            // Stick to strings for consistency.
+            cloudEvent.SetAttributeFromString(name, attributeValue);
+        }
+    }
+
+    private void ValidateTokenTypeForAttribute(CloudEventAttribute? attribute, JsonValueKind valueKind)
+    {
+        // We can't validate unknown attributes, don't check for extension attributes,
+        // and null values will be ignored anyway.
+        if (attribute is null || attribute.IsExtension || valueKind == JsonValueKind.Null)
+        {
+            return;
+        }
+
+        // This is deliberately written so that if a new attribute type is added without this being updated, we "fail valid".
+        // (That should only happen in major versions anyway, but it's worth being somewhat forgiving here.)
+        var valid = CloudEventAttributeTypes.GetOrdinal(attribute.Type) switch
+        {
+            CloudEventAttributeTypeOrdinal.Binary => valueKind == JsonValueKind.String,
+            CloudEventAttributeTypeOrdinal.Boolean => valueKind == JsonValueKind.True || valueKind == JsonValueKind.False,
+            CloudEventAttributeTypeOrdinal.Integer => valueKind == JsonValueKind.Number,
+            CloudEventAttributeTypeOrdinal.String => valueKind == JsonValueKind.String,
+            CloudEventAttributeTypeOrdinal.Timestamp => valueKind == JsonValueKind.String,
+            CloudEventAttributeTypeOrdinal.Uri => valueKind == JsonValueKind.String,
+            CloudEventAttributeTypeOrdinal.UriReference => valueKind == JsonValueKind.String,
+            _ => true
+        };
+        if (!valid)
+        {
+            throw new ArgumentException($"Invalid token type '{valueKind}' for CloudEvent attribute '{attribute.Name}' with type '{attribute.Type}'");
+        }
+    }
+
+    private void PopulateDataFromStructuredEvent(CloudEvent cloudEvent, JsonElement element)
+    {
+        // Fetch data and data_base64 tokens, and treat null as missing.
+        element.TryGetProperty(DataPropertyName, out var dataElement);
+        element.TryGetProperty(DataBase64PropertyName, out var dataBase64Element);
+
+        bool dataPresent = dataElement.ValueKind != JsonValueKind.Null && dataElement.ValueKind != JsonValueKind.Undefined;
+        bool dataBase64Present = dataBase64Element.ValueKind != JsonValueKind.Null && dataBase64Element.ValueKind != JsonValueKind.Undefined;
+
+        // If we don't have any data, we're done.
+        if (!dataPresent && !dataBase64Present)
+        {
+            return;
+        }
+        // We can't handle both properties being set.
+        if (dataPresent && dataBase64Present)
+        {
+            throw new ArgumentException($"Structured mode content cannot contain both '{DataPropertyName}' and '{DataBase64PropertyName}' properties.");
+        }
+        // Okay, we have exactly one non-null data/data_base64 property.
+        // Decode it, potentially using overridden methods for specialization.
+        if (dataBase64Present)
+        {
+            DecodeStructuredModeDataBase64Property(dataBase64Element, cloudEvent);
+        }
+        else
+        {
+            // If no content type has been specified, default to application/json
+            cloudEvent.DataContentType ??= JsonMediaType;
+
+            DecodeStructuredModeDataProperty(dataElement, cloudEvent);
+        }
+    }
+
+    /// <summary>
+    /// Decodes the "data_base64" property provided within a structured-mode message,
+    /// populating the <see cref="CloudEvent.Data"/> property accordingly.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// When encoding CloudEvent data, the behavior of this implementation depends on the data
-    /// content type of the CloudEvent and the type of the <see cref="CloudEvent.Data"/> property value,
-    /// following the rules below. Derived classes can specialize this behavior by overriding
-    /// <see cref="EncodeStructuredModeData(CloudEvent, Utf8JsonWriter)"/> or <see cref="EncodeBinaryModeEventData(CloudEvent)"/>.
+    /// This implementation converts JSON string tokens to byte arrays, and fails for any other token type.
     /// </para>
-    /// <list type="bullet">
-    /// <item><description>
-    /// If the data value is null, the content is empty for a binary mode message, and neither the "data"
-    /// nor "data_base64" property is populated in a structured mode message.
-    /// </description></item>
-    /// <item><description>
-    /// If the data value is a byte array, it is serialized either directly as binary data
-    /// (for binary mode messages) or as base64 data (for structured mode messages).
-    /// </description></item>
-    /// <item><description>
-    /// Otherwise, if the data content type is absent or has a media type indicating JSON, the data is encoded as JSON,
-    /// using the <see cref="JsonSerializerOptions"/> passed into the constructor, or the default options.
-    /// </description></item>
-    /// <item><description>
-    /// Otherwise, if the data content type has a media type beginning with "text/" and the data value is a string,
-    /// the data is serialized as a string.
-    /// </description></item>
-    /// <item><description>
-    /// Otherwise, the encoding operation fails.
-    /// </description></item>
-    /// </list>
     /// <para>
-    /// When decoding structured mode CloudEvent data, this implementation uses the following rules,
-    /// which can be modified by overriding <see cref="DecodeStructuredModeDataBase64Property(JsonElement, CloudEvent)"/>
-    /// and <see cref="DecodeStructuredModeDataProperty(JsonElement, CloudEvent)"/>.
-    /// </para>
-    /// <list type="bullet">
-    /// <item><description>
-    /// If the "data_base64" property is present, its value is decoded as a byte array.
-    /// </description></item>
-    /// <item><description>
-    /// If the "data" property is present (and non-null) and the content type is absent or indicates a JSON media type,
-    /// the JSON token present in the property is preserved as a <see cref="JsonElement"/> that can be used for further
-    /// deserialization (e.g. to a specific CLR type).
-    /// </description></item>
-    /// <item><description>
-    /// If the "data" property has a string value and a non-JSON content type has been specified, the data is
-    /// deserialized as a string.
-    /// </description></item>
-    /// <item><description>
-    /// If the "data" property has a non-null, non-string value and a non-JSON content type has been specified,
-    /// the deserialization operation fails.
-    /// </description></item>
-    /// </list>
-    /// <para>
-    /// In a binary mode message, the data is parsed based on the content type of the message. When the content
-    /// type is absent or has a media type of "application/json", the data is parsed as JSON, with the result as
-    /// a <see cref="JsonElement"/> (or null if the data is empty). When the content type has a media type beginning
-    /// with "text/", the data is parsed as a string. In all other cases, the data is left as a byte array.
-    /// This behavior can be specialized by overriding <see cref="DecodeBinaryModeEventData(ReadOnlyMemory{byte}, CloudEvent)"/>.
+    /// Override this method to provide more specialized conversions.
     /// </para>
     /// </remarks>
-    public class JsonEventFormatter : CloudEventFormatter
+    /// <param name="dataBase64Element">The "data_base64" property value within the structured-mode message. Will not be null, and will
+    /// not have a null token type.</param>
+    /// <param name="cloudEvent">The event being decoded. This should not be modified except to
+    /// populate the <see cref="CloudEvent.Data"/> property, but may be used to provide extra
+    /// information such as the data content type. Will not be null.</param>
+    /// <returns>The data to populate in the <see cref="CloudEvent.Data"/> property.</returns>
+    protected virtual void DecodeStructuredModeDataBase64Property(JsonElement dataBase64Element, CloudEvent cloudEvent)
     {
-        private const string JsonMediaType = "application/json";
-        private const string MediaTypeSuffix = "+json";
-
-        private static readonly string StructuredMediaType = MimeUtilities.MediaType + MediaTypeSuffix;
-        private static readonly string BatchMediaType = MimeUtilities.BatchMediaType + MediaTypeSuffix;
-
-        /// <summary>
-        /// The property name to use for base64-encoded binary data in a structured-mode message.
-        /// </summary>
-        protected const string DataBase64PropertyName = "data_base64";
-
-        /// <summary>
-        /// The property name to use for general data in a structured-mode message.
-        /// </summary>
-        protected const string DataPropertyName = "data";
-
-        /// <summary>
-        /// The options to use when serializing objects to JSON.
-        /// </summary>
-        protected JsonSerializerOptions? SerializerOptions { get; }
-
-        /// <summary>
-        /// The options to use when parsing JSON documents.
-        /// </summary>
-        protected JsonDocumentOptions DocumentOptions { get; }
-
-        /// <summary>
-        /// Creates a JsonEventFormatter that uses the default <see cref="JsonSerializerOptions"/>
-        /// and <see cref="JsonDocumentOptions"/> for serializing and parsing.
-        /// </summary>
-        public JsonEventFormatter() : this(null, default)
+        if (dataBase64Element.ValueKind != JsonValueKind.String)
         {
+            throw new ArgumentException($"Structured mode property '{DataBase64PropertyName}' must be a string, when present.");
         }
+        cloudEvent.Data = dataBase64Element.GetBytesFromBase64();
+    }
 
-        /// <summary>
-        /// Creates a JsonEventFormatter that uses the specified <see cref="JsonSerializerOptions"/>
-        /// and <see cref="JsonDocumentOptions"/> for serializing and parsing.
-        /// </summary>
-        /// <param name="serializerOptions">The options to use when serializing objects to JSON. May be null.</param>
-        /// <param name="documentOptions">The options to use when parsing JSON documents.</param>
-        public JsonEventFormatter(JsonSerializerOptions? serializerOptions, JsonDocumentOptions documentOptions)
+    /// <summary>
+    /// Decodes the "data" property provided within a structured-mode message,
+    /// populating the <see cref="CloudEvent.Data"/> property accordingly.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This implementation will populate the Data property with the verbatim <see cref="JsonElement"/> if
+    /// the content type is deemed to be JSON according to <see cref="IsJsonMediaType(string)"/>. Otherwise,
+    /// it validates that the token is a string, and the Data property is populated with that string.
+    /// </para>
+    /// <para>
+    /// Override this method to provide more specialized conversions.
+    /// </para>
+    /// </remarks>
+    /// <param name="dataElement">The "data" property value within the structured-mode message. Will not be null, and will
+    /// not have a null token type.</param>
+    /// <param name="cloudEvent">The event being decoded. This should not be modified except to
+    /// populate the <see cref="CloudEvent.Data"/> property, but may be used to provide extra
+    /// information such as the data content type. Will not be null, and the <see cref="CloudEvent.DataContentType"/>
+    /// property will be non-null.</param>
+    /// <returns>The data to populate in the <see cref="CloudEvent.Data"/> property.</returns>
+    protected virtual void DecodeStructuredModeDataProperty(JsonElement dataElement, CloudEvent cloudEvent)
+    {
+        if (IsJsonMediaType(new ContentType(cloudEvent.DataContentType!).MediaType))
         {
-            SerializerOptions = serializerOptions;
-            DocumentOptions = documentOptions;
+            cloudEvent.Data = dataElement.Clone();
         }
-
-        /// <inheritdoc />
-        public override async Task<CloudEvent> DecodeStructuredModeMessageAsync(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
-            await DecodeStructuredModeMessageImpl(body, contentType, extensionAttributes, true).ConfigureAwait(false);
-
-        /// <inheritdoc />
-        public override CloudEvent DecodeStructuredModeMessage(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
-            DecodeStructuredModeMessageImpl(body, contentType, extensionAttributes, false).GetAwaiter().GetResult();
-
-        /// <inheritdoc />
-        public override CloudEvent DecodeStructuredModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
-            DecodeStructuredModeMessageImpl(BinaryDataUtilities.AsStream(body), contentType, extensionAttributes, false).GetAwaiter().GetResult();
-
-        private async Task<CloudEvent> DecodeStructuredModeMessageImpl(Stream data, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes, bool async)
+        else
         {
-            Validation.CheckNotNull(data, nameof(data));
-            JsonDocument document = await ReadDocumentAsync(data, contentType, async).ConfigureAwait(false);
-            using (document)
+            if (dataElement.ValueKind != JsonValueKind.String)
             {
-                return DecodeJsonElement(document.RootElement, extensionAttributes, nameof(data));
+                throw new ArgumentException("CloudEvents with a non-JSON datacontenttype can only have string data values.");
+            }
+            cloudEvent.Data = dataElement.GetString();
+        }
+    }
+
+    /// <inheritdoc />
+    public override ReadOnlyMemory<byte> EncodeBatchModeMessage(IEnumerable<CloudEvent> cloudEvents, out ContentType contentType)
+    {
+        Validation.CheckNotNull(cloudEvents, nameof(cloudEvents));
+
+        contentType = new ContentType(BatchMediaType)
+        {
+            CharSet = Encoding.UTF8.WebName
+        };
+
+        var stream = new MemoryStream();
+        var writer = CreateUtf8JsonWriter(stream);
+        writer.WriteStartArray();
+        foreach (var cloudEvent in cloudEvents)
+        {
+            WriteCloudEventForBatchOrStructuredMode(writer, cloudEvent);
+        }
+        writer.WriteEndArray();
+        writer.Flush();
+        return stream.ToArray();
+    }
+
+    /// <inheritdoc />
+    public override ReadOnlyMemory<byte> EncodeStructuredModeMessage(CloudEvent cloudEvent, out ContentType contentType)
+    {
+        contentType = new ContentType(StructuredMediaType)
+        {
+            CharSet = Encoding.UTF8.WebName
+        };
+
+        var stream = new MemoryStream();
+        var writer = CreateUtf8JsonWriter(stream);
+        WriteCloudEventForBatchOrStructuredMode(writer, cloudEvent);
+        writer.Flush();
+        return stream.ToArray();
+    }
+
+    /// <summary>
+    /// Converts the given <see cref="CloudEvent"/> to a <see cref="JsonElement"/> containing the structured mode JSON format representation
+    /// of the event.
+    /// </summary>
+    /// <remarks>The current implementation of this method is inefficient. Care should be taken before
+    /// using this in performance-sensitive scenarios. The efficiency may well be improved in the future.</remarks>
+    /// <param name="cloudEvent">The event to convert. Must not be null.</param>
+    /// <returns>A <see cref="JsonElement"/> containing the structured mode JSON format representation of the event.</returns>
+    public JsonElement ConvertToJsonElement(CloudEvent cloudEvent)
+    {
+        // Unfortunately System.Text.Json doesn't have an equivalent of JTokenWriter,
+        // so we serialize all the data then parse it. That's horrible, but at least
+        // it's contained in this one place (rather than in user code everywhere else).
+        // We can optimize it later by duplicating the logic of WriteCloudEventForBatchOrStructuredMode
+        // to use System.Text.Json.Nodes.
+        var data = EncodeStructuredModeMessage(cloudEvent, out _);
+        using var document = JsonDocument.Parse(data);
+        // We have to clone the data so that we can dispose of the JsonDocument.
+        return document.RootElement.Clone();
+    }
+
+    private Utf8JsonWriter CreateUtf8JsonWriter(Stream stream)
+    {
+        var options = new JsonWriterOptions
+        {
+            Encoder = SerializerOptions?.Encoder,
+            Indented = SerializerOptions?.WriteIndented ?? false,
+            // TODO: Consider skipping validation in the future for the sake of performance.
+            SkipValidation = false
+        };
+        return new Utf8JsonWriter(stream, options);
+    }
+
+    private void WriteCloudEventForBatchOrStructuredMode(Utf8JsonWriter writer, CloudEvent cloudEvent)
+    {
+        Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
+
+        writer.WriteStartObject();
+        writer.WritePropertyName(CloudEventsSpecVersion.SpecVersionAttribute.Name);
+        writer.WriteStringValue(cloudEvent.SpecVersion.VersionId);
+        var attributes = cloudEvent.GetPopulatedAttributes();
+        foreach (var keyValuePair in attributes)
+        {
+            var attribute = keyValuePair.Key;
+            var value = keyValuePair.Value;
+            writer.WritePropertyName(attribute.Name);
+            switch (CloudEventAttributeTypes.GetOrdinal(attribute.Type))
+            {
+                case CloudEventAttributeTypeOrdinal.Integer:
+                    writer.WriteNumberValue((int) value);
+                    break;
+                case CloudEventAttributeTypeOrdinal.Boolean:
+                    writer.WriteBooleanValue((bool) value);
+                    break;
+                default:
+                    writer.WriteStringValue(attribute.Type.Format(value));
+                    break;
             }
         }
 
-        /// <inheritdoc />
-        public override Task<IReadOnlyList<CloudEvent>> DecodeBatchModeMessageAsync(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
-            DecodeBatchModeMessageImpl(body, contentType, extensionAttributes, true);
-
-        /// <inheritdoc />
-        public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
-            DecodeBatchModeMessageImpl(body, contentType, extensionAttributes, false).GetAwaiter().GetResult();
-
-        /// <inheritdoc />
-        public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
-            DecodeBatchModeMessageImpl(BinaryDataUtilities.AsStream(body), contentType, extensionAttributes, false).GetAwaiter().GetResult();
-
-        /// <summary>
-        /// Converts the given <see cref="JsonElement"/> into a <see cref="CloudEvent"/>.
-        /// </summary>
-        /// <param name="element">The JSON representation of a CloudEvent. Must have a <see cref="JsonElement.ValueKind"/> of <see cref="JsonValueKind.Object"/>.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
-        /// <returns>The SDK representation of the CloudEvent.</returns>
-        public CloudEvent ConvertFromJsonElement(JsonElement element, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
-            DecodeJsonElement(element, extensionAttributes, nameof(element));
-
-        private async Task<IReadOnlyList<CloudEvent>> DecodeBatchModeMessageImpl(Stream data, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes, bool async)
+        if (cloudEvent.Data is object)
         {
-            Validation.CheckNotNull(data, nameof(data));
-            var document = await ReadDocumentAsync(data, contentType, async).ConfigureAwait(false);
-            using (document)
+            if (cloudEvent.DataContentType is null && GetOrInferDataContentType(cloudEvent) is string inferredDataContentType)
             {
-                var root = document.RootElement;
-                if (root.ValueKind != JsonValueKind.Array)
-                {
-                    throw new ArgumentException($"Cannot decode JSON element of kind '{root.ValueKind}' as batch CloudEvent");
-                }
-                // Avoiding LINQ to avoid extraneous allocations etc.
-                List<CloudEvent> events = new List<CloudEvent>(root.GetArrayLength());
-                foreach (var element in root.EnumerateArray())
-                {
-                    events.Add(DecodeJsonElement(element, extensionAttributes, nameof(data)));
-                }
-                return events;
+                cloudEvent.SpecVersion.DataContentTypeAttribute.Validate(inferredDataContentType);
+                writer.WritePropertyName(cloudEvent.SpecVersion.DataContentTypeAttribute.Name);
+                writer.WriteStringValue(inferredDataContentType);
+            }
+            EncodeStructuredModeData(cloudEvent, writer);
+        }
+        writer.WriteEndObject();
+    }
+
+    /// <summary>
+    /// Infers the data content type of a CloudEvent based on its data. This implementation
+    /// infers a data content type of "application/json" for any non-binary data, and performs
+    /// no inference for binary data.
+    /// </summary>
+    /// <param name="data">The CloudEvent to infer the data content from. Must not be null.</param>
+    /// <returns>The inferred data content type, or null if no inference is performed.</returns>
+    protected override string? InferDataContentType(object data) => data is byte[]? null : JsonMediaType;
+
+    /// <summary>
+    /// Encodes structured mode data within a CloudEvent, writing it to the specified <see cref="Utf8JsonWriter"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This implementation follows the rules listed in the class remarks. Override this method
+    /// to provide more specialized behavior, writing only <see cref="DataPropertyName"/> or
+    /// <see cref="DataBase64PropertyName"/> properties.
+    /// </para>
+    /// </remarks>
+    /// <param name="cloudEvent">The CloudEvent being encoded, which will have a non-null value for
+    /// its <see cref="CloudEvent.Data"/> property.
+    /// <param name="writer"/>The writer to serialize the data to. Will not be null.</param>
+    protected virtual void EncodeStructuredModeData(CloudEvent cloudEvent, Utf8JsonWriter writer)
+    {
+        // Binary data is encoded using the data_base64 property, regardless of content type.
+        // TODO: Support other forms of binary data, e.g. ReadOnlyMemory<byte>
+        if (cloudEvent.Data is byte[] binary)
+        {
+            writer.WritePropertyName(DataBase64PropertyName);
+            writer.WriteStringValue(Convert.ToBase64String(binary));
+        }
+        else
+        {
+            ContentType dataContentType = new ContentType(cloudEvent.DataContentType ?? JsonMediaType);
+            if (IsJsonMediaType(dataContentType.MediaType))
+            {
+                writer.WritePropertyName(DataPropertyName);
+                JsonSerializer.Serialize(writer, cloudEvent.Data, SerializerOptions);
+            }
+            else if (cloudEvent.Data is string text && dataContentType.MediaType.StartsWith("text/"))
+            {
+                writer.WritePropertyName(DataPropertyName);
+                writer.WriteStringValue(text);
+            }
+            else
+            {
+                // We assume CloudEvent.Data is not null due to the way this is called.
+                throw new ArgumentException($"{nameof(JsonEventFormatter)} cannot serialize data of type {cloudEvent.Data!.GetType()} with content type '{cloudEvent.DataContentType}'");
             }
         }
+    }
 
-        private async Task<JsonDocument> ReadDocumentAsync(Stream data, ContentType? contentType, bool async)
+    /// <inheritdoc />
+    public override ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent)
+    {
+        Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
+
+        if (cloudEvent.Data is null)
+        {
+            return Array.Empty<byte>();
+        }
+        // Binary data is left alone, regardless of the content type.
+        // TODO: Support other forms of binary data, e.g. ReadOnlyMemory<byte>
+        if (cloudEvent.Data is byte[] bytes)
+        {
+            return bytes;
+        }
+        ContentType contentType = new ContentType(cloudEvent.DataContentType ?? JsonMediaType);
+        if (IsJsonMediaType(contentType.MediaType))
         {
             var encoding = MimeUtilities.GetEncoding(contentType);
             if (encoding is UTF8Encoding)
             {
-                return async
-                    ? await JsonDocument.ParseAsync(data, DocumentOptions).ConfigureAwait(false)
-                    : JsonDocument.Parse(data, DocumentOptions);
+                return JsonSerializer.SerializeToUtf8Bytes(cloudEvent.Data, SerializerOptions);
             }
             else
             {
-                using var reader = new StreamReader(data, encoding);
-                var json = async
-                    ? await reader.ReadToEndAsync().ConfigureAwait(false)
-                    : reader.ReadToEnd();
-                return JsonDocument.Parse(json, DocumentOptions);
+                return MimeUtilities.GetEncoding(contentType).GetBytes(JsonSerializer.Serialize(cloudEvent.Data, SerializerOptions));
             }
         }
-
-        private CloudEvent DecodeJsonElement(JsonElement element, IEnumerable<CloudEventAttribute>? extensionAttributes, string paramName)
+        if (contentType.MediaType.StartsWith("text/") && cloudEvent.Data is string text)
         {
-            if (element.ValueKind != JsonValueKind.Object)
-            {
-                throw new ArgumentException($"Cannot decode JSON element of kind '{element.ValueKind}' as CloudEvent");
-            }
-
-            if (!element.TryGetProperty(CloudEventsSpecVersion.SpecVersionAttribute.Name, out var specVersionProperty)
-                || specVersionProperty.ValueKind != JsonValueKind.String)
-            {
-                throw new ArgumentException($"Structured mode content does not represent a CloudEvent");
-            }
-            var specVersion = CloudEventsSpecVersion.FromVersionId(specVersionProperty.GetString())
-                ?? throw new ArgumentException($"Unsupported CloudEvents spec version '{specVersionProperty.GetString()}'");
-
-            var cloudEvent = new CloudEvent(specVersion, extensionAttributes);
-            PopulateAttributesFromStructuredEvent(cloudEvent, element);
-            PopulateDataFromStructuredEvent(cloudEvent, element);
-            return Validation.CheckCloudEventArgument(cloudEvent, paramName);
+            return MimeUtilities.GetEncoding(contentType).GetBytes(text);
         }
+        throw new ArgumentException($"{nameof(JsonEventFormatter)} cannot serialize data of type {cloudEvent.Data.GetType()} with content type '{cloudEvent.DataContentType}'");
+    }
 
-        private void PopulateAttributesFromStructuredEvent(CloudEvent cloudEvent, JsonElement element)
+    /// <inheritdoc />
+    public override void DecodeBinaryModeEventData(ReadOnlyMemory<byte> body, CloudEvent cloudEvent)
+    {
+        Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
+
+        ContentType contentType = new ContentType(cloudEvent.DataContentType ?? JsonMediaType);
+
+        Encoding encoding = MimeUtilities.GetEncoding(contentType);
+
+        if (contentType.MediaType == JsonMediaType)
         {
-            foreach (var jsonProperty in element.EnumerateObject())
+            if (body.Length > 0)
             {
-                var name = jsonProperty.Name;
-                var value = jsonProperty.Value;
-
-                // Skip the spec version attribute, which we've already taken account of.
-                // Data is handled later, when everything else (importantly, the data content type)
-                // has been populated.
-                if (name == CloudEventsSpecVersion.SpecVersionAttribute.Name ||
-                    name == DataBase64PropertyName ||
-                    name == DataPropertyName)
-                {
-                    continue;
-                }
-
-                // For non-extension attributes, validate that the token type is as expected.
-                // We're more forgiving for extension attributes: if an integer-typed extension attribute
-                // has a value of "10" (i.e. as a string), that's fine. (If it has a value of "garbage",
-                // that will throw in SetAttributeFromString.)
-                ValidateTokenTypeForAttribute(cloudEvent.GetAttribute(name), value.ValueKind);
-
-                // TODO: This currently performs more conversions than it really should, in the cause of simplicity.
-                // We basically need a matrix of "attribute type vs token type" but that's rather complicated.
-
-                string? attributeValue = value.ValueKind switch
-                {
-                    JsonValueKind.String => value.GetString(),
-                    JsonValueKind.True => CloudEventAttributeType.Boolean.Format(true),
-                    JsonValueKind.False => CloudEventAttributeType.Boolean.Format(false),
-                    JsonValueKind.Null => null,
-                    // Note: this will fail if the value isn't an integer, or is out of range for Int32.
-                    JsonValueKind.Number => CloudEventAttributeType.Integer.Format(value.GetInt32()),
-                    _ => throw new ArgumentException($"Invalid token type '{value.ValueKind}' for CloudEvent attribute")
-                };
-                if (attributeValue is null)
-                {
-                    continue;
-                }
-                // Note: we *could* infer an extension type of integer and Boolean, but not other extension types.
-                // (We don't want to assume that everything that looks like a timestamp is a timestamp, etc.)
-                // Stick to strings for consistency.
-                cloudEvent.SetAttributeFromString(name, attributeValue);
-            }
-        }
-
-        private void ValidateTokenTypeForAttribute(CloudEventAttribute? attribute, JsonValueKind valueKind)
-        {
-            // We can't validate unknown attributes, don't check for extension attributes,
-            // and null values will be ignored anyway.
-            if (attribute is null || attribute.IsExtension || valueKind == JsonValueKind.Null)
-            {
-                return;
-            }
-
-            // This is deliberately written so that if a new attribute type is added without this being updated, we "fail valid".
-            // (That should only happen in major versions anyway, but it's worth being somewhat forgiving here.)
-            var valid = CloudEventAttributeTypes.GetOrdinal(attribute.Type) switch
-            {
-                CloudEventAttributeTypeOrdinal.Binary => valueKind == JsonValueKind.String,
-                CloudEventAttributeTypeOrdinal.Boolean => valueKind == JsonValueKind.True || valueKind == JsonValueKind.False,
-                CloudEventAttributeTypeOrdinal.Integer => valueKind == JsonValueKind.Number,
-                CloudEventAttributeTypeOrdinal.String => valueKind == JsonValueKind.String,
-                CloudEventAttributeTypeOrdinal.Timestamp => valueKind == JsonValueKind.String,
-                CloudEventAttributeTypeOrdinal.Uri => valueKind == JsonValueKind.String,
-                CloudEventAttributeTypeOrdinal.UriReference => valueKind == JsonValueKind.String,
-                _ => true
-            };
-            if (!valid)
-            {
-                throw new ArgumentException($"Invalid token type '{valueKind}' for CloudEvent attribute '{attribute.Name}' with type '{attribute.Type}'");
-            }
-        }
-
-        private void PopulateDataFromStructuredEvent(CloudEvent cloudEvent, JsonElement element)
-        {
-            // Fetch data and data_base64 tokens, and treat null as missing.
-            element.TryGetProperty(DataPropertyName, out var dataElement);
-            element.TryGetProperty(DataBase64PropertyName, out var dataBase64Element);
-
-            bool dataPresent = dataElement.ValueKind != JsonValueKind.Null && dataElement.ValueKind != JsonValueKind.Undefined;
-            bool dataBase64Present = dataBase64Element.ValueKind != JsonValueKind.Null && dataBase64Element.ValueKind != JsonValueKind.Undefined;
-
-            // If we don't have any data, we're done.
-            if (!dataPresent && !dataBase64Present)
-            {
-                return;
-            }
-            // We can't handle both properties being set.
-            if (dataPresent && dataBase64Present)
-            {
-                throw new ArgumentException($"Structured mode content cannot contain both '{DataPropertyName}' and '{DataBase64PropertyName}' properties.");
-            }
-            // Okay, we have exactly one non-null data/data_base64 property.
-            // Decode it, potentially using overridden methods for specialization.
-            if (dataBase64Present)
-            {
-                DecodeStructuredModeDataBase64Property(dataBase64Element, cloudEvent);
+                using JsonDocument document = encoding is UTF8Encoding
+                    ? JsonDocument.Parse(body, DocumentOptions)
+                    : JsonDocument.Parse(BinaryDataUtilities.GetString(body, encoding), DocumentOptions);
+                // We have to clone the data so that we can dispose of the JsonDocument.
+                cloudEvent.Data = document.RootElement.Clone();
             }
             else
             {
-                // If no content type has been specified, default to application/json
-                cloudEvent.DataContentType ??= JsonMediaType;
-
-                DecodeStructuredModeDataProperty(dataElement, cloudEvent);
+                cloudEvent.Data = null;
             }
         }
-
-        /// <summary>
-        /// Decodes the "data_base64" property provided within a structured-mode message,
-        /// populating the <see cref="CloudEvent.Data"/> property accordingly.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// This implementation converts JSON string tokens to byte arrays, and fails for any other token type.
-        /// </para>
-        /// <para>
-        /// Override this method to provide more specialized conversions.
-        /// </para>
-        /// </remarks>
-        /// <param name="dataBase64Element">The "data_base64" property value within the structured-mode message. Will not be null, and will
-        /// not have a null token type.</param>
-        /// <param name="cloudEvent">The event being decoded. This should not be modified except to
-        /// populate the <see cref="CloudEvent.Data"/> property, but may be used to provide extra
-        /// information such as the data content type. Will not be null.</param>
-        /// <returns>The data to populate in the <see cref="CloudEvent.Data"/> property.</returns>
-        protected virtual void DecodeStructuredModeDataBase64Property(JsonElement dataBase64Element, CloudEvent cloudEvent)
+        else if (contentType.MediaType.StartsWith("text/") == true)
         {
-            if (dataBase64Element.ValueKind != JsonValueKind.String)
-            {
-                throw new ArgumentException($"Structured mode property '{DataBase64PropertyName}' must be a string, when present.");
-            }
-            cloudEvent.Data = dataBase64Element.GetBytesFromBase64();
+            cloudEvent.Data = BinaryDataUtilities.GetString(body, encoding);
         }
-
-        /// <summary>
-        /// Decodes the "data" property provided within a structured-mode message,
-        /// populating the <see cref="CloudEvent.Data"/> property accordingly.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// This implementation will populate the Data property with the verbatim <see cref="JsonElement"/> if
-        /// the content type is deemed to be JSON according to <see cref="IsJsonMediaType(string)"/>. Otherwise,
-        /// it validates that the token is a string, and the Data property is populated with that string.
-        /// </para>
-        /// <para>
-        /// Override this method to provide more specialized conversions.
-        /// </para>
-        /// </remarks>
-        /// <param name="dataElement">The "data" property value within the structured-mode message. Will not be null, and will
-        /// not have a null token type.</param>
-        /// <param name="cloudEvent">The event being decoded. This should not be modified except to
-        /// populate the <see cref="CloudEvent.Data"/> property, but may be used to provide extra
-        /// information such as the data content type. Will not be null, and the <see cref="CloudEvent.DataContentType"/>
-        /// property will be non-null.</param>
-        /// <returns>The data to populate in the <see cref="CloudEvent.Data"/> property.</returns>
-        protected virtual void DecodeStructuredModeDataProperty(JsonElement dataElement, CloudEvent cloudEvent)
+        else
         {
-            if (IsJsonMediaType(new ContentType(cloudEvent.DataContentType!).MediaType))
-            {
-                cloudEvent.Data = dataElement.Clone();
-            }
-            else
-            {
-                if (dataElement.ValueKind != JsonValueKind.String)
-                {
-                    throw new ArgumentException("CloudEvents with a non-JSON datacontenttype can only have string data values.");
-                }
-                cloudEvent.Data = dataElement.GetString();
-            }
+            cloudEvent.Data = body.ToArray();
         }
-
-        /// <inheritdoc />
-        public override ReadOnlyMemory<byte> EncodeBatchModeMessage(IEnumerable<CloudEvent> cloudEvents, out ContentType contentType)
-        {
-            Validation.CheckNotNull(cloudEvents, nameof(cloudEvents));
-
-            contentType = new ContentType(BatchMediaType)
-            {
-                CharSet = Encoding.UTF8.WebName
-            };
-
-            var stream = new MemoryStream();
-            var writer = CreateUtf8JsonWriter(stream);
-            writer.WriteStartArray();
-            foreach (var cloudEvent in cloudEvents)
-            {
-                WriteCloudEventForBatchOrStructuredMode(writer, cloudEvent);
-            }
-            writer.WriteEndArray();
-            writer.Flush();
-            return stream.ToArray();
-        }
-
-        /// <inheritdoc />
-        public override ReadOnlyMemory<byte> EncodeStructuredModeMessage(CloudEvent cloudEvent, out ContentType contentType)
-        {
-            contentType = new ContentType(StructuredMediaType)
-            {
-                CharSet = Encoding.UTF8.WebName
-            };
-
-            var stream = new MemoryStream();
-            var writer = CreateUtf8JsonWriter(stream);
-            WriteCloudEventForBatchOrStructuredMode(writer, cloudEvent);
-            writer.Flush();
-            return stream.ToArray();
-        }
-
-        /// <summary>
-        /// Converts the given <see cref="CloudEvent"/> to a <see cref="JsonElement"/> containing the structured mode JSON format representation
-        /// of the event.
-        /// </summary>
-        /// <remarks>The current implementation of this method is inefficient. Care should be taken before
-        /// using this in performance-sensitive scenarios. The efficiency may well be improved in the future.</remarks>
-        /// <param name="cloudEvent">The event to convert. Must not be null.</param>
-        /// <returns>A <see cref="JsonElement"/> containing the structured mode JSON format representation of the event.</returns>
-        public JsonElement ConvertToJsonElement(CloudEvent cloudEvent)
-        {
-            // Unfortunately System.Text.Json doesn't have an equivalent of JTokenWriter,
-            // so we serialize all the data then parse it. That's horrible, but at least
-            // it's contained in this one place (rather than in user code everywhere else).
-            // We can optimize it later by duplicating the logic of WriteCloudEventForBatchOrStructuredMode
-            // to use System.Text.Json.Nodes.
-            var data = EncodeStructuredModeMessage(cloudEvent, out _);
-            using var document = JsonDocument.Parse(data);
-            // We have to clone the data so that we can dispose of the JsonDocument.
-            return document.RootElement.Clone();
-        }
-
-        private Utf8JsonWriter CreateUtf8JsonWriter(Stream stream)
-        {
-            var options = new JsonWriterOptions
-            {
-                Encoder = SerializerOptions?.Encoder,
-                Indented = SerializerOptions?.WriteIndented ?? false,
-                // TODO: Consider skipping validation in the future for the sake of performance.
-                SkipValidation = false
-            };
-            return new Utf8JsonWriter(stream, options);
-        }
-
-        private void WriteCloudEventForBatchOrStructuredMode(Utf8JsonWriter writer, CloudEvent cloudEvent)
-        {
-            Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
-
-            writer.WriteStartObject();
-            writer.WritePropertyName(CloudEventsSpecVersion.SpecVersionAttribute.Name);
-            writer.WriteStringValue(cloudEvent.SpecVersion.VersionId);
-            var attributes = cloudEvent.GetPopulatedAttributes();
-            foreach (var keyValuePair in attributes)
-            {
-                var attribute = keyValuePair.Key;
-                var value = keyValuePair.Value;
-                writer.WritePropertyName(attribute.Name);
-                switch (CloudEventAttributeTypes.GetOrdinal(attribute.Type))
-                {
-                    case CloudEventAttributeTypeOrdinal.Integer:
-                        writer.WriteNumberValue((int) value);
-                        break;
-                    case CloudEventAttributeTypeOrdinal.Boolean:
-                        writer.WriteBooleanValue((bool) value);
-                        break;
-                    default:
-                        writer.WriteStringValue(attribute.Type.Format(value));
-                        break;
-                }
-            }
-
-            if (cloudEvent.Data is object)
-            {
-                if (cloudEvent.DataContentType is null && GetOrInferDataContentType(cloudEvent) is string inferredDataContentType)
-                {
-                    cloudEvent.SpecVersion.DataContentTypeAttribute.Validate(inferredDataContentType);
-                    writer.WritePropertyName(cloudEvent.SpecVersion.DataContentTypeAttribute.Name);
-                    writer.WriteStringValue(inferredDataContentType);
-                }
-                EncodeStructuredModeData(cloudEvent, writer);
-            }
-            writer.WriteEndObject();
-        }
-
-        /// <summary>
-        /// Infers the data content type of a CloudEvent based on its data. This implementation
-        /// infers a data content type of "application/json" for any non-binary data, and performs
-        /// no inference for binary data.
-        /// </summary>
-        /// <param name="data">The CloudEvent to infer the data content from. Must not be null.</param>
-        /// <returns>The inferred data content type, or null if no inference is performed.</returns>
-        protected override string? InferDataContentType(object data) => data is byte[]? null : JsonMediaType;
-
-        /// <summary>
-        /// Encodes structured mode data within a CloudEvent, writing it to the specified <see cref="Utf8JsonWriter"/>.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// This implementation follows the rules listed in the class remarks. Override this method
-        /// to provide more specialized behavior, writing only <see cref="DataPropertyName"/> or
-        /// <see cref="DataBase64PropertyName"/> properties.
-        /// </para>
-        /// </remarks>
-        /// <param name="cloudEvent">The CloudEvent being encoded, which will have a non-null value for
-        /// its <see cref="CloudEvent.Data"/> property.
-        /// <param name="writer"/>The writer to serialize the data to. Will not be null.</param>
-        protected virtual void EncodeStructuredModeData(CloudEvent cloudEvent, Utf8JsonWriter writer)
-        {
-            // Binary data is encoded using the data_base64 property, regardless of content type.
-            // TODO: Support other forms of binary data, e.g. ReadOnlyMemory<byte>
-            if (cloudEvent.Data is byte[] binary)
-            {
-                writer.WritePropertyName(DataBase64PropertyName);
-                writer.WriteStringValue(Convert.ToBase64String(binary));
-            }
-            else
-            {
-                ContentType dataContentType = new ContentType(cloudEvent.DataContentType ?? JsonMediaType);
-                if (IsJsonMediaType(dataContentType.MediaType))
-                {
-                    writer.WritePropertyName(DataPropertyName);
-                    JsonSerializer.Serialize(writer, cloudEvent.Data, SerializerOptions);
-                }
-                else if (cloudEvent.Data is string text && dataContentType.MediaType.StartsWith("text/"))
-                {
-                    writer.WritePropertyName(DataPropertyName);
-                    writer.WriteStringValue(text);
-                }
-                else
-                {
-                    // We assume CloudEvent.Data is not null due to the way this is called.
-                    throw new ArgumentException($"{nameof(JsonEventFormatter)} cannot serialize data of type {cloudEvent.Data!.GetType()} with content type '{cloudEvent.DataContentType}'");
-                }
-            }
-        }
-
-        /// <inheritdoc />
-        public override ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent)
-        {
-            Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
-
-            if (cloudEvent.Data is null)
-            {
-                return Array.Empty<byte>();
-            }
-            // Binary data is left alone, regardless of the content type.
-            // TODO: Support other forms of binary data, e.g. ReadOnlyMemory<byte>
-            if (cloudEvent.Data is byte[] bytes)
-            {
-                return bytes;
-            }
-            ContentType contentType = new ContentType(cloudEvent.DataContentType ?? JsonMediaType);
-            if (IsJsonMediaType(contentType.MediaType))
-            {
-                var encoding = MimeUtilities.GetEncoding(contentType);
-                if (encoding is UTF8Encoding)
-                {
-                    return JsonSerializer.SerializeToUtf8Bytes(cloudEvent.Data, SerializerOptions);
-                }
-                else
-                {
-                    return MimeUtilities.GetEncoding(contentType).GetBytes(JsonSerializer.Serialize(cloudEvent.Data, SerializerOptions));
-                }
-            }
-            if (contentType.MediaType.StartsWith("text/") && cloudEvent.Data is string text)
-            {
-                return MimeUtilities.GetEncoding(contentType).GetBytes(text);
-            }
-            throw new ArgumentException($"{nameof(JsonEventFormatter)} cannot serialize data of type {cloudEvent.Data.GetType()} with content type '{cloudEvent.DataContentType}'");
-        }
-
-        /// <inheritdoc />
-        public override void DecodeBinaryModeEventData(ReadOnlyMemory<byte> body, CloudEvent cloudEvent)
-        {
-            Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
-
-            ContentType contentType = new ContentType(cloudEvent.DataContentType ?? JsonMediaType);
-
-            Encoding encoding = MimeUtilities.GetEncoding(contentType);
-
-            if (contentType.MediaType == JsonMediaType)
-            {
-                if (body.Length > 0)
-                {
-                    using JsonDocument document = encoding is UTF8Encoding
-                        ? JsonDocument.Parse(body, DocumentOptions)
-                        : JsonDocument.Parse(BinaryDataUtilities.GetString(body, encoding), DocumentOptions);
-                    // We have to clone the data so that we can dispose of the JsonDocument.
-                    cloudEvent.Data = document.RootElement.Clone();
-                }
-                else
-                {
-                    cloudEvent.Data = null;
-                }
-            }
-            else if (contentType.MediaType.StartsWith("text/") == true)
-            {
-                cloudEvent.Data = BinaryDataUtilities.GetString(body, encoding);
-            }
-            else
-            {
-                cloudEvent.Data = body.ToArray();
-            }
-        }
-
-        /// <summary>
-        /// Determines whether the given media type should be handled as JSON.
-        /// The default implementation treats anything ending with "/json" or "+json"
-        /// as JSON.
-        /// </summary>
-        /// <param name="mediaType">The media type to check for JSON. Will not be null.</param>
-        /// <returns>Whether or not <paramref name="mediaType"/> indicates JSON data.</returns>
-        protected virtual bool IsJsonMediaType(string mediaType) => mediaType.EndsWith("/json") || mediaType.EndsWith("+json");
     }
 
     /// <summary>
-    /// CloudEvent formatter implementing the JSON Event Format, but with an expectation that
-    /// any CloudEvent with a data payload can be converted to <typeparamref name="T" /> using
-    /// the <see cref="JsonSerializer"/> associated with the formatter. The content type is ignored.
+    /// Determines whether the given media type should be handled as JSON.
+    /// The default implementation treats anything ending with "/json" or "+json"
+    /// as JSON.
     /// </summary>
-    /// <typeparam name="T">The type of data to serialize and deserialize.</typeparam>
-    public class JsonEventFormatter<T> : JsonEventFormatter
+    /// <param name="mediaType">The media type to check for JSON. Will not be null.</param>
+    /// <returns>Whether or not <paramref name="mediaType"/> indicates JSON data.</returns>
+    protected virtual bool IsJsonMediaType(string mediaType) => mediaType.EndsWith("/json") || mediaType.EndsWith("+json");
+}
+
+/// <summary>
+/// CloudEvent formatter implementing the JSON Event Format, but with an expectation that
+/// any CloudEvent with a data payload can be converted to <typeparamref name="T" /> using
+/// the <see cref="JsonSerializer"/> associated with the formatter. The content type is ignored.
+/// </summary>
+/// <typeparam name="T">The type of data to serialize and deserialize.</typeparam>
+public class JsonEventFormatter<T> : JsonEventFormatter
+{
+    /// <summary>
+    /// Creates a JsonEventFormatter that uses the default <see cref="JsonSerializerOptions"/>
+    /// and <see cref="JsonDocumentOptions"/> for serializing and parsing.
+    /// </summary>
+    public JsonEventFormatter()
     {
-        /// <summary>
-        /// Creates a JsonEventFormatter that uses the default <see cref="JsonSerializerOptions"/>
-        /// and <see cref="JsonDocumentOptions"/> for serializing and parsing.
-        /// </summary>
-        public JsonEventFormatter()
-        {
-        }
-
-        /// <summary>
-        /// Creates a JsonEventFormatter that uses the serializer <see cref="JsonSerializerOptions"/>
-        /// and <see cref="JsonDocumentOptions"/> for serializing and parsing.
-        /// </summary>
-        /// <param name="serializerOptions">The options to use when serializing and parsing. May be null.</param>
-        /// <param name="documentOptions">The options to use when parsing JSON documents.</param>
-        public JsonEventFormatter(JsonSerializerOptions serializerOptions, JsonDocumentOptions documentOptions)
-            : base(serializerOptions, documentOptions)
-        {
-        }
-
-        /// <inheritdoc />
-        public override ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent)
-        {
-            Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
-
-            if (cloudEvent.Data is null)
-            {
-                return Array.Empty<byte>();
-            }
-            T data = (T) cloudEvent.Data;
-            return JsonSerializer.SerializeToUtf8Bytes(data, SerializerOptions);
-        }
-
-        /// <inheritdoc />
-        public override void DecodeBinaryModeEventData(ReadOnlyMemory<byte> body, CloudEvent cloudEvent)
-        {
-            Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
-
-            if (body.Length == 0)
-            {
-                cloudEvent.Data = null;
-                return;
-            }
-            cloudEvent.Data = JsonSerializer.Deserialize<T>(body.Span, SerializerOptions);
-        }
-
-        /// <inheritdoc />
-        protected override void EncodeStructuredModeData(CloudEvent cloudEvent, Utf8JsonWriter writer)
-        {
-            T data = (T) cloudEvent.Data;
-            writer.WritePropertyName(DataPropertyName);
-            JsonSerializer.Serialize(writer, data, SerializerOptions);
-        }
-
-        /// <inheritdoc />
-        protected override void DecodeStructuredModeDataProperty(JsonElement dataElement, CloudEvent cloudEvent) =>
-            // Note: this is an inefficient way of doing this.
-            // See https://github.com/dotnet/runtime/issues/31274 - when that's implemented, we can use the new method here.
-            cloudEvent.Data = JsonSerializer.Deserialize<T>(dataElement.GetRawText(), SerializerOptions);
-
-        // TODO: Consider decoding the base64 data as a byte array, then using DecodeBinaryModeData.
-        /// <inheritdoc />
-        protected override void DecodeStructuredModeDataBase64Property(JsonElement dataBase64Element, CloudEvent cloudEvent) =>
-            throw new ArgumentException($"Data unexpectedly represented using '{DataBase64PropertyName}' within structured mode CloudEvent.");
     }
+
+    /// <summary>
+    /// Creates a JsonEventFormatter that uses the serializer <see cref="JsonSerializerOptions"/>
+    /// and <see cref="JsonDocumentOptions"/> for serializing and parsing.
+    /// </summary>
+    /// <param name="serializerOptions">The options to use when serializing and parsing. May be null.</param>
+    /// <param name="documentOptions">The options to use when parsing JSON documents.</param>
+    public JsonEventFormatter(JsonSerializerOptions serializerOptions, JsonDocumentOptions documentOptions)
+        : base(serializerOptions, documentOptions)
+    {
+    }
+
+    /// <inheritdoc />
+    public override ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent)
+    {
+        Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
+
+        if (cloudEvent.Data is null)
+        {
+            return Array.Empty<byte>();
+        }
+        T data = (T) cloudEvent.Data;
+        return JsonSerializer.SerializeToUtf8Bytes(data, SerializerOptions);
+    }
+
+    /// <inheritdoc />
+    public override void DecodeBinaryModeEventData(ReadOnlyMemory<byte> body, CloudEvent cloudEvent)
+    {
+        Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
+
+        if (body.Length == 0)
+        {
+            cloudEvent.Data = null;
+            return;
+        }
+        cloudEvent.Data = JsonSerializer.Deserialize<T>(body.Span, SerializerOptions);
+    }
+
+    /// <inheritdoc />
+    protected override void EncodeStructuredModeData(CloudEvent cloudEvent, Utf8JsonWriter writer)
+    {
+        T data = (T) cloudEvent.Data!;
+        writer.WritePropertyName(DataPropertyName);
+        JsonSerializer.Serialize(writer, data, SerializerOptions);
+    }
+
+    /// <inheritdoc />
+    protected override void DecodeStructuredModeDataProperty(JsonElement dataElement, CloudEvent cloudEvent) =>
+        // Note: this is an inefficient way of doing this.
+        // See https://github.com/dotnet/runtime/issues/31274 - when that's implemented, we can use the new method here.
+        cloudEvent.Data = JsonSerializer.Deserialize<T>(dataElement.GetRawText(), SerializerOptions);
+
+    // TODO: Consider decoding the base64 data as a byte array, then using DecodeBinaryModeData.
+    /// <inheritdoc />
+    protected override void DecodeStructuredModeDataBase64Property(JsonElement dataBase64Element, CloudEvent cloudEvent) =>
+        throw new ArgumentException($"Data unexpectedly represented using '{DataBase64PropertyName}' within structured mode CloudEvent.");
 }

--- a/src/CloudNative.CloudEvents/CloudEvent.cs
+++ b/src/CloudNative.CloudEvents/CloudEvent.cs
@@ -7,381 +7,380 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace CloudNative.CloudEvents
+namespace CloudNative.CloudEvents;
+
+/// <summary>
+/// Represents a CloudEvent.
+/// </summary>
+public sealed class CloudEvent
 {
+    private readonly Dictionary<string, CloudEventAttribute> extensionAttributes = new Dictionary<string, CloudEventAttribute>();
+
     /// <summary>
-    /// Represents a CloudEvent.
+    /// Values for all attributes other than spec version.
     /// </summary>
-    public sealed class CloudEvent
+    private readonly Dictionary<string, object> attributeValues = new Dictionary<string, object>();
+
+    /// <summary>
+    /// Creates a new instance, using the default <see cref="CloudEventsSpecVersion"/>
+    /// and no initial extension attributes.
+    /// </summary>
+    public CloudEvent() : this(CloudEventsSpecVersion.Default, null)
     {
-        private readonly Dictionary<string, CloudEventAttribute> extensionAttributes = new Dictionary<string, CloudEventAttribute>();
-
-        /// <summary>
-        /// Values for all attributes other than spec version.
-        /// </summary>
-        private readonly Dictionary<string, object> attributeValues = new Dictionary<string, object>();
-
-        /// <summary>
-        /// Creates a new instance, using the default <see cref="CloudEventsSpecVersion"/>
-        /// and no initial extension attributes.
-        /// </summary>
-        public CloudEvent() : this(CloudEventsSpecVersion.Default, null)
-        {
-        }
-
-        /// <summary>
-        /// Creates a new instance, using the specified <see cref="CloudEventsSpecVersion"/>
-        /// and no initial extension attributes.
-        /// </summary>
-        /// <param name="specVersion">CloudEvents Specification version for this instance. Must not be null.</param>
-        public CloudEvent(CloudEventsSpecVersion specVersion) : this(specVersion, null)
-        {
-        }
-
-        /// <summary>
-        /// Creates a new instance, using the default <see cref="CloudEventsSpecVersion"/>
-        /// and the specified initial extension attributes.
-        /// </summary>
-        /// <param name="extensionAttributes">Initial extension attributes. May be null, which is equivalent
-        /// to an empty sequence.</param>
-        public CloudEvent(IEnumerable<CloudEventAttribute>? extensionAttributes) : this(CloudEventsSpecVersion.Default, extensionAttributes)
-        {
-        }
-
-        /// <summary>
-        /// Creates a new instance, using the specified <see cref="CloudEventsSpecVersion"/>
-        /// and the specified initial extension attributes.
-        /// </summary>
-        /// <param name="specVersion">CloudEvents Specification version for this instance. Must not be null.</param>
-        /// <param name="extensionAttributes">Initial extension attributes. May be null, which is equivalent
-        /// to an empty sequence.</param>
-        public CloudEvent(CloudEventsSpecVersion specVersion, IEnumerable<CloudEventAttribute>? extensionAttributes)
-        {
-            // TODO: Work out how to be more efficient, e.g. not creating a dictionary at all if there are no
-            // extension attributes.
-            SpecVersion = Validation.CheckNotNull(specVersion, nameof(specVersion));
-            if (extensionAttributes is object)
-            {
-                foreach (var extension in extensionAttributes)
-                {
-                    Validation.CheckArgument(
-                        extension is object,
-                        nameof(extensionAttributes),
-                        "Extension attribute collection cannot contain null elements");
-                    Validation.CheckArgument(
-                        extension.Name != CloudEventsSpecVersion.SpecVersionAttributeName,
-                        nameof(extensionAttributes),
-                        "The 'specversion' attribute cannot be specified as an extension attribute");
-                    Validation.CheckArgument(
-                        SpecVersion.GetAttributeByName(extension.Name) is null,
-                        nameof(extensionAttributes),
-                        "'{0}' cannot be specified as the name of an extension attribute; it is already a context attribute",
-                        extension.Name);
-                    Validation.CheckArgument(
-                        extension.IsExtension,
-                        nameof(extensionAttributes),
-                        "'{0}' is not an extension attribute",
-                        extension.Name);
-                    Validation.CheckArgument(
-                        !this.extensionAttributes.ContainsKey(extension.Name),
-                        nameof(extensionAttributes),
-                        "'{0}' cannot be specified more than once as an extension attribute");
-                    this.extensionAttributes.Add(extension.Name, extension);
-                }
-            }
-        }
-
-        /// <summary>
-        /// The CloudEvents specification version for this event.
-        /// </summary>
-        public CloudEventsSpecVersion SpecVersion { get; }
-
-        /// <summary>
-        /// Sets or fetches the value associated with the given attribute.
-        /// If the attribute is not known in this event, fetching the value always returns null, and
-        /// setting the value adds the attribute, which must be an extension attribute with a name which is
-        /// not otherwise present known to the event.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// If non-null, the value must be compatible with the type of the attribute. For example, an attempt
-        /// to store a Time context attribute with a string value will fail with an <see cref="ArgumentException"/>.
-        /// </para>
-        /// <para>
-        /// The the value being set is null, any existing value is removed from the event.
-        /// </para>
-        /// <para>
-        /// The indexer cannot be used to access the 'specversion' attribute. Use <see cref="SpecVersion"/>
-        /// for that purpose.
-        /// </para>
-        /// </remarks>
-        /// <param name="attribute">The attribute whose value should be set or fetched.</param>
-        /// <returns>The fetched attribute value, or null if the attribute has no value in this event.</returns>
-        public object? this[CloudEventAttribute attribute]
-        {
-            get
-            {
-                Validation.CheckNotNull(attribute, nameof(attribute));
-                Validation.CheckArgument(attribute.Name != CloudEventsSpecVersion.SpecVersionAttributeName, nameof(attribute), () => Strings.ErrorCannotIndexBySpecVersionAttribute);
-
-                // TODO: Is this validation definitely useful? It does mean we never return something
-                // that's invalid for the attribute, which is potentially good...
-                var value = attributeValues.GetValueOrDefault(attribute.Name);
-                if (value is object)
-                {
-                    attribute.Validate(value);
-                }
-                return value;
-            }
-            set
-            {
-                Validation.CheckNotNull(attribute, nameof(attribute));
-                Validation.CheckArgument(attribute.Name != CloudEventsSpecVersion.SpecVersionAttributeName, nameof(attribute), () => Strings.ErrorCannotIndexBySpecVersionAttribute);
-
-                string name = attribute.Name;
-                var knownAttribute = GetAttribute(name);
-
-                // TODO: Are we happy to add the extension in even if the value is null?
-                Validation.CheckArgument(knownAttribute is object || attribute.IsExtension,
-                    nameof(attribute),
-                    "Cannot add an unknown non-extension attribute to an event.");
-
-                // If the attribute is new, or we previously had an extension attribute, replace it with our new information.
-                // TODO: Alternatively, we could validate that it's got the same type... but what if it has
-                // different validation criteria?
-                if (knownAttribute is null || (knownAttribute.IsExtension && knownAttribute != attribute))
-                {
-                    extensionAttributes[name] = attribute;
-                }
-
-                if (value is null)
-                {
-                    attributeValues.Remove(name);
-                    return;
-                }
-                // TODO: We could convert the attribute value here instead? Or is that a bit too much "magic"?
-                attributeValues[name] = attribute.Validate(value);
-            }
-        }
-
-        /// <summary>
-        /// Sets or fetches the value associated with the given attribute name.
-        /// Setting a value of null removes the value from the event, if it exists.
-        /// If the attribute is not known in this event, fetching the value always returns null, and
-        /// setting the value add a new extension attribute with the given name, and a type of string.
-        /// (The value for an unknown attribute must be a string or null.)
-        /// </summary>
-        /// <remarks>
-        /// The indexer cannot be used to access the 'specversion' attribute. Use <see cref="SpecVersion"/>
-        /// for that purpose.
-        /// </remarks>
-        public object? this[string attributeName]
-        {
-            get
-            {
-                // TODO: Validate the attribute name is valid (e.g. not upper case)? Seems overkill.
-                Validation.CheckNotNull(attributeName, nameof(attributeName));
-                Validation.CheckArgument(attributeName != CloudEventsSpecVersion.SpecVersionAttributeName, nameof(attributeName), () => Strings.ErrorCannotIndexBySpecVersionAttribute);
-                return attributeValues.GetValueOrDefault(Validation.CheckNotNull(attributeName, nameof(attributeName)));
-            }
-            set
-            {
-                Validation.CheckNotNull(attributeName, nameof(attributeName));
-                Validation.CheckArgument(attributeName != CloudEventsSpecVersion.SpecVersionAttributeName, nameof(attributeName), () => Strings.ErrorCannotIndexBySpecVersionAttribute);
-
-                var knownAttribute = GetAttribute(attributeName);
-
-                // TODO: Are we happy to add the extension in even if the value is null?
-                // (It's a simple way of populating extensions after the fact...)
-                if (knownAttribute is null)
-                {
-                    Validation.CheckArgument(value is null || value is string,
-                        nameof(value), "Cannot assign value of type {0} to unknown attribute '{1}'",
-                        value?.GetType(), attributeName);
-                    knownAttribute = CloudEventAttribute.CreateExtension(attributeName, CloudEventAttributeType.String);
-                    extensionAttributes[attributeName] = knownAttribute;
-                }
-
-                if (value is null)
-                {
-                    attributeValues.Remove(attributeName);
-                    return;
-                }
-                // TODO: We could convert the attribute value here instead? Or is that a bit too much "magic"?
-                attributeValues[attributeName] = knownAttribute.Validate(value);
-            }
-        }
-
-        /// <summary>
-        /// CloudEvent 'data' content.  The event payload. The payload depends on the type
-        /// and the 'schemaurl'. It is encoded into a media format which is specified by the
-        /// 'contenttype' attribute (e.g. application/json).
-        /// </summary>
-        /// <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#event-data"/>
-        public object? Data { get; set; }
-
-        /// <summary>
-        /// CloudEvent <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#datacontenttype">'datacontenttype'</see> attribute.
-        /// This is the content type of the <see cref="Data"/> property.
-        /// This attribute enables the data attribute to carry any type of content, where the
-        /// format and encoding might differ from that of the chosen event format.
-        /// </summary>
-        public string? DataContentType
-        {
-            // TODO: Guard against a version that doesn't have this attribute?
-            get => (string?) this[SpecVersion.DataContentTypeAttribute];
-            set => this[SpecVersion.DataContentTypeAttribute] = value;
-        }
-
-        /// <summary>
-        /// CloudEvent <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#id">'id'</see> attribute,
-        /// This is the ID of the event. When combined with <see cref="Source"/>, this enables deduplication.
-        /// </summary>
-        public string? Id
-        {
-            get => (string?) this[SpecVersion.IdAttribute];
-            set => this[SpecVersion.IdAttribute] = value;
-        }
-
-        /// <summary>
-        /// CloudEvents <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#dataschema">'dataschema'</see> attribute.
-        /// A link to the schema that the data attribute adheres to.
-        /// Incompatible changes to the schema SHOULD be reflected by a different URI.
-        /// </summary>
-        public Uri? DataSchema
-        {
-            get => (Uri?) this[SpecVersion.DataSchemaAttribute];
-            set => this[SpecVersion.DataSchemaAttribute] = value;
-        }
-
-        /// <summary>
-        /// CloudEvents <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#source">'source'</see> attribute.
-        /// This describes the event producer. Often this will include information such as the type of the event source, the
-        /// organization publishing the event, the process that produced the event, and some unique identifiers.
-        /// When combined with <see cref="Id"/>, this enables deduplication.
-        /// </summary>
-        public Uri? Source
-        {
-            get => (Uri?) this[SpecVersion.SourceAttribute];
-            set => this[SpecVersion.SourceAttribute] = value;
-        }
-
-        // TODO: Consider exposing publicly.
-        // TODO: Reimplement when we have other versions to support.
-        // internal CloudEvent WithSpecVersion(CloudEventsSpecVersion newSpecVersion) =>
-        //    new CloudEvent(attributes.WithSpecVersion(newSpecVersion), Extensions.Values);
-
-        /// <summary>
-        /// CloudEvents <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#subject">'subject'</see> attribute.
-        /// This describes the subject of the event in the context of the event producer (identified by <see cref="Source"/>).
-        /// In publish-subscribe scenarios, a subscriber will typically subscribe to events emitted by a source,
-        /// but the source identifier alone might not be sufficient as a qualifier for any specific event if the source context has
-        /// internal sub-structure.
-        /// </summary>
-        public string? Subject
-        {
-            get => (string?) this[SpecVersion.SubjectAttribute];
-            set => this[SpecVersion.SubjectAttribute] = value;
-        }
-
-        /// <summary>
-        /// CloudEvents <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#time">'time'</see> attribute.
-        /// Timestamp of when the occurrence happened.
-        /// </summary>
-        public DateTimeOffset? Time
-        {
-            get => (DateTimeOffset?) this[SpecVersion.TimeAttribute];
-            set => this[SpecVersion.TimeAttribute] = value;
-        }
-
-        /// <summary>
-        /// CloudEvents <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#type">'type'</see> attribute.
-        /// Type of occurrence which has happened.
-        /// Often this attribute is used for routing, observability, policy enforcement, etc.
-        /// </summary>
-        public string? Type
-        {
-            get => (string?) this[SpecVersion.TypeAttribute];
-            set => this[SpecVersion.TypeAttribute] = value;
-        }
-
-        /// <summary>
-        /// Returns the attribute with the given name, which may be a standard
-        /// context attribute or an extension. Note that this returns the attribute
-        /// definition, not the value of the attribute.
-        /// </summary>
-        /// <param name="name">The attribute name to look up.</param>
-        /// <returns>The attribute with the given name, or null if no this event
-        /// does not know of such an attribute.</returns>
-        public CloudEventAttribute? GetAttribute(string name) =>
-            SpecVersion.GetAttributeByName(name) ?? extensionAttributes.GetValueOrDefault(name);
-
-        /// <summary>
-        /// Returns the extension attributes known to this event, regardless of whether or not
-        /// they're populated. Currently the order in which the attributes is returned is not guaranteed.
-        /// </summary>
-        public IEnumerable<CloudEventAttribute> ExtensionAttributes => extensionAttributes.Values;
-
-        /// <summary>
-        /// Returns a sequence of attributes and their values, for values which are populated in this event.
-        /// This does not include the CloudEvents spec version attribute.
-        /// Currently the order in which the attributes is returned is not guaranteed.
-        /// </summary>
-        public IEnumerable<KeyValuePair<CloudEventAttribute, object>> GetPopulatedAttributes()
-        {
-            foreach (var pair in attributeValues)
-            {
-                yield return new KeyValuePair<CloudEventAttribute, object>(GetAttribute(pair.Key)!, pair.Value);
-            }
-        }
-
-        /// <summary>
-        /// Sets the value for the attribute with the given name, based on its string value which is
-        /// expected to be the CloudEvents canonical representation of the value.
-        /// The value will be parsed and converted for non-string attributes. Unknown attributes are
-        /// assumed to be string-values extension attributes.
-        /// </summary>
-        /// <param name="name">The name of the attribute to set. Must not be null.</param>
-        /// <param name="value">The value of the attribute to set. Must not be null.</param>
-        public void SetAttributeFromString(string name, string value)
-        {
-            Validation.CheckNotNull(name, nameof(name));
-            Validation.CheckNotNull(value, nameof(value));
-
-            var attribute = GetAttribute(name);
-            if (attribute is null)
-            {
-                // Populate a new extension attribute with the value.
-                this[name] = value;
-            }
-            else
-            {
-                // Perform any string to value parsing and validating required.
-                this[attribute] = attribute.Parse(value);
-            }
-        }
-
-        /// <summary>
-        /// Validates that this CloudEvent is valid in the same way as <see cref="IsValid"/>,
-        /// but throwing an <see cref="InvalidOperationException"/> if the event is invalid.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">The event is invalid.</exception>
-        /// <returns>A reference to the same object, for simplicity of method chaining.</returns>
-        public CloudEvent Validate()
-        {
-            if (IsValid)
-            {
-                return this;
-            }
-            var missing = SpecVersion.RequiredAttributes.Where(attr => this[attr] is null).ToList();
-            string joinedMissing = string.Join(", ", missing);
-            throw new InvalidOperationException($"Missing required attributes: {joinedMissing}");
-        }
-
-        /// <summary>
-        /// Returns whether this CloudEvent is valid, i.e. whether all required attributes have
-        /// values.
-        /// </summary>
-        public bool IsValid => SpecVersion.RequiredAttributes.All(attr => this[attr] is object);
     }
+
+    /// <summary>
+    /// Creates a new instance, using the specified <see cref="CloudEventsSpecVersion"/>
+    /// and no initial extension attributes.
+    /// </summary>
+    /// <param name="specVersion">CloudEvents Specification version for this instance. Must not be null.</param>
+    public CloudEvent(CloudEventsSpecVersion specVersion) : this(specVersion, null)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance, using the default <see cref="CloudEventsSpecVersion"/>
+    /// and the specified initial extension attributes.
+    /// </summary>
+    /// <param name="extensionAttributes">Initial extension attributes. May be null, which is equivalent
+    /// to an empty sequence.</param>
+    public CloudEvent(IEnumerable<CloudEventAttribute>? extensionAttributes) : this(CloudEventsSpecVersion.Default, extensionAttributes)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance, using the specified <see cref="CloudEventsSpecVersion"/>
+    /// and the specified initial extension attributes.
+    /// </summary>
+    /// <param name="specVersion">CloudEvents Specification version for this instance. Must not be null.</param>
+    /// <param name="extensionAttributes">Initial extension attributes. May be null, which is equivalent
+    /// to an empty sequence.</param>
+    public CloudEvent(CloudEventsSpecVersion specVersion, IEnumerable<CloudEventAttribute>? extensionAttributes)
+    {
+        // TODO: Work out how to be more efficient, e.g. not creating a dictionary at all if there are no
+        // extension attributes.
+        SpecVersion = Validation.CheckNotNull(specVersion, nameof(specVersion));
+        if (extensionAttributes is object)
+        {
+            foreach (var extension in extensionAttributes)
+            {
+                Validation.CheckArgument(
+                    extension is object,
+                    nameof(extensionAttributes),
+                    "Extension attribute collection cannot contain null elements");
+                Validation.CheckArgument(
+                    extension.Name != CloudEventsSpecVersion.SpecVersionAttributeName,
+                    nameof(extensionAttributes),
+                    "The 'specversion' attribute cannot be specified as an extension attribute");
+                Validation.CheckArgument(
+                    SpecVersion.GetAttributeByName(extension.Name) is null,
+                    nameof(extensionAttributes),
+                    "'{0}' cannot be specified as the name of an extension attribute; it is already a context attribute",
+                    extension.Name);
+                Validation.CheckArgument(
+                    extension.IsExtension,
+                    nameof(extensionAttributes),
+                    "'{0}' is not an extension attribute",
+                    extension.Name);
+                Validation.CheckArgument(
+                    !this.extensionAttributes.ContainsKey(extension.Name),
+                    nameof(extensionAttributes),
+                    "'{0}' cannot be specified more than once as an extension attribute");
+                this.extensionAttributes.Add(extension.Name, extension);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The CloudEvents specification version for this event.
+    /// </summary>
+    public CloudEventsSpecVersion SpecVersion { get; }
+
+    /// <summary>
+    /// Sets or fetches the value associated with the given attribute.
+    /// If the attribute is not known in this event, fetching the value always returns null, and
+    /// setting the value adds the attribute, which must be an extension attribute with a name which is
+    /// not otherwise present known to the event.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If non-null, the value must be compatible with the type of the attribute. For example, an attempt
+    /// to store a Time context attribute with a string value will fail with an <see cref="ArgumentException"/>.
+    /// </para>
+    /// <para>
+    /// The the value being set is null, any existing value is removed from the event.
+    /// </para>
+    /// <para>
+    /// The indexer cannot be used to access the 'specversion' attribute. Use <see cref="SpecVersion"/>
+    /// for that purpose.
+    /// </para>
+    /// </remarks>
+    /// <param name="attribute">The attribute whose value should be set or fetched.</param>
+    /// <returns>The fetched attribute value, or null if the attribute has no value in this event.</returns>
+    public object? this[CloudEventAttribute attribute]
+    {
+        get
+        {
+            Validation.CheckNotNull(attribute, nameof(attribute));
+            Validation.CheckArgument(attribute.Name != CloudEventsSpecVersion.SpecVersionAttributeName, nameof(attribute), () => Strings.ErrorCannotIndexBySpecVersionAttribute);
+
+            // TODO: Is this validation definitely useful? It does mean we never return something
+            // that's invalid for the attribute, which is potentially good...
+            var value = attributeValues.GetValueOrDefault(attribute.Name);
+            if (value is object)
+            {
+                attribute.Validate(value);
+            }
+            return value;
+        }
+        set
+        {
+            Validation.CheckNotNull(attribute, nameof(attribute));
+            Validation.CheckArgument(attribute.Name != CloudEventsSpecVersion.SpecVersionAttributeName, nameof(attribute), () => Strings.ErrorCannotIndexBySpecVersionAttribute);
+
+            string name = attribute.Name;
+            var knownAttribute = GetAttribute(name);
+
+            // TODO: Are we happy to add the extension in even if the value is null?
+            Validation.CheckArgument(knownAttribute is object || attribute.IsExtension,
+                nameof(attribute),
+                "Cannot add an unknown non-extension attribute to an event.");
+
+            // If the attribute is new, or we previously had an extension attribute, replace it with our new information.
+            // TODO: Alternatively, we could validate that it's got the same type... but what if it has
+            // different validation criteria?
+            if (knownAttribute is null || (knownAttribute.IsExtension && knownAttribute != attribute))
+            {
+                extensionAttributes[name] = attribute;
+            }
+
+            if (value is null)
+            {
+                attributeValues.Remove(name);
+                return;
+            }
+            // TODO: We could convert the attribute value here instead? Or is that a bit too much "magic"?
+            attributeValues[name] = attribute.Validate(value);
+        }
+    }
+
+    /// <summary>
+    /// Sets or fetches the value associated with the given attribute name.
+    /// Setting a value of null removes the value from the event, if it exists.
+    /// If the attribute is not known in this event, fetching the value always returns null, and
+    /// setting the value add a new extension attribute with the given name, and a type of string.
+    /// (The value for an unknown attribute must be a string or null.)
+    /// </summary>
+    /// <remarks>
+    /// The indexer cannot be used to access the 'specversion' attribute. Use <see cref="SpecVersion"/>
+    /// for that purpose.
+    /// </remarks>
+    public object? this[string attributeName]
+    {
+        get
+        {
+            // TODO: Validate the attribute name is valid (e.g. not upper case)? Seems overkill.
+            Validation.CheckNotNull(attributeName, nameof(attributeName));
+            Validation.CheckArgument(attributeName != CloudEventsSpecVersion.SpecVersionAttributeName, nameof(attributeName), () => Strings.ErrorCannotIndexBySpecVersionAttribute);
+            return attributeValues.GetValueOrDefault(Validation.CheckNotNull(attributeName, nameof(attributeName)));
+        }
+        set
+        {
+            Validation.CheckNotNull(attributeName, nameof(attributeName));
+            Validation.CheckArgument(attributeName != CloudEventsSpecVersion.SpecVersionAttributeName, nameof(attributeName), () => Strings.ErrorCannotIndexBySpecVersionAttribute);
+
+            var knownAttribute = GetAttribute(attributeName);
+
+            // TODO: Are we happy to add the extension in even if the value is null?
+            // (It's a simple way of populating extensions after the fact...)
+            if (knownAttribute is null)
+            {
+                Validation.CheckArgument(value is null || value is string,
+                    nameof(value), "Cannot assign value of type {0} to unknown attribute '{1}'",
+                    value?.GetType(), attributeName);
+                knownAttribute = CloudEventAttribute.CreateExtension(attributeName, CloudEventAttributeType.String);
+                extensionAttributes[attributeName] = knownAttribute;
+            }
+
+            if (value is null)
+            {
+                attributeValues.Remove(attributeName);
+                return;
+            }
+            // TODO: We could convert the attribute value here instead? Or is that a bit too much "magic"?
+            attributeValues[attributeName] = knownAttribute.Validate(value);
+        }
+    }
+
+    /// <summary>
+    /// CloudEvent 'data' content.  The event payload. The payload depends on the type
+    /// and the 'schemaurl'. It is encoded into a media format which is specified by the
+    /// 'contenttype' attribute (e.g. application/json).
+    /// </summary>
+    /// <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#event-data"/>
+    public object? Data { get; set; }
+
+    /// <summary>
+    /// CloudEvent <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#datacontenttype">'datacontenttype'</see> attribute.
+    /// This is the content type of the <see cref="Data"/> property.
+    /// This attribute enables the data attribute to carry any type of content, where the
+    /// format and encoding might differ from that of the chosen event format.
+    /// </summary>
+    public string? DataContentType
+    {
+        // TODO: Guard against a version that doesn't have this attribute?
+        get => (string?) this[SpecVersion.DataContentTypeAttribute];
+        set => this[SpecVersion.DataContentTypeAttribute] = value;
+    }
+
+    /// <summary>
+    /// CloudEvent <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#id">'id'</see> attribute,
+    /// This is the ID of the event. When combined with <see cref="Source"/>, this enables deduplication.
+    /// </summary>
+    public string? Id
+    {
+        get => (string?) this[SpecVersion.IdAttribute];
+        set => this[SpecVersion.IdAttribute] = value;
+    }
+
+    /// <summary>
+    /// CloudEvents <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#dataschema">'dataschema'</see> attribute.
+    /// A link to the schema that the data attribute adheres to.
+    /// Incompatible changes to the schema SHOULD be reflected by a different URI.
+    /// </summary>
+    public Uri? DataSchema
+    {
+        get => (Uri?) this[SpecVersion.DataSchemaAttribute];
+        set => this[SpecVersion.DataSchemaAttribute] = value;
+    }
+
+    /// <summary>
+    /// CloudEvents <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#source">'source'</see> attribute.
+    /// This describes the event producer. Often this will include information such as the type of the event source, the
+    /// organization publishing the event, the process that produced the event, and some unique identifiers.
+    /// When combined with <see cref="Id"/>, this enables deduplication.
+    /// </summary>
+    public Uri? Source
+    {
+        get => (Uri?) this[SpecVersion.SourceAttribute];
+        set => this[SpecVersion.SourceAttribute] = value;
+    }
+
+    // TODO: Consider exposing publicly.
+    // TODO: Reimplement when we have other versions to support.
+    // internal CloudEvent WithSpecVersion(CloudEventsSpecVersion newSpecVersion) =>
+    //    new CloudEvent(attributes.WithSpecVersion(newSpecVersion), Extensions.Values);
+
+    /// <summary>
+    /// CloudEvents <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#subject">'subject'</see> attribute.
+    /// This describes the subject of the event in the context of the event producer (identified by <see cref="Source"/>).
+    /// In publish-subscribe scenarios, a subscriber will typically subscribe to events emitted by a source,
+    /// but the source identifier alone might not be sufficient as a qualifier for any specific event if the source context has
+    /// internal sub-structure.
+    /// </summary>
+    public string? Subject
+    {
+        get => (string?) this[SpecVersion.SubjectAttribute];
+        set => this[SpecVersion.SubjectAttribute] = value;
+    }
+
+    /// <summary>
+    /// CloudEvents <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#time">'time'</see> attribute.
+    /// Timestamp of when the occurrence happened.
+    /// </summary>
+    public DateTimeOffset? Time
+    {
+        get => (DateTimeOffset?) this[SpecVersion.TimeAttribute];
+        set => this[SpecVersion.TimeAttribute] = value;
+    }
+
+    /// <summary>
+    /// CloudEvents <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#type">'type'</see> attribute.
+    /// Type of occurrence which has happened.
+    /// Often this attribute is used for routing, observability, policy enforcement, etc.
+    /// </summary>
+    public string? Type
+    {
+        get => (string?) this[SpecVersion.TypeAttribute];
+        set => this[SpecVersion.TypeAttribute] = value;
+    }
+
+    /// <summary>
+    /// Returns the attribute with the given name, which may be a standard
+    /// context attribute or an extension. Note that this returns the attribute
+    /// definition, not the value of the attribute.
+    /// </summary>
+    /// <param name="name">The attribute name to look up.</param>
+    /// <returns>The attribute with the given name, or null if no this event
+    /// does not know of such an attribute.</returns>
+    public CloudEventAttribute? GetAttribute(string name) =>
+        SpecVersion.GetAttributeByName(name) ?? extensionAttributes.GetValueOrDefault(name);
+
+    /// <summary>
+    /// Returns the extension attributes known to this event, regardless of whether or not
+    /// they're populated. Currently the order in which the attributes is returned is not guaranteed.
+    /// </summary>
+    public IEnumerable<CloudEventAttribute> ExtensionAttributes => extensionAttributes.Values;
+
+    /// <summary>
+    /// Returns a sequence of attributes and their values, for values which are populated in this event.
+    /// This does not include the CloudEvents spec version attribute.
+    /// Currently the order in which the attributes is returned is not guaranteed.
+    /// </summary>
+    public IEnumerable<KeyValuePair<CloudEventAttribute, object>> GetPopulatedAttributes()
+    {
+        foreach (var pair in attributeValues)
+        {
+            yield return new KeyValuePair<CloudEventAttribute, object>(GetAttribute(pair.Key)!, pair.Value);
+        }
+    }
+
+    /// <summary>
+    /// Sets the value for the attribute with the given name, based on its string value which is
+    /// expected to be the CloudEvents canonical representation of the value.
+    /// The value will be parsed and converted for non-string attributes. Unknown attributes are
+    /// assumed to be string-values extension attributes.
+    /// </summary>
+    /// <param name="name">The name of the attribute to set. Must not be null.</param>
+    /// <param name="value">The value of the attribute to set. Must not be null.</param>
+    public void SetAttributeFromString(string name, string value)
+    {
+        Validation.CheckNotNull(name, nameof(name));
+        Validation.CheckNotNull(value, nameof(value));
+
+        var attribute = GetAttribute(name);
+        if (attribute is null)
+        {
+            // Populate a new extension attribute with the value.
+            this[name] = value;
+        }
+        else
+        {
+            // Perform any string to value parsing and validating required.
+            this[attribute] = attribute.Parse(value);
+        }
+    }
+
+    /// <summary>
+    /// Validates that this CloudEvent is valid in the same way as <see cref="IsValid"/>,
+    /// but throwing an <see cref="InvalidOperationException"/> if the event is invalid.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The event is invalid.</exception>
+    /// <returns>A reference to the same object, for simplicity of method chaining.</returns>
+    public CloudEvent Validate()
+    {
+        if (IsValid)
+        {
+            return this;
+        }
+        var missing = SpecVersion.RequiredAttributes.Where(attr => this[attr] is null).ToList();
+        string joinedMissing = string.Join(", ", missing);
+        throw new InvalidOperationException($"Missing required attributes: {joinedMissing}");
+    }
+
+    /// <summary>
+    /// Returns whether this CloudEvent is valid, i.e. whether all required attributes have
+    /// values.
+    /// </summary>
+    public bool IsValid => SpecVersion.RequiredAttributes.All(attr => this[attr] is object);
 }

--- a/src/CloudNative.CloudEvents/CloudEventAttribute.cs
+++ b/src/CloudNative.CloudEvents/CloudEventAttribute.cs
@@ -6,175 +6,174 @@ using CloudNative.CloudEvents.Core;
 using System;
 using System.Collections.Generic;
 
-namespace CloudNative.CloudEvents
+namespace CloudNative.CloudEvents;
+
+/// <summary>
+/// An attribute that can be associated with a <see cref="CloudEvent"/>.
+/// This may be a context attribute or an extension attribute.
+/// This class represents the abstract concept of an attribute, rather than
+/// an attribute value.
+/// </summary>
+public class CloudEventAttribute
 {
-    /// <summary>
-    /// An attribute that can be associated with a <see cref="CloudEvent"/>.
-    /// This may be a context attribute or an extension attribute.
-    /// This class represents the abstract concept of an attribute, rather than
-    /// an attribute value.
-    /// </summary>
-    public class CloudEventAttribute
-    {
-        private static readonly IList<string> ReservedNames = new List<string>
+    private static readonly IList<string> ReservedNames = new List<string>
         {
             CloudEventsSpecVersion.SpecVersionAttributeName,
             "data"
         };
 
-        /// <summary>
-        /// The type of the attribute. All values provided must be compatible with this.
-        /// </summary>
-        public CloudEventAttributeType Type { get; }
+    /// <summary>
+    /// The type of the attribute. All values provided must be compatible with this.
+    /// </summary>
+    public CloudEventAttributeType Type { get; }
 
-        /// <summary>
-        /// The name of the attribute. Instances of this class associated with different
-        /// versions of the specification may use different names for the same concept.
-        /// </summary>
-        public string Name { get; }
+    /// <summary>
+    /// The name of the attribute. Instances of this class associated with different
+    /// versions of the specification may use different names for the same concept.
+    /// </summary>
+    public string Name { get; }
 
-        /// <summary>
-        /// Indicates whether this attribute is a required attribute.
-        /// Extension attributes are never required.
-        /// </summary>
-        public bool IsRequired { get; }
+    /// <summary>
+    /// Indicates whether this attribute is a required attribute.
+    /// Extension attributes are never required.
+    /// </summary>
+    public bool IsRequired { get; }
 
-        /// <summary>
-        /// Indicates whether this attribute is an extension attribute.
-        /// </summary>
-        public bool IsExtension { get; }
+    /// <summary>
+    /// Indicates whether this attribute is an extension attribute.
+    /// </summary>
+    public bool IsExtension { get; }
 
-        private readonly Action<object>? validator;
+    private readonly Action<object>? validator;
 
-        // TODO: Have a "mode" of Required/Optional/Extension?
+    // TODO: Have a "mode" of Required/Optional/Extension?
 
-        private CloudEventAttribute(string name, CloudEventAttributeType type, bool required, bool extension, Action<object>? validator) =>
-            (Name, Type, IsRequired, IsExtension, this.validator) = (ValidateName(name), Validation.CheckNotNull(type, nameof(type)), required, extension, validator);
+    private CloudEventAttribute(string name, CloudEventAttributeType type, bool required, bool extension, Action<object>? validator) =>
+        (Name, Type, IsRequired, IsExtension, this.validator) = (ValidateName(name), Validation.CheckNotNull(type, nameof(type)), required, extension, validator);
 
-        internal static CloudEventAttribute CreateRequired(string name, CloudEventAttributeType type, Action<object>? validator) =>
-            new CloudEventAttribute(name, type, required: true, extension: false, validator: validator);
+    internal static CloudEventAttribute CreateRequired(string name, CloudEventAttributeType type, Action<object>? validator) =>
+        new CloudEventAttribute(name, type, required: true, extension: false, validator: validator);
 
-        internal static CloudEventAttribute CreateOptional(string name, CloudEventAttributeType type, Action<object>? validator) =>
-            new CloudEventAttribute(name, type, required: false, extension: false, validator: validator);
+    internal static CloudEventAttribute CreateOptional(string name, CloudEventAttributeType type, Action<object>? validator) =>
+        new CloudEventAttribute(name, type, required: false, extension: false, validator: validator);
 
-        /// <summary>
-        /// Creates an extension attribute with the given name and type.
-        /// </summary>
-        /// <param name="name">The extension attribute name. Must not be null, and must not be 'specversion'.</param>
-        /// <param name="type">The extension attribute type. Must not be null.</param>
-        /// <returns>The extension attribute represented as a <see cref="CloudEventAttribute"/>.</returns>
-        public static CloudEventAttribute CreateExtension(string name, CloudEventAttributeType type)
+    /// <summary>
+    /// Creates an extension attribute with the given name and type.
+    /// </summary>
+    /// <param name="name">The extension attribute name. Must not be null, and must not be 'specversion'.</param>
+    /// <param name="type">The extension attribute type. Must not be null.</param>
+    /// <returns>The extension attribute represented as a <see cref="CloudEventAttribute"/>.</returns>
+    public static CloudEventAttribute CreateExtension(string name, CloudEventAttributeType type)
+    {
+        Validation.CheckNotNull(name, nameof(name));
+        Validation.CheckNotNull(type, nameof(type));
+        if (ReservedNames.Contains(name))
         {
-            Validation.CheckNotNull(name, nameof(name));
-            Validation.CheckNotNull(type, nameof(type));
-            if (ReservedNames.Contains(name))
-            {
-                throw new ArgumentException($"The attribute name '{name}' is reserved and cannot be used for an extension attribute.");
-            }
-            return new CloudEventAttribute(name, type, required: false, extension: true, validator: null);
+            throw new ArgumentException($"The attribute name '{name}' is reserved and cannot be used for an extension attribute.");
         }
+        return new CloudEventAttribute(name, type, required: false, extension: true, validator: null);
+    }
 
-        /// <summary>
-        /// Creates an extension attribute with a custom validator.
-        /// </summary>
-        /// <param name="name">The extension attribute name. Must not be null, and must not be 'specversion'.</param>
-        /// <param name="type">The extension attribute type. Must not be null.</param>
-        /// <param name="validator">Validator to use when parsing or formatting values. May be null.
-        /// This delegate is only ever called with a non-null value which can be cast to the attribute type's corresponding
-        /// CLR type. If the validator throws any exception, it is wrapped in an ArgumentException containing the
-        /// attribute details.</param>
-        /// <returns>The extension attribute represented as a <see cref="CloudEventAttribute"/>.</returns>
-        public static CloudEventAttribute CreateExtension(string name, CloudEventAttributeType type, Action<object>? validator) =>
-            new CloudEventAttribute(name, type, required: false, extension: true, validator: validator);
+    /// <summary>
+    /// Creates an extension attribute with a custom validator.
+    /// </summary>
+    /// <param name="name">The extension attribute name. Must not be null, and must not be 'specversion'.</param>
+    /// <param name="type">The extension attribute type. Must not be null.</param>
+    /// <param name="validator">Validator to use when parsing or formatting values. May be null.
+    /// This delegate is only ever called with a non-null value which can be cast to the attribute type's corresponding
+    /// CLR type. If the validator throws any exception, it is wrapped in an ArgumentException containing the
+    /// attribute details.</param>
+    /// <returns>The extension attribute represented as a <see cref="CloudEventAttribute"/>.</returns>
+    public static CloudEventAttribute CreateExtension(string name, CloudEventAttributeType type, Action<object>? validator) =>
+        new CloudEventAttribute(name, type, required: false, extension: true, validator: validator);
 
-        /// <summary>
-        /// Returns the name of the attribute.
-        /// </summary>
-        /// <returns>The name of the attribute.</returns>
-        public override string ToString() => Name;
+    /// <summary>
+    /// Returns the name of the attribute.
+    /// </summary>
+    /// <returns>The name of the attribute.</returns>
+    public override string ToString() => Name;
 
-        /// <summary>
-        /// Validates that the given name is valid for an attribute. It must be non-empty,
-        /// and consist entirely of lower-case ASCII letters or digits. While the specification recommends
-        /// that attribute names should be at most 20 characters long, this method does not validate that.
-        /// </summary>
-        /// <param name="name">The name to validate.</param>
-        /// <exception cref="ArgumentException"><paramref name="name"/> is not a valid argument name.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="name"/> is null.</exception>
-        /// <returns><paramref name="name"/>, for convenience.</returns>
-        private static string ValidateName(string name)
+    /// <summary>
+    /// Validates that the given name is valid for an attribute. It must be non-empty,
+    /// and consist entirely of lower-case ASCII letters or digits. While the specification recommends
+    /// that attribute names should be at most 20 characters long, this method does not validate that.
+    /// </summary>
+    /// <param name="name">The name to validate.</param>
+    /// <exception cref="ArgumentException"><paramref name="name"/> is not a valid argument name.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is null.</exception>
+    /// <returns><paramref name="name"/>, for convenience.</returns>
+    private static string ValidateName(string name)
+    {
+        Validation.CheckNotNull(name, nameof(name));
+        if (name.Length == 0)
         {
-            Validation.CheckNotNull(name, nameof(name));
-            if (name.Length == 0)
-            {
-                throw new ArgumentException("Attribute names must be non-empty", nameof(name));
-            }
-            for (int i = 0; i < name.Length; i++)
-            {
-                char c = name[i];
-                bool valid = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z');
-                if (!valid)
-                {
-                    throw new ArgumentException($"Invalid character '{c}' in attribute name '{name}'", nameof(name));
-                }
-            }
-            return name;
+            throw new ArgumentException("Attribute names must be non-empty", nameof(name));
         }
-
-        /// <summary>
-        /// Parses the given string representation of an attribute value into a suitable CLR representation.
-        /// </summary>
-        /// <param name="text">The text representation to parse. Must not be null, and must be a valid value for this attribute.</param>
-        /// <returns>The CLR representation of the given textual value for this attribute.</returns>
-        public object Parse(string text)
+        for (int i = 0; i < name.Length; i++)
         {
-            Validation.CheckNotNull(text, nameof(text));
-            object value;
-            // By wrapping every exception here, we always get an
-            // ArgumentException (other than the ArgumentNullException above) and have the name in the message.
-            try
+            char c = name[i];
+            bool valid = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z');
+            if (!valid)
             {
-                value = Type.Parse(text);
+                throw new ArgumentException($"Invalid character '{c}' in attribute name '{name}'", nameof(name));
             }
-            catch (Exception e)
-            {
-                throw new ArgumentException($"Text for attribute '{Name}' is invalid: {e.Message}", nameof(value), e);
-            }
-            return Validate(value);
         }
+        return name;
+    }
 
-        /// <summary>
-        /// Formats the given value for this attribute as a string.
-        /// </summary>
-        /// <param name="value">The value to format. Must not be null, and must be a suitable value for this attribute.</param>
-        /// <returns>The string representation of this attribute.</returns>
-        public string Format(object value) => Type.Format(Validate(value));
-
-        /// <summary>
-        /// Validates that the given value is appropriate for this attribute.
-        /// </summary>
-        /// <param name="value">The value to validate.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
-        /// <exception cref="ArgumentException"><paramref name="value"/> is invalid for this attribute.</exception>
-        /// <returns>The value, for simple method chaining.</returns>
-        public object Validate(object value)
+    /// <summary>
+    /// Parses the given string representation of an attribute value into a suitable CLR representation.
+    /// </summary>
+    /// <param name="text">The text representation to parse. Must not be null, and must be a valid value for this attribute.</param>
+    /// <returns>The CLR representation of the given textual value for this attribute.</returns>
+    public object Parse(string text)
+    {
+        Validation.CheckNotNull(text, nameof(text));
+        object value;
+        // By wrapping every exception here, we always get an
+        // ArgumentException (other than the ArgumentNullException above) and have the name in the message.
+        try
         {
-            Validation.CheckNotNull(value, nameof(value));
-            // By wrapping every exception, whether from the type or the custom validator, we always get an
-            // ArgumentException (other than the ArgumentNullException above) and have the name in the message.
-            try
-            {
-                Type.Validate(value);
-                if (validator is object)
-                {
-                    validator(value);
-                }
-            }
-            catch (Exception e)
-            {
-                throw new ArgumentException($"Value for attribute '{Name}' is invalid: {e.Message}", nameof(value), e);
-            }
-            return value;
+            value = Type.Parse(text);
         }
+        catch (Exception e)
+        {
+            throw new ArgumentException($"Text for attribute '{Name}' is invalid: {e.Message}", nameof(value), e);
+        }
+        return Validate(value);
+    }
+
+    /// <summary>
+    /// Formats the given value for this attribute as a string.
+    /// </summary>
+    /// <param name="value">The value to format. Must not be null, and must be a suitable value for this attribute.</param>
+    /// <returns>The string representation of this attribute.</returns>
+    public string Format(object value) => Type.Format(Validate(value));
+
+    /// <summary>
+    /// Validates that the given value is appropriate for this attribute.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="value"/> is invalid for this attribute.</exception>
+    /// <returns>The value, for simple method chaining.</returns>
+    public object Validate(object value)
+    {
+        Validation.CheckNotNull(value, nameof(value));
+        // By wrapping every exception, whether from the type or the custom validator, we always get an
+        // ArgumentException (other than the ArgumentNullException above) and have the name in the message.
+        try
+        {
+            Type.Validate(value);
+            if (validator is object)
+            {
+                validator(value);
+            }
+        }
+        catch (Exception e)
+        {
+            throw new ArgumentException($"Value for attribute '{Name}' is invalid: {e.Message}", nameof(value), e);
+        }
+        return value;
     }
 }

--- a/src/CloudNative.CloudEvents/CloudEventAttributeType.cs
+++ b/src/CloudNative.CloudEvents/CloudEventAttributeType.cs
@@ -6,304 +6,303 @@ using CloudNative.CloudEvents.Core;
 using System;
 using System.Globalization;
 
-namespace CloudNative.CloudEvents
+namespace CloudNative.CloudEvents;
+
+// TODO: Expose the generic type? That might avoid boxing, and make various aspects more type-safe at compile time.
+// TODO: Clarify validation requirements. At the moment I suspect we're validating more often than we need to.
+// (This is just a little inefficient.)
+
+/// <summary>
+/// The type of an event attribute, providing simple formatting and parsing functionality.
+/// </summary>
+public abstract class CloudEventAttributeType
 {
-    // TODO: Expose the generic type? That might avoid boxing, and make various aspects more type-safe at compile time.
-    // TODO: Clarify validation requirements. At the moment I suspect we're validating more often than we need to.
-    // (This is just a little inefficient.)
+    /// <summary>
+    /// A Boolean value of "true" or "false".
+    /// </summary>
+    public static CloudEventAttributeType Boolean { get; } = new BooleanType();
 
     /// <summary>
-    /// The type of an event attribute, providing simple formatting and parsing functionality.
+    /// A whole number in the range -2,147,483,648 to +2,147,483,647 inclusive.
     /// </summary>
-    public abstract class CloudEventAttributeType
+    public static CloudEventAttributeType Integer { get; } = new IntegerType();
+
+    /// <summary>
+    /// A sequence of allowable Unicode characters.
+    /// </summary>
+    public static CloudEventAttributeType String { get; } = new StringType();
+
+    /// <summary>
+    /// A sequence of bytes.
+    /// </summary>
+    public static CloudEventAttributeType Binary { get; } = new BinaryType();
+
+    /// <summary>
+    /// An absolute uniform resource identifier.
+    /// </summary>
+    public static CloudEventAttributeType Uri { get; } = new UriType();
+
+    /// <summary>
+    /// A uniform resource identifier reference.
+    /// </summary>
+    public static CloudEventAttributeType UriReference { get; } = new UriReferenceType();
+
+    /// <summary>
+    /// A date and time expression using the Gregorian calendar.
+    /// </summary>
+    public static CloudEventAttributeType Timestamp { get; } = new TimestampType();
+
+    /// <summary>
+    /// The <see cref="Ordinal"/> value for this type.
+    /// </summary>
+    internal CloudEventAttributeTypeOrdinal Ordinal { get; }
+
+    /// <summary>
+    /// The name of the type, as it is written in the CloudEvents specification.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// CLR type used to represent a value of this attribute type.
+    /// </summary>
+    public Type ClrType { get; }
+
+    /// <summary>
+    /// Returns the name of the type.
+    /// </summary>
+    /// <returns>The name of the type.</returns>
+    public override string ToString() => Name;
+
+    /// <summary>
+    /// Converts the given value to its canonical string representation.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public abstract string Format(object value);
+
+    /// <summary>
+    /// Converts the given value from its canonical string representation
+    /// into <see cref="ClrType"/>.
+    /// </summary>
+    public abstract object Parse(string text);
+
+    /// <summary>
+    /// Validates that the given value is valid for this type.
+    /// </summary>
+    /// <param name="value">The value to validate. Must be non-null, and suitable for this attribute type.</param>
+    public abstract void Validate(object value);
+
+    private CloudEventAttributeType(string name, CloudEventAttributeTypeOrdinal ordinal, Type clrType)
     {
-        /// <summary>
-        /// A Boolean value of "true" or "false".
-        /// </summary>
-        public static CloudEventAttributeType Boolean { get; } = new BooleanType();
+        Name = name;
+        Ordinal = ordinal;
+        ClrType = clrType;
+    }
 
-        /// <summary>
-        /// A whole number in the range -2,147,483,648 to +2,147,483,647 inclusive.
-        /// </summary>
-        public static CloudEventAttributeType Integer { get; } = new IntegerType();
-
-        /// <summary>
-        /// A sequence of allowable Unicode characters.
-        /// </summary>
-        public static CloudEventAttributeType String { get; } = new StringType();
-
-        /// <summary>
-        /// A sequence of bytes.
-        /// </summary>
-        public static CloudEventAttributeType Binary { get; } = new BinaryType();
-
-        /// <summary>
-        /// An absolute uniform resource identifier.
-        /// </summary>
-        public static CloudEventAttributeType Uri { get; } = new UriType();
-
-        /// <summary>
-        /// A uniform resource identifier reference.
-        /// </summary>
-        public static CloudEventAttributeType UriReference { get; } = new UriReferenceType();
-
-        /// <summary>
-        /// A date and time expression using the Gregorian calendar.
-        /// </summary>
-        public static CloudEventAttributeType Timestamp { get; } = new TimestampType();
-
-        /// <summary>
-        /// The <see cref="Ordinal"/> value for this type.
-        /// </summary>
-        internal CloudEventAttributeTypeOrdinal Ordinal { get; }
-
-        /// <summary>
-        /// The name of the type, as it is written in the CloudEvents specification.
-        /// </summary>
-        public string Name { get; }
-
-        /// <summary>
-        /// CLR type used to represent a value of this attribute type.
-        /// </summary>
-        public Type ClrType { get; }
-
-        /// <summary>
-        /// Returns the name of the type.
-        /// </summary>
-        /// <returns>The name of the type.</returns>
-        public override string ToString() => Name;
-
-        /// <summary>
-        /// Converts the given value to its canonical string representation.
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        public abstract string Format(object value);
-
-        /// <summary>
-        /// Converts the given value from its canonical string representation
-        /// into <see cref="ClrType"/>.
-        /// </summary>
-        public abstract object Parse(string text);
-
-        /// <summary>
-        /// Validates that the given value is valid for this type.
-        /// </summary>
-        /// <param name="value">The value to validate. Must be non-null, and suitable for this attribute type.</param>
-        public abstract void Validate(object value);
-
-        private CloudEventAttributeType(string name, CloudEventAttributeTypeOrdinal ordinal, Type clrType)
+    private abstract class GenericCloudEventsAttributeType<T> : CloudEventAttributeType where T : notnull
+    {
+        protected GenericCloudEventsAttributeType(string name, CloudEventAttributeTypeOrdinal ordinal) : base(name, ordinal, typeof(T))
         {
-            Name = name;
-            Ordinal = ordinal;
-            ClrType = clrType;
         }
 
-        private abstract class GenericCloudEventsAttributeType<T> : CloudEventAttributeType where T : notnull
+        public sealed override object Parse(string value) => ParseImpl(Validation.CheckNotNull(value, nameof(value)));
+
+        public sealed override string Format(object value)
         {
-            protected GenericCloudEventsAttributeType(string name, CloudEventAttributeTypeOrdinal ordinal) : base(name, ordinal, typeof(T))
-            {
-            }
-
-            public sealed override object Parse(string value) => ParseImpl(Validation.CheckNotNull(value, nameof(value)));
-
-            public sealed override string Format(object value)
-            {
-                Validate(value);
-                // TODO: Avoid the double cast.
-                return FormatImpl((T) value);
-            }
-
-            public sealed override void Validate(object value)
-            {
-                Validation.CheckNotNull(value, nameof(value));
-                if (!ClrType.IsInstanceOfType(value))
-                {
-                    throw new ArgumentException($"Value of type {value.GetType()} is incompatible with expected type {ClrType}", nameof(value));
-                }
-
-                ValidateImpl((T) Validation.CheckNotNull(value, nameof(value)));
-            }
-
-            protected abstract T ParseImpl(string value);
-
-            protected abstract string FormatImpl(T value);
-
-            // Default is for all values to be valid.
-            protected virtual void ValidateImpl(T value) { }
+            Validate(value);
+            // TODO: Avoid the double cast.
+            return FormatImpl((T) value);
         }
 
-        private class BooleanType : GenericCloudEventsAttributeType<bool>
+        public sealed override void Validate(object value)
         {
-            public BooleanType() : base("Boolean", CloudEventAttributeTypeOrdinal.Boolean)
+            Validation.CheckNotNull(value, nameof(value));
+            if (!ClrType.IsInstanceOfType(value))
             {
+                throw new ArgumentException($"Value of type {value.GetType()} is incompatible with expected type {ClrType}", nameof(value));
             }
 
-            protected override string FormatImpl(bool value) => value ? "true" : "false";
-            protected override bool ParseImpl(string value) =>
+            ValidateImpl((T) Validation.CheckNotNull(value, nameof(value)));
+        }
+
+        protected abstract T ParseImpl(string value);
+
+        protected abstract string FormatImpl(T value);
+
+        // Default is for all values to be valid.
+        protected virtual void ValidateImpl(T value) { }
+    }
+
+    private class BooleanType : GenericCloudEventsAttributeType<bool>
+    {
+        public BooleanType() : base("Boolean", CloudEventAttributeTypeOrdinal.Boolean)
+        {
+        }
+
+        protected override string FormatImpl(bool value) => value ? "true" : "false";
+        protected override bool ParseImpl(string value) =>
 #pragma warning disable IDE0075 // Simplify conditional expression (the suggestion really isn't simpler)
-                value == "true" ? true
-                : value == "false" ? false
-                : throw new ArgumentException("Invalid Boolean attribute value");
+            value == "true" ? true
+            : value == "false" ? false
+            : throw new ArgumentException("Invalid Boolean attribute value");
 #pragma warning restore IDE0075 // Simplify conditional expression
+    }
+
+    private class StringType : GenericCloudEventsAttributeType<string>
+    {
+        public StringType() : base("String", CloudEventAttributeTypeOrdinal.String)
+        {
         }
 
-        private class StringType : GenericCloudEventsAttributeType<string>
+        // Note: these methods deliberately don't validate, to avoid repeated validation.
+        // The "owning attribute" already validates the value when parsing or formatting.
+        protected override string FormatImpl(string value) => value;
+        protected override string ParseImpl(string value) => value;
+
+        protected override void ValidateImpl(string value)
         {
-            public StringType() : base("String", CloudEventAttributeTypeOrdinal.String)
+            bool lastCharWasHighSurrogate = false;
+            for (int i = 0; i < value.Length; i++)
             {
-            }
-
-            // Note: these methods deliberately don't validate, to avoid repeated validation.
-            // The "owning attribute" already validates the value when parsing or formatting.
-            protected override string FormatImpl(string value) => value;
-            protected override string ParseImpl(string value) => value;
-
-            protected override void ValidateImpl(string value)
-            {
-                bool lastCharWasHighSurrogate = false;
-                for (int i = 0; i < value.Length; i++)
+                char c = value[i];
+                // Directly from the spec
+                if (c <= 0x1f || (c >= 0x7f && c <= 0x9f))
                 {
-                    char c = value[i];
-                    // Directly from the spec
-                    if (c <= 0x1f || (c >= 0x7f && c <= 0x9f))
-                    {
-                        throw new ArgumentException($"Control character U+{(ushort) c:x4} is not permitted in string attributes");
-                    }
-                    // First two ranges in http://www.unicode.org/faq/private_use.html#noncharacters
-                    if (c >= 0xfffe || (c >= 0xfdd0 && c <= 0xfdef))
-                    {
-                        throw new ArgumentException($"Noncharacter U+{(ushort) c:x4} is not permitted in string attributes");
-                    }
+                    throw new ArgumentException($"Control character U+{(ushort) c:x4} is not permitted in string attributes");
+                }
+                // First two ranges in http://www.unicode.org/faq/private_use.html#noncharacters
+                if (c >= 0xfffe || (c >= 0xfdd0 && c <= 0xfdef))
+                {
+                    throw new ArgumentException($"Noncharacter U+{(ushort) c:x4} is not permitted in string attributes");
+                }
 
-                    // Handle surrogate pairs, based on this character and whether the last character was a high surrogate.
-                    // Every high surrogate must be followed by a low surrogate, and every low surrogate must be preceded by a high surrogate.
-                    // Confusingly, the "high surrogate" region [U+D800, U+DBFF] is lower in value than the "low surrogate" region [U+DC00, U+DFFF].
-                    if (char.IsSurrogate(c))
+                // Handle surrogate pairs, based on this character and whether the last character was a high surrogate.
+                // Every high surrogate must be followed by a low surrogate, and every low surrogate must be preceded by a high surrogate.
+                // Confusingly, the "high surrogate" region [U+D800, U+DBFF] is lower in value than the "low surrogate" region [U+DC00, U+DFFF].
+                if (char.IsSurrogate(c))
+                {
+                    if (char.IsHighSurrogate(c))
                     {
-                        if (char.IsHighSurrogate(c))
+                        if (lastCharWasHighSurrogate)
                         {
-                            if (lastCharWasHighSurrogate)
-                            {
-                                throw new ArgumentException($"High surrogate character U+{(ushort) value[i - 1]:x4} must be followed by a low surrogate character");
-                            }
-                            lastCharWasHighSurrogate = true;
+                            throw new ArgumentException($"High surrogate character U+{(ushort) value[i - 1]:x4} must be followed by a low surrogate character");
                         }
-                        else
-                        {
-                            if (!lastCharWasHighSurrogate)
-                            {
-                                throw new ArgumentException($"Low surrogate character U+{(ushort) c:x4} must be preceded by a high surrogate character");
-                            }
-                            // Convert the surrogate pair to validate it's not a non-character.
-                            // This is the third rule in http://www.unicode.org/faq/private_use.html#noncharacters
-                            int utf32 = char.ConvertToUtf32(value[i - 1], c);
-                            var last16Bits = utf32 & 0xffff;
-                            if (last16Bits == 0xffff || last16Bits == 0xfffe)
-                            {
-                                throw new ArgumentException($"Noncharacter U+{utf32:x} is not permitted in string attributes");
-                            }
-                            lastCharWasHighSurrogate = false;
-                        }
+                        lastCharWasHighSurrogate = true;
                     }
-                    else if (lastCharWasHighSurrogate)
+                    else
                     {
-                        throw new ArgumentException($"High surrogate character U+{(ushort) value[i - 1]:x4} must be followed by a low surrogate character");
+                        if (!lastCharWasHighSurrogate)
+                        {
+                            throw new ArgumentException($"Low surrogate character U+{(ushort) c:x4} must be preceded by a high surrogate character");
+                        }
+                        // Convert the surrogate pair to validate it's not a non-character.
+                        // This is the third rule in http://www.unicode.org/faq/private_use.html#noncharacters
+                        int utf32 = char.ConvertToUtf32(value[i - 1], c);
+                        var last16Bits = utf32 & 0xffff;
+                        if (last16Bits == 0xffff || last16Bits == 0xfffe)
+                        {
+                            throw new ArgumentException($"Noncharacter U+{utf32:x} is not permitted in string attributes");
+                        }
+                        lastCharWasHighSurrogate = false;
                     }
                 }
-                if (lastCharWasHighSurrogate)
+                else if (lastCharWasHighSurrogate)
                 {
-                    throw new ArgumentException($"String must not end with high surrogate character U+{(ushort) value[value.Length - 1]:x4}");
+                    throw new ArgumentException($"High surrogate character U+{(ushort) value[i - 1]:x4} must be followed by a low surrogate character");
                 }
             }
-        }
-
-        private class TimestampType : GenericCloudEventsAttributeType<DateTimeOffset>
-        {
-            public TimestampType() : base("Timestamp", CloudEventAttributeTypeOrdinal.Timestamp)
+            if (lastCharWasHighSurrogate)
             {
-            }
-
-            protected override string FormatImpl(DateTimeOffset value) => Timestamps.Format(value);
-            protected override DateTimeOffset ParseImpl(string value) => Timestamps.Parse(value);
-        }
-
-        // FIXME: Decide on escaping policies here. Uri will automatically perform escaping for us,
-        // but it's not clear what the behavior should be. Should we assert that when parsing, the
-        // string is already well-formed, and then use the original string when formatting?
-        // That makes sense when we parse a CloudEvent and then reformat it, but if users provide
-        // a Uri object to us, they may well want it to be escaped for them.
-        // Side-note: Uri.IsWellFormedOriginalString() rejects "#fragment" for some reason, which makes
-        // it very hard to really validate.
-        // Note that it doesn't look like IsWellFormedOriginalString actually checks whether things 
-        // need escaping anyway :(
-        // While URI and URI-Reference could be implemented in the same class, there were sufficient
-        // differences to make it not worthwhile.
-        private class UriType : GenericCloudEventsAttributeType<Uri>
-        {
-            public UriType() : base("URI", CloudEventAttributeTypeOrdinal.Uri)
-            {
-            }
-
-            protected override string FormatImpl(Uri value) => value.OriginalString;
-
-            protected override Uri ParseImpl(string value)
-            {
-                Uri uri = new Uri(value, UriKind.Absolute);
-                // On Linux, URIs starting with '/' are implicitly absolute with a scheme of "file".
-                // We don't want that...
-                if (value.StartsWith("/"))
-                {
-                    throw new UriFormatException("Invalid URI: expected an absolute URI");
-                }
-                return uri;
-            }
-
-            protected override void ValidateImpl(Uri value)
-            {
-                if (!value.IsAbsoluteUri)
-                {
-                    throw new ArgumentException("URI must be absolute.");
-                }
+                throw new ArgumentException($"String must not end with high surrogate character U+{(ushort) value[value.Length - 1]:x4}");
             }
         }
+    }
 
-        private class UriReferenceType : GenericCloudEventsAttributeType<Uri>
+    private class TimestampType : GenericCloudEventsAttributeType<DateTimeOffset>
+    {
+        public TimestampType() : base("Timestamp", CloudEventAttributeTypeOrdinal.Timestamp)
         {
-            public UriReferenceType() : base("URI-Reference", CloudEventAttributeTypeOrdinal.UriReference)
-            {
-            }
-
-            protected override string FormatImpl(Uri value) => value.OriginalString;
-
-            protected override Uri ParseImpl(string value) => new Uri(value, UriKind.RelativeOrAbsolute);
         }
 
-        private class BinaryType : GenericCloudEventsAttributeType<byte[]>
-        {
-            public BinaryType() : base("Binary", CloudEventAttributeTypeOrdinal.Binary)
-            {
-            }
+        protected override string FormatImpl(DateTimeOffset value) => Timestamps.Format(value);
+        protected override DateTimeOffset ParseImpl(string value) => Timestamps.Parse(value);
+    }
 
-            protected override string FormatImpl(byte[] value) => Convert.ToBase64String(value);
-            protected override byte[] ParseImpl(string value) => Convert.FromBase64String(value);
+    // FIXME: Decide on escaping policies here. Uri will automatically perform escaping for us,
+    // but it's not clear what the behavior should be. Should we assert that when parsing, the
+    // string is already well-formed, and then use the original string when formatting?
+    // That makes sense when we parse a CloudEvent and then reformat it, but if users provide
+    // a Uri object to us, they may well want it to be escaped for them.
+    // Side-note: Uri.IsWellFormedOriginalString() rejects "#fragment" for some reason, which makes
+    // it very hard to really validate.
+    // Note that it doesn't look like IsWellFormedOriginalString actually checks whether things 
+    // need escaping anyway :(
+    // While URI and URI-Reference could be implemented in the same class, there were sufficient
+    // differences to make it not worthwhile.
+    private class UriType : GenericCloudEventsAttributeType<Uri>
+    {
+        public UriType() : base("URI", CloudEventAttributeTypeOrdinal.Uri)
+        {
         }
 
-        private class IntegerType : GenericCloudEventsAttributeType<int>
-        {
-            public IntegerType() : base("Integer", CloudEventAttributeTypeOrdinal.Integer)
-            {
-            }
+        protected override string FormatImpl(Uri value) => value.OriginalString;
 
-            protected override string FormatImpl(int value) => value.ToString(CultureInfo.InvariantCulture);
-            protected override int ParseImpl(string value)
+        protected override Uri ParseImpl(string value)
+        {
+            Uri uri = new Uri(value, UriKind.Absolute);
+            // On Linux, URIs starting with '/' are implicitly absolute with a scheme of "file".
+            // We don't want that...
+            if (value.StartsWith("/"))
             {
-                if (value.Length > 0 && value[0] == '+')
-                {
-                    throw new FormatException("Leading + sign is not permitted");
-                }
-                return int.Parse(value, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture);
+                throw new UriFormatException("Invalid URI: expected an absolute URI");
             }
+            return uri;
+        }
+
+        protected override void ValidateImpl(Uri value)
+        {
+            if (!value.IsAbsoluteUri)
+            {
+                throw new ArgumentException("URI must be absolute.");
+            }
+        }
+    }
+
+    private class UriReferenceType : GenericCloudEventsAttributeType<Uri>
+    {
+        public UriReferenceType() : base("URI-Reference", CloudEventAttributeTypeOrdinal.UriReference)
+        {
+        }
+
+        protected override string FormatImpl(Uri value) => value.OriginalString;
+
+        protected override Uri ParseImpl(string value) => new Uri(value, UriKind.RelativeOrAbsolute);
+    }
+
+    private class BinaryType : GenericCloudEventsAttributeType<byte[]>
+    {
+        public BinaryType() : base("Binary", CloudEventAttributeTypeOrdinal.Binary)
+        {
+        }
+
+        protected override string FormatImpl(byte[] value) => Convert.ToBase64String(value);
+        protected override byte[] ParseImpl(string value) => Convert.FromBase64String(value);
+    }
+
+    private class IntegerType : GenericCloudEventsAttributeType<int>
+    {
+        public IntegerType() : base("Integer", CloudEventAttributeTypeOrdinal.Integer)
+        {
+        }
+
+        protected override string FormatImpl(int value) => value.ToString(CultureInfo.InvariantCulture);
+        protected override int ParseImpl(string value)
+        {
+            if (value.Length > 0 && value[0] == '+')
+            {
+                throw new FormatException("Leading + sign is not permitted");
+            }
+            return int.Parse(value, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture);
         }
     }
 }

--- a/src/CloudNative.CloudEvents/CloudEventFormatter.cs
+++ b/src/CloudNative.CloudEvents/CloudEventFormatter.cs
@@ -9,196 +9,195 @@ using System.IO;
 using System.Net.Mime;
 using System.Threading.Tasks;
 
-namespace CloudNative.CloudEvents
+namespace CloudNative.CloudEvents;
+
+/// <summary>
+/// Performs CloudEvent conversions as part of encoding and decoding messages for protocol bindings.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Event formatters are responsible for complete CloudEvent encoding and decoding for structured-mode messages (where
+/// all the CloudEvent information is represented within the message body), and data-only encoding and decoding
+/// for binary-mode messages (where CloudEvent attributes are represented in message metadata, and the CloudEvent data
+/// is represented in the message body).
+/// </para>
+/// <para>
+/// Each event formatter type is responsible for documenting what types of value are acceptable for the <see cref="CloudEvent.Data"/>
+/// property in CloudEvents it is asked to encode, and likewise what types of value will be present in the same property
+/// when it is asked to decode a message. Event formatters should aim to be as consistent as possible with respect to data handling
+/// between structured and binary modes, although this is not always possible as the structured mode representation may contain
+/// more hints around how to interpret the data than the binary mode representation. Inconsistencies should be carefully
+/// noted so that consumers can write robust code.
+/// </para>
+/// <para>
+/// An event format is often naturally associated with a particular kind of data, but it is not limited to working with
+/// that kind. For example, the JSON event format allows JSON data to be stored particularly naturally within the structured-mode
+/// message body (which is itself JSON), but it is still able to handle arbitrary binary or text data.
+/// </para>
+/// </remarks>
+public abstract class CloudEventFormatter
 {
     /// <summary>
-    /// Performs CloudEvent conversions as part of encoding and decoding messages for protocol bindings.
+    /// Decodes a CloudEvent from a structured-mode message body, represented as a read-only memory segment.
+    /// </summary>
+    /// <param name="body">The message body (content).</param>
+    /// <param name="contentType">The content type of the message, or null if no content type is known.
+    /// Typically this is a content type with a media type of "application/cloudevents"; the additional
+    /// information such as the charset parameter may be needed in order to decode the message body.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
+    /// <returns>The CloudEvent derived from the structured message body.</returns>
+    public abstract CloudEvent DecodeStructuredModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes);
+
+    /// <summary>
+    /// Decodes a CloudEvent from a structured-mode message body, represented as a stream. The default implementation copies the
+    /// content of the stream into a read-only memory segment before passing it to <see cref="DecodeStructuredModeMessage(ReadOnlyMemory{byte}, ContentType, IEnumerable{CloudEventAttribute})"/>
+    /// but this can be overridden by event formatters that can decode a stream more efficiently.
+    /// </summary>
+    /// <param name="messageBody">The message body (content). Must not be null.</param>
+    /// <param name="contentType">The content type of the message, or null if no content type is known.
+    /// Typically this is a content type with a media type of "application/cloudevents"; the additional
+    /// information such as the charset parameter may be needed in order to decode the message body.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
+    /// <returns>The decoded CloudEvent.</returns>
+    public virtual CloudEvent DecodeStructuredModeMessage(Stream messageBody, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
+    {
+        var bytes = BinaryDataUtilities.ToReadOnlyMemory(messageBody);
+        return DecodeStructuredModeMessage(bytes, contentType, extensionAttributes);
+    }
+
+    /// <summary>
+    /// Asynchronously decodes a CloudEvent from a structured-mode message body, represented as a stream. The default implementation asynchronously copies the
+    /// content of the stream into a read-only memory segment before passing it to <see cref="DecodeStructuredModeMessage(ReadOnlyMemory{byte}, ContentType, IEnumerable{CloudEventAttribute})"/>
+    /// but this can be overridden by event formatters that can decode a stream more efficiently.
+    /// </summary>
+    /// <param name="body">The message body (content). Must not be null.</param>
+    /// <param name="contentType">The content type of the message, or null if no content type is known.
+    /// Typically this is a content type with a media type of "application/cloudevents"; the additional
+    /// information such as the charset parameter may be needed in order to decode the message body.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
+    /// <returns>The CloudEvent derived from the structured message body.</returns>
+    public virtual async Task<CloudEvent> DecodeStructuredModeMessageAsync(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
+    {
+        var bytes = await BinaryDataUtilities.ToReadOnlyMemoryAsync(body).ConfigureAwait(false);
+        return DecodeStructuredModeMessage(bytes, contentType, extensionAttributes);
+    }
+
+    /// <summary>
+    /// Encodes a CloudEvent as the body of a structured-mode message.
+    /// </summary>
+    /// <param name="cloudEvent">The CloudEvent to encode. Must not be null.</param>
+    /// <param name="contentType">On successful return, the content type of the structured-mode message body.
+    /// Must not be null (on return).</param>
+    /// <returns>The structured-mode representation of the CloudEvent.</returns>
+    public abstract ReadOnlyMemory<byte> EncodeStructuredModeMessage(CloudEvent cloudEvent, out ContentType contentType);
+
+    /// <summary>
+    /// Decodes the given data obtained from a binary-mode message, populating the <see cref="CloudEvent.Data"/>
+    /// property of <paramref name="cloudEvent"/>. Other attributes within the CloudEvent may be used to inform
+    /// the interpretation of the message body. This method is expected to be called after all other aspects of the CloudEvent
+    /// have been populated.
+    /// </summary>
+    /// <param name="body">The message body (content). Must not be null, but may be empty.</param>
+    /// <param name="cloudEvent">The CloudEvent whose Data property should be populated. Must not be null.</param>
+    /// <exception cref="ArgumentException">The data in the given CloudEvent cannot be decoded by this
+    /// event formatter.</exception>
+    public abstract void DecodeBinaryModeEventData(ReadOnlyMemory<byte> body, CloudEvent cloudEvent);
+
+    /// <summary>
+    /// Encodes the data from <paramref name="cloudEvent"/> in a manner suitable for a binary mode message.
+    /// </summary>
+    /// <exception cref="ArgumentException">The data in the given CloudEvent cannot be encoded by this
+    /// event formatter.</exception>
+    /// <returns>The binary-mode representation of the CloudEvent.</returns>
+    public abstract ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent);
+
+    /// <summary>
+    /// Decodes a collection CloudEvents from a batch-mode message body, represented as a read-only memory segment.
+    /// </summary>
+    /// <param name="body">The message body (content).</param>
+    /// <param name="contentType">The content type of the message, or null if no content type is known.
+    /// Typically this is a content type with a media type with a prefix of "application/cloudevents-batch"; the additional
+    /// information such as the charset parameter may be needed in order to decode the message body.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
+    /// <returns>The collection of CloudEvents derived from the batch message body.</returns>
+    public abstract IReadOnlyList<CloudEvent> DecodeBatchModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes);
+
+    /// <summary>
+    /// Decodes a collection CloudEvents from a batch-mode message body, represented as a stream. The default implementation copies the
+    /// content of the stream into a read-only memory segment before passing it to <see cref="DecodeBatchModeMessage(ReadOnlyMemory{byte}, ContentType, IEnumerable{CloudEventAttribute})"/>
+    /// but this can be overridden by event formatters that can decode a stream more efficiently.
+    /// </summary>
+    /// <param name="body">The message body (content). Must not be null.</param>
+    /// <param name="contentType">The content type of the message, or null if no content type is known.
+    /// Typically this is a content type with a media type with a prefix of "application/cloudevents"; the additional
+    /// information such as the charset parameter may be needed in order to decode the message body.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
+    /// <returns>The collection of CloudEvents derived from the batch message body.</returns>
+    public virtual IReadOnlyList<CloudEvent> DecodeBatchModeMessage(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
+    {
+        var bytes = BinaryDataUtilities.ToReadOnlyMemory(body);
+        return DecodeBatchModeMessage(bytes, contentType, extensionAttributes);
+    }
+
+    /// <summary>
+    /// Asynchronously decodes a collection CloudEvents from a batch-mode message body, represented as a stream. The default implementation asynchronously copies the
+    /// content of the stream into a read-only memory segment before passing it to <see cref="DecodeBatchModeMessage(ReadOnlyMemory{byte}, ContentType, IEnumerable{CloudEventAttribute})"/>
+    /// but this can be overridden by event formatters that can decode a stream more efficiently.
+    /// </summary>
+    /// <param name="body">The message body (content). Must not be null.</param>
+    /// <param name="contentType">The content type of the message, or null if no content type is known.
+    /// Typically this is a content type with a media type with a prefix of "application/cloudevents"; the additional
+    /// information such as the charset parameter may be needed in order to decode the message body.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
+    /// <returns>The collection of CloudEvents derived from the batch message body.</returns>
+    public virtual async Task<IReadOnlyList<CloudEvent>> DecodeBatchModeMessageAsync(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
+    {
+        var bytes = await BinaryDataUtilities.ToReadOnlyMemoryAsync(body).ConfigureAwait(false);
+        return DecodeBatchModeMessage(bytes, contentType, extensionAttributes);
+    }
+
+    /// <summary>
+    /// Encodes a sequence of CloudEvents as the body of a message.
+    /// </summary>
+    /// <param name="cloudEvents">The CloudEvents to encode. Must not be null.</param>
+    /// <param name="contentType">On successful return, the content type of the batch message body.
+    /// Must not be null (on return).</param>
+    /// <returns>The batch representation of the CloudEvent.</returns>
+    public abstract ReadOnlyMemory<byte> EncodeBatchModeMessage(IEnumerable<CloudEvent> cloudEvents, out ContentType contentType);
+
+    /// <summary>
+    /// Determines the effective data content type of the given CloudEvent.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Event formatters are responsible for complete CloudEvent encoding and decoding for structured-mode messages (where
-    /// all the CloudEvent information is represented within the message body), and data-only encoding and decoding
-    /// for binary-mode messages (where CloudEvent attributes are represented in message metadata, and the CloudEvent data
-    /// is represented in the message body).
+    /// This implementation validates that <paramref name="cloudEvent"/> is not null,
+    /// returns the existing <see cref="CloudEvent.DataContentType"/> if that's not null,
+    /// and otherwise returns null if <see cref="CloudEvent.Data"/> is null or
+    /// delegates to <see cref="InferDataContentType(object)"/> to infer the data content type
+    /// from the actual data.
     /// </para>
     /// <para>
-    /// Each event formatter type is responsible for documenting what types of value are acceptable for the <see cref="CloudEvent.Data"/>
-    /// property in CloudEvents it is asked to encode, and likewise what types of value will be present in the same property
-    /// when it is asked to decode a message. Event formatters should aim to be as consistent as possible with respect to data handling
-    /// between structured and binary modes, although this is not always possible as the structured mode representation may contain
-    /// more hints around how to interpret the data than the binary mode representation. Inconsistencies should be carefully
-    /// noted so that consumers can write robust code.
-    /// </para>
-    /// <para>
-    /// An event format is often naturally associated with a particular kind of data, but it is not limited to working with
-    /// that kind. For example, the JSON event format allows JSON data to be stored particularly naturally within the structured-mode
-    /// message body (which is itself JSON), but it is still able to handle arbitrary binary or text data.
+    /// Derived classes may override this if additional information is needed from the CloudEvent
+    /// in order to determine the effective data content type, but most cases can be handled by
+    /// simply overriding <see cref="InferDataContentType(object)"/>.
     /// </para>
     /// </remarks>
-    public abstract class CloudEventFormatter
+    /// <param name="cloudEvent">The CloudEvent to get or infer the data content type from. Must not be null.</param>
+    /// <returns>The data content type of the CloudEvent, or null for no data content type.</returns>
+    public virtual string? GetOrInferDataContentType(CloudEvent cloudEvent)
     {
-        /// <summary>
-        /// Decodes a CloudEvent from a structured-mode message body, represented as a read-only memory segment.
-        /// </summary>
-        /// <param name="body">The message body (content).</param>
-        /// <param name="contentType">The content type of the message, or null if no content type is known.
-        /// Typically this is a content type with a media type of "application/cloudevents"; the additional
-        /// information such as the charset parameter may be needed in order to decode the message body.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
-        /// <returns>The CloudEvent derived from the structured message body.</returns>
-        public abstract CloudEvent DecodeStructuredModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes);
-
-        /// <summary>
-        /// Decodes a CloudEvent from a structured-mode message body, represented as a stream. The default implementation copies the
-        /// content of the stream into a read-only memory segment before passing it to <see cref="DecodeStructuredModeMessage(ReadOnlyMemory{byte}, ContentType, IEnumerable{CloudEventAttribute})"/>
-        /// but this can be overridden by event formatters that can decode a stream more efficiently.
-        /// </summary>
-        /// <param name="messageBody">The message body (content). Must not be null.</param>
-        /// <param name="contentType">The content type of the message, or null if no content type is known.
-        /// Typically this is a content type with a media type of "application/cloudevents"; the additional
-        /// information such as the charset parameter may be needed in order to decode the message body.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
-        /// <returns>The decoded CloudEvent.</returns>
-        public virtual CloudEvent DecodeStructuredModeMessage(Stream messageBody, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
-        {
-            var bytes = BinaryDataUtilities.ToReadOnlyMemory(messageBody);
-            return DecodeStructuredModeMessage(bytes, contentType, extensionAttributes);
-        }
-
-        /// <summary>
-        /// Asynchronously decodes a CloudEvent from a structured-mode message body, represented as a stream. The default implementation asynchronously copies the
-        /// content of the stream into a read-only memory segment before passing it to <see cref="DecodeStructuredModeMessage(ReadOnlyMemory{byte}, ContentType, IEnumerable{CloudEventAttribute})"/>
-        /// but this can be overridden by event formatters that can decode a stream more efficiently.
-        /// </summary>
-        /// <param name="body">The message body (content). Must not be null.</param>
-        /// <param name="contentType">The content type of the message, or null if no content type is known.
-        /// Typically this is a content type with a media type of "application/cloudevents"; the additional
-        /// information such as the charset parameter may be needed in order to decode the message body.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
-        /// <returns>The CloudEvent derived from the structured message body.</returns>
-        public virtual async Task<CloudEvent> DecodeStructuredModeMessageAsync(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
-        {
-            var bytes = await BinaryDataUtilities.ToReadOnlyMemoryAsync(body).ConfigureAwait(false);
-            return DecodeStructuredModeMessage(bytes, contentType, extensionAttributes);
-        }
-
-        /// <summary>
-        /// Encodes a CloudEvent as the body of a structured-mode message.
-        /// </summary>
-        /// <param name="cloudEvent">The CloudEvent to encode. Must not be null.</param>
-        /// <param name="contentType">On successful return, the content type of the structured-mode message body.
-        /// Must not be null (on return).</param>
-        /// <returns>The structured-mode representation of the CloudEvent.</returns>
-        public abstract ReadOnlyMemory<byte> EncodeStructuredModeMessage(CloudEvent cloudEvent, out ContentType contentType);
-
-        /// <summary>
-        /// Decodes the given data obtained from a binary-mode message, populating the <see cref="CloudEvent.Data"/>
-        /// property of <paramref name="cloudEvent"/>. Other attributes within the CloudEvent may be used to inform
-        /// the interpretation of the message body. This method is expected to be called after all other aspects of the CloudEvent
-        /// have been populated.
-        /// </summary>
-        /// <param name="body">The message body (content). Must not be null, but may be empty.</param>
-        /// <param name="cloudEvent">The CloudEvent whose Data property should be populated. Must not be null.</param>
-        /// <exception cref="ArgumentException">The data in the given CloudEvent cannot be decoded by this
-        /// event formatter.</exception>
-        public abstract void DecodeBinaryModeEventData(ReadOnlyMemory<byte> body, CloudEvent cloudEvent);
-
-        /// <summary>
-        /// Encodes the data from <paramref name="cloudEvent"/> in a manner suitable for a binary mode message.
-        /// </summary>
-        /// <exception cref="ArgumentException">The data in the given CloudEvent cannot be encoded by this
-        /// event formatter.</exception>
-        /// <returns>The binary-mode representation of the CloudEvent.</returns>
-        public abstract ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent);
-
-        /// <summary>
-        /// Decodes a collection CloudEvents from a batch-mode message body, represented as a read-only memory segment.
-        /// </summary>
-        /// <param name="body">The message body (content).</param>
-        /// <param name="contentType">The content type of the message, or null if no content type is known.
-        /// Typically this is a content type with a media type with a prefix of "application/cloudevents-batch"; the additional
-        /// information such as the charset parameter may be needed in order to decode the message body.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
-        /// <returns>The collection of CloudEvents derived from the batch message body.</returns>
-        public abstract IReadOnlyList<CloudEvent> DecodeBatchModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes);
-
-        /// <summary>
-        /// Decodes a collection CloudEvents from a batch-mode message body, represented as a stream. The default implementation copies the
-        /// content of the stream into a read-only memory segment before passing it to <see cref="DecodeBatchModeMessage(ReadOnlyMemory{byte}, ContentType, IEnumerable{CloudEventAttribute})"/>
-        /// but this can be overridden by event formatters that can decode a stream more efficiently.
-        /// </summary>
-        /// <param name="body">The message body (content). Must not be null.</param>
-        /// <param name="contentType">The content type of the message, or null if no content type is known.
-        /// Typically this is a content type with a media type with a prefix of "application/cloudevents"; the additional
-        /// information such as the charset parameter may be needed in order to decode the message body.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
-        /// <returns>The collection of CloudEvents derived from the batch message body.</returns>
-        public virtual IReadOnlyList<CloudEvent> DecodeBatchModeMessage(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
-        {
-            var bytes = BinaryDataUtilities.ToReadOnlyMemory(body);
-            return DecodeBatchModeMessage(bytes, contentType, extensionAttributes);
-        }
-
-        /// <summary>
-        /// Asynchronously decodes a collection CloudEvents from a batch-mode message body, represented as a stream. The default implementation asynchronously copies the
-        /// content of the stream into a read-only memory segment before passing it to <see cref="DecodeBatchModeMessage(ReadOnlyMemory{byte}, ContentType, IEnumerable{CloudEventAttribute})"/>
-        /// but this can be overridden by event formatters that can decode a stream more efficiently.
-        /// </summary>
-        /// <param name="body">The message body (content). Must not be null.</param>
-        /// <param name="contentType">The content type of the message, or null if no content type is known.
-        /// Typically this is a content type with a media type with a prefix of "application/cloudevents"; the additional
-        /// information such as the charset parameter may be needed in order to decode the message body.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when populating the CloudEvent. May be null.</param>
-        /// <returns>The collection of CloudEvents derived from the batch message body.</returns>
-        public virtual async Task<IReadOnlyList<CloudEvent>> DecodeBatchModeMessageAsync(Stream body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes)
-        {
-            var bytes = await BinaryDataUtilities.ToReadOnlyMemoryAsync(body).ConfigureAwait(false);
-            return DecodeBatchModeMessage(bytes, contentType, extensionAttributes);
-        }
-
-        /// <summary>
-        /// Encodes a sequence of CloudEvents as the body of a message.
-        /// </summary>
-        /// <param name="cloudEvents">The CloudEvents to encode. Must not be null.</param>
-        /// <param name="contentType">On successful return, the content type of the batch message body.
-        /// Must not be null (on return).</param>
-        /// <returns>The batch representation of the CloudEvent.</returns>
-        public abstract ReadOnlyMemory<byte> EncodeBatchModeMessage(IEnumerable<CloudEvent> cloudEvents, out ContentType contentType);
-
-        /// <summary>
-        /// Determines the effective data content type of the given CloudEvent.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// This implementation validates that <paramref name="cloudEvent"/> is not null,
-        /// returns the existing <see cref="CloudEvent.DataContentType"/> if that's not null,
-        /// and otherwise returns null if <see cref="CloudEvent.Data"/> is null or
-        /// delegates to <see cref="InferDataContentType(object)"/> to infer the data content type
-        /// from the actual data.
-        /// </para>
-        /// <para>
-        /// Derived classes may override this if additional information is needed from the CloudEvent
-        /// in order to determine the effective data content type, but most cases can be handled by
-        /// simply overriding <see cref="InferDataContentType(object)"/>.
-        /// </para>
-        /// </remarks>
-        /// <param name="cloudEvent">The CloudEvent to get or infer the data content type from. Must not be null.</param>
-        /// <returns>The data content type of the CloudEvent, or null for no data content type.</returns>
-        public virtual string? GetOrInferDataContentType(CloudEvent cloudEvent)
-        {
-            Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
-            return cloudEvent.DataContentType is string dataContentType ? dataContentType
-                : cloudEvent.Data is not object data ? null
-                : InferDataContentType(data);
-        }
-
-        /// <summary>
-        /// Infers the effective data content type based on the actual data. This base implementation
-        /// always returns null, but derived classes may override this method to effectively provide
-        /// a default data content type based on the in-memory data type.
-        /// </summary>
-        /// <param name="data">The data within a CloudEvent. Should not be null.</param>
-        /// <returns>The inferred content type, or null if no content type is inferred.</returns>
-        protected virtual string? InferDataContentType(object data) => null;
+        Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
+        return cloudEvent.DataContentType is string dataContentType ? dataContentType
+            : cloudEvent.Data is not object data ? null
+            : InferDataContentType(data);
     }
+
+    /// <summary>
+    /// Infers the effective data content type based on the actual data. This base implementation
+    /// always returns null, but derived classes may override this method to effectively provide
+    /// a default data content type based on the in-memory data type.
+    /// </summary>
+    /// <param name="data">The data within a CloudEvent. Should not be null.</param>
+    /// <returns>The inferred content type, or null if no content type is inferred.</returns>
+    protected virtual string? InferDataContentType(object data) => null;
 }

--- a/src/CloudNative.CloudEvents/CloudEventFormatterAttribute.cs
+++ b/src/CloudNative.CloudEvents/CloudEventFormatterAttribute.cs
@@ -6,73 +6,72 @@ using CloudNative.CloudEvents.Core;
 using System;
 using System.Reflection;
 
-namespace CloudNative.CloudEvents
+namespace CloudNative.CloudEvents;
+
+/// <summary>
+/// Indicates the <see cref="CloudEventFormatter"/> type for the "target" type on which this attribute is placed.
+/// The formatter type is expected to be a concrete type derived from <see cref="CloudEventFormatter"/>,
+/// and must have a public parameterless constructor. It should ensure that any decoded CloudEvents
+/// populate the <see cref="CloudEvent.Data"/> property with an instance of the target type (or leave it
+/// as null if the CloudEvent has no data).
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct, Inherited = true, AllowMultiple = false)]
+public sealed class CloudEventFormatterAttribute : Attribute
 {
     /// <summary>
-    /// Indicates the <see cref="CloudEventFormatter"/> type for the "target" type on which this attribute is placed.
-    /// The formatter type is expected to be a concrete type derived from <see cref="CloudEventFormatter"/>,
-    /// and must have a public parameterless constructor. It should ensure that any decoded CloudEvents
-    /// populate the <see cref="CloudEvent.Data"/> property with an instance of the target type (or leave it
-    /// as null if the CloudEvent has no data).
+    /// The type to use for CloudEvent formatting. Must not be null.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct, Inherited = true, AllowMultiple = false)]
-    public sealed class CloudEventFormatterAttribute : Attribute
+    public Type FormatterType { get; }
+
+    /// <summary>
+    /// Constructs an instance of the attribute for the specified formatter type.
+    /// </summary>
+    /// <param name="formatterType">The type performing the data conversions.</param>
+    public CloudEventFormatterAttribute(Type formatterType) =>
+        FormatterType = formatterType;
+
+    /// <summary>
+    /// Creates a <see cref="CloudEventFormatter"/> based on <see cref="FormatterType"/> if
+    /// the specified target type (or an ancestor) has the attribute applied to it. This method does not
+    /// perform any caching; callers may wish to cache the results themselves.
+    /// </summary>
+    /// <param name="targetType">The type for which to create a formatter if possible. Must not be null</param>
+    /// <exception cref="InvalidOperationException">The target type is decorated with this attribute, but the
+    /// type cannot be instantiated or does not derive from <see cref="CloudEventFormatter"/>.</exception>
+    /// <returns>A new instance of the specified formatter, or null if the type is not decorated with this attribute.</returns>
+    public static CloudEventFormatter? CreateFormatter(Type targetType)
     {
-        /// <summary>
-        /// The type to use for CloudEvent formatting. Must not be null.
-        /// </summary>
-        public Type FormatterType { get; }
-
-        /// <summary>
-        /// Constructs an instance of the attribute for the specified formatter type.
-        /// </summary>
-        /// <param name="formatterType">The type performing the data conversions.</param>
-        public CloudEventFormatterAttribute(Type formatterType) =>
-            FormatterType = formatterType;
-
-        /// <summary>
-        /// Creates a <see cref="CloudEventFormatter"/> based on <see cref="FormatterType"/> if
-        /// the specified target type (or an ancestor) has the attribute applied to it. This method does not
-        /// perform any caching; callers may wish to cache the results themselves.
-        /// </summary>
-        /// <param name="targetType">The type for which to create a formatter if possible. Must not be null</param>
-        /// <exception cref="InvalidOperationException">The target type is decorated with this attribute, but the
-        /// type cannot be instantiated or does not derive from <see cref="CloudEventFormatter"/>.</exception>
-        /// <returns>A new instance of the specified formatter, or null if the type is not decorated with this attribute.</returns>
-        public static CloudEventFormatter? CreateFormatter(Type targetType)
+        Validation.CheckNotNull(targetType, nameof(targetType));
+        var attribute = targetType.GetCustomAttribute<CloudEventFormatterAttribute>(inherit: true);
+        if (attribute is null)
         {
-            Validation.CheckNotNull(targetType, nameof(targetType));
-            var attribute = targetType.GetCustomAttribute<CloudEventFormatterAttribute>(inherit: true);
-            if (attribute is null)
-            {
-                return null;
-            }
-
-            // It's fine for the converter creation to fail: we'll try it on every attempt,
-            // and always end up with an exception.
-            var formatterType = attribute.FormatterType;
-            if (formatterType is null)
-            {
-                throw new ArgumentException($"The {nameof(CloudEventFormatterAttribute)} on type {targetType} has no converter type specified.", nameof(targetType));
-            }
-
-            object? instance;
-            try
-            {
-                instance = Activator.CreateInstance(formatterType);
-            }
-            catch (Exception e)
-            {
-                throw new ArgumentException($"Unable to create CloudEvent formatter for target type {targetType}", nameof(targetType), e);
-            }
-
-            var formatter = instance as CloudEventFormatter;
-            if (formatter is null)
-            {
-                throw new ArgumentException($"CloudEventFormatter type {formatterType} does not derive from {nameof(CloudEventFormatter)}.", nameof(targetType));
-            }
-
-            return formatter;
+            return null;
         }
+
+        // It's fine for the converter creation to fail: we'll try it on every attempt,
+        // and always end up with an exception.
+        var formatterType = attribute.FormatterType;
+        if (formatterType is null)
+        {
+            throw new ArgumentException($"The {nameof(CloudEventFormatterAttribute)} on type {targetType} has no converter type specified.", nameof(targetType));
+        }
+
+        object? instance;
+        try
+        {
+            instance = Activator.CreateInstance(formatterType);
+        }
+        catch (Exception e)
+        {
+            throw new ArgumentException($"Unable to create CloudEvent formatter for target type {targetType}", nameof(targetType), e);
+        }
+
+        var formatter = instance as CloudEventFormatter;
+        if (formatter is null)
+        {
+            throw new ArgumentException($"CloudEventFormatter type {formatterType} does not derive from {nameof(CloudEventFormatter)}.", nameof(targetType));
+        }
+
+        return formatter;
     }
 }

--- a/src/CloudNative.CloudEvents/CloudEventsSpecVersion.cs
+++ b/src/CloudNative.CloudEvents/CloudEventsSpecVersion.cs
@@ -9,182 +9,181 @@ using System.Linq;
 using System.Net.Mime;
 using static CloudNative.CloudEvents.CloudEventAttribute;
 
-namespace CloudNative.CloudEvents
+namespace CloudNative.CloudEvents;
+
+/// <summary>
+/// Represents a version of the CloudEvents specification, including
+/// the context attribute values known to that version.
+/// </summary>
+public sealed class CloudEventsSpecVersion
 {
+    internal const string SpecVersionAttributeName = "specversion";
+
     /// <summary>
-    /// Represents a version of the CloudEvents specification, including
-    /// the context attribute values known to that version.
+    /// The attribute used to indicate the version of the CloudEvents specification being used.
     /// </summary>
-    public sealed class CloudEventsSpecVersion
+    public static CloudEventAttribute SpecVersionAttribute { get; } = CreateRequired(SpecVersionAttributeName, CloudEventAttributeType.String, NonEmptyString);
+
+    // Populated by the constructor.
+    private static readonly List<CloudEventsSpecVersion> allVersions = new List<CloudEventsSpecVersion>();
+
+    /// <summary>
+    /// The default <see cref="CloudEventsSpecVersion"/> produced by this version of the library.
+    /// </summary>
+    public static CloudEventsSpecVersion Default => V1_0;
+
+    /// <summary>
+    /// The <see cref="CloudEventsSpecVersion"/> for version 1.0 of the CloudEvents specification.
+    /// </summary>
+    public static CloudEventsSpecVersion V1_0 { get; } = new CloudEventsSpecVersion(
+        "1.0",
+        CreateRequired("id", CloudEventAttributeType.String, NonEmptyString),
+        CreateRequired("source", CloudEventAttributeType.UriReference, NonEmptyUriReference),
+        CreateRequired("type", CloudEventAttributeType.String, NonEmptyString),
+        CreateOptional("datacontenttype", CloudEventAttributeType.String, Rfc2046String),
+        CreateOptional("dataschema", CloudEventAttributeType.Uri, NonEmptyUriReference),
+        CreateOptional("subject", CloudEventAttributeType.String, NonEmptyString),
+        CreateOptional("time", CloudEventAttributeType.Timestamp, null));
+
+    /// <summary>
+    /// The ID of the spec version, in its canonical serialized form,
+    /// such as "1.0".
+    /// </summary>
+    public string VersionId { get; }
+
+    // TODO: Should any of these properties be nullable? What if CloudEvents 2.0 removes the Subject attribute, for example? We'd need a breaking change...
+    // (On the other hand, that's unlikely, and keeping them non-nullable is really convenient...)
+
+    /// <summary>
+    /// The attribute for the <see cref="CloudEvent.Id"/> property.
+    /// </summary>
+    public CloudEventAttribute IdAttribute { get; }
+
+    /// <summary>
+    /// The attribute for the <see cref="CloudEvent.DataContentType"/> property.
+    /// </summary>
+    public CloudEventAttribute DataContentTypeAttribute { get; }
+
+    /// <summary>
+    /// The attribute for the <see cref="CloudEvent.DataSchema"/> property.
+    /// </summary>
+    public CloudEventAttribute DataSchemaAttribute { get; }
+
+    /// <summary>
+    /// The attribute for the <see cref="CloudEvent.Source"/> property.
+    /// </summary>
+    public CloudEventAttribute SourceAttribute { get; }
+
+    /// <summary>
+    /// The attribute for the <see cref="CloudEvent.Subject"/> property.
+    /// </summary>
+    public CloudEventAttribute SubjectAttribute { get; }
+
+    /// <summary>
+    /// The attribute for the <see cref="CloudEvent.Time"/> property.
+    /// </summary>
+    public CloudEventAttribute TimeAttribute { get; }
+
+    /// <summary>
+    /// The attribute for the <see cref="CloudEvent.Type"/> property.
+    /// </summary>
+    public CloudEventAttribute TypeAttribute { get; }
+
+    private readonly Dictionary<string, CloudEventAttribute> attributesByName;
+
+    // TODO: What's the compatibility story? What might be in 1.1, and how would we handle that in 1.0?
+
+    /// <summary>
+    /// Returns the CloudEvents spec version for the given version ID (e.g. "1.0"),
+    /// or null if no such version is known.
+    /// </summary>
+    /// <param name="versionId">The version ID to check. May be null, in which case the result will be null.</param>
+    [return: NotNullIfNotNull(nameof(VersionId))]
+    public static CloudEventsSpecVersion? FromVersionId(string? versionId) =>
+        allVersions.FirstOrDefault(version => version.VersionId == versionId);
+
+    private CloudEventsSpecVersion(
+        string versionId,
+        CloudEventAttribute idAttribute,
+        CloudEventAttribute sourceAttribute,
+        CloudEventAttribute typeAttribute,
+        CloudEventAttribute dataContentTypeAttribute,
+        CloudEventAttribute dataSchemaAttribute,
+        CloudEventAttribute subjectAttribute,
+        CloudEventAttribute timeAttribute)
     {
-        internal const string SpecVersionAttributeName = "specversion";
+        VersionId = versionId;
+        IdAttribute = idAttribute;
+        SourceAttribute = sourceAttribute;
+        TypeAttribute = typeAttribute;
+        DataContentTypeAttribute = dataContentTypeAttribute;
+        DataSchemaAttribute = dataSchemaAttribute;
+        SubjectAttribute = subjectAttribute;
+        TimeAttribute = timeAttribute;
 
-        /// <summary>
-        /// The attribute used to indicate the version of the CloudEvents specification being used.
-        /// </summary>
-        public static CloudEventAttribute SpecVersionAttribute { get; } = CreateRequired(SpecVersionAttributeName, CloudEventAttributeType.String, NonEmptyString);
-
-        // Populated by the constructor.
-        private static readonly List<CloudEventsSpecVersion> allVersions = new List<CloudEventsSpecVersion>();
-
-        /// <summary>
-        /// The default <see cref="CloudEventsSpecVersion"/> produced by this version of the library.
-        /// </summary>
-        public static CloudEventsSpecVersion Default => V1_0;
-
-        /// <summary>
-        /// The <see cref="CloudEventsSpecVersion"/> for version 1.0 of the CloudEvents specification.
-        /// </summary>
-        public static CloudEventsSpecVersion V1_0 { get; } = new CloudEventsSpecVersion(
-            "1.0",
-            CreateRequired("id", CloudEventAttributeType.String, NonEmptyString),
-            CreateRequired("source", CloudEventAttributeType.UriReference, NonEmptyUriReference),
-            CreateRequired("type", CloudEventAttributeType.String, NonEmptyString),
-            CreateOptional("datacontenttype", CloudEventAttributeType.String, Rfc2046String),
-            CreateOptional("dataschema", CloudEventAttributeType.Uri, NonEmptyUriReference),
-            CreateOptional("subject", CloudEventAttributeType.String, NonEmptyString),
-            CreateOptional("time", CloudEventAttributeType.Timestamp, null));
-
-        /// <summary>
-        /// The ID of the spec version, in its canonical serialized form,
-        /// such as "1.0".
-        /// </summary>
-        public string VersionId { get; }
-
-        // TODO: Should any of these properties be nullable? What if CloudEvents 2.0 removes the Subject attribute, for example? We'd need a breaking change...
-        // (On the other hand, that's unlikely, and keeping them non-nullable is really convenient...)
-
-        /// <summary>
-        /// The attribute for the <see cref="CloudEvent.Id"/> property.
-        /// </summary>
-        public CloudEventAttribute IdAttribute { get; }
-
-        /// <summary>
-        /// The attribute for the <see cref="CloudEvent.DataContentType"/> property.
-        /// </summary>
-        public CloudEventAttribute DataContentTypeAttribute { get; }
-
-        /// <summary>
-        /// The attribute for the <see cref="CloudEvent.DataSchema"/> property.
-        /// </summary>
-        public CloudEventAttribute DataSchemaAttribute { get; }
-
-        /// <summary>
-        /// The attribute for the <see cref="CloudEvent.Source"/> property.
-        /// </summary>
-        public CloudEventAttribute SourceAttribute { get; }
-
-        /// <summary>
-        /// The attribute for the <see cref="CloudEvent.Subject"/> property.
-        /// </summary>
-        public CloudEventAttribute SubjectAttribute { get; }
-
-        /// <summary>
-        /// The attribute for the <see cref="CloudEvent.Time"/> property.
-        /// </summary>
-        public CloudEventAttribute TimeAttribute { get; }
-
-        /// <summary>
-        /// The attribute for the <see cref="CloudEvent.Type"/> property.
-        /// </summary>
-        public CloudEventAttribute TypeAttribute { get; }
-
-        private readonly Dictionary<string, CloudEventAttribute> attributesByName;
-
-        // TODO: What's the compatibility story? What might be in 1.1, and how would we handle that in 1.0?
-
-        /// <summary>
-        /// Returns the CloudEvents spec version for the given version ID (e.g. "1.0"),
-        /// or null if no such version is known.
-        /// </summary>
-        /// <param name="versionId">The version ID to check. May be null, in which case the result will be null.</param>
-        [return: NotNullIfNotNull(nameof(VersionId))]
-        public static CloudEventsSpecVersion? FromVersionId(string? versionId) =>
-            allVersions.FirstOrDefault(version => version.VersionId == versionId);
-
-        private CloudEventsSpecVersion(
-            string versionId,
-            CloudEventAttribute idAttribute,
-            CloudEventAttribute sourceAttribute,
-            CloudEventAttribute typeAttribute,
-            CloudEventAttribute dataContentTypeAttribute,
-            CloudEventAttribute dataSchemaAttribute,
-            CloudEventAttribute subjectAttribute,
-            CloudEventAttribute timeAttribute)
+        var allAttributes = new[]
         {
-            VersionId = versionId;
-            IdAttribute = idAttribute;
-            SourceAttribute = sourceAttribute;
-            TypeAttribute = typeAttribute;
-            DataContentTypeAttribute = dataContentTypeAttribute;
-            DataSchemaAttribute = dataSchemaAttribute;
-            SubjectAttribute = subjectAttribute;
-            TimeAttribute = timeAttribute;
-
-            var allAttributes = new[]
-            {
                 idAttribute, sourceAttribute, typeAttribute, dataContentTypeAttribute,
                 dataSchemaAttribute, subjectAttribute, timeAttribute
             };
-            RequiredAttributes = allAttributes.Where(a => a.IsRequired).ToList().AsReadOnly();
-            OptionalAttributes = allAttributes.Where(a => !a.IsRequired).ToList().AsReadOnly();
-            AllAttributes = RequiredAttributes.Concat(OptionalAttributes).ToList().AsReadOnly();
-            attributesByName = AllAttributes.ToDictionary(attr => attr.Name);
-            allVersions.Add(this);
-        }
+        RequiredAttributes = allAttributes.Where(a => a.IsRequired).ToList().AsReadOnly();
+        OptionalAttributes = allAttributes.Where(a => !a.IsRequired).ToList().AsReadOnly();
+        AllAttributes = RequiredAttributes.Concat(OptionalAttributes).ToList().AsReadOnly();
+        attributesByName = AllAttributes.ToDictionary(attr => attr.Name);
+        allVersions.Add(this);
+    }
 
-        /// <summary>
-        /// Returns the attribute with the given name, or null if this
-        /// spec version does not contain any such attribute.
-        /// </summary>
-        /// <param name="name">The name of the attribute to find.</param>
-        /// <returns>The attribute with the given name, or null if this spec version does not contain any such attribute.</returns>
-        internal CloudEventAttribute? GetAttributeByName(string name) => attributesByName.GetValueOrDefault(name);
+    /// <summary>
+    /// Returns the attribute with the given name, or null if this
+    /// spec version does not contain any such attribute.
+    /// </summary>
+    /// <param name="name">The name of the attribute to find.</param>
+    /// <returns>The attribute with the given name, or null if this spec version does not contain any such attribute.</returns>
+    internal CloudEventAttribute? GetAttributeByName(string name) => attributesByName.GetValueOrDefault(name);
 
-        /// <summary>
-        /// Returns all required attributes in this version of the CloudEvents specification.
-        /// </summary>
-        public IEnumerable<CloudEventAttribute> RequiredAttributes { get; }
+    /// <summary>
+    /// Returns all required attributes in this version of the CloudEvents specification.
+    /// </summary>
+    public IEnumerable<CloudEventAttribute> RequiredAttributes { get; }
 
-        /// <summary>
-        /// Returns all optional, non-extension attributes in this version of the CloudEvents specification.
-        /// </summary>
-        public IEnumerable<CloudEventAttribute> OptionalAttributes { get; }
+    /// <summary>
+    /// Returns all optional, non-extension attributes in this version of the CloudEvents specification.
+    /// </summary>
+    public IEnumerable<CloudEventAttribute> OptionalAttributes { get; }
 
-        /// <summary>
-        /// Returns all the non-extension attributes in this version of the CloudEvents specification.
-        /// All required attributes are returned before optional attributes.
-        /// </summary>
-        public IEnumerable<CloudEventAttribute> AllAttributes { get; }
+    /// <summary>
+    /// Returns all the non-extension attributes in this version of the CloudEvents specification.
+    /// All required attributes are returned before optional attributes.
+    /// </summary>
+    public IEnumerable<CloudEventAttribute> AllAttributes { get; }
 
-        private static void NonEmptyString(object value)
+    private static void NonEmptyString(object value)
+    {
+        string text = (string) value;
+        if (text.Length == 0)
         {
-            string text = (string) value;
-            if (text.Length == 0)
-            {
-                throw new ArgumentException("Value must be non-empty");
-            }
+            throw new ArgumentException("Value must be non-empty");
         }
+    }
 
-        private static void NonEmptyUriReference(object value)
+    private static void NonEmptyUriReference(object value)
+    {
+        Uri uri = (Uri) value;
+        if (uri.OriginalString.Length == 0)
         {
-            Uri uri = (Uri) value;
-            if (uri.OriginalString.Length == 0)
-            {
-                throw new ArgumentException("URI reference must be non-empty");
-            }
+            throw new ArgumentException("URI reference must be non-empty");
         }
+    }
 
-        private static void Rfc2046String(object value)
+    private static void Rfc2046String(object value)
+    {
+        try
         {
-            try
-            {
-                _ = new ContentType((string) value);
-            }
-            catch
-            {
-                throw new ArgumentException(Strings.ErrorContentTypeIsNotRFC2046);
-            }
+            _ = new ContentType((string) value);
+        }
+        catch
+        {
+            throw new ArgumentException(Strings.ErrorContentTypeIsNotRFC2046);
         }
     }
 }

--- a/src/CloudNative.CloudEvents/CollectionExtensions.cs
+++ b/src/CloudNative.CloudEvents/CollectionExtensions.cs
@@ -4,17 +4,16 @@
 
 using System.Collections.Generic;
 
-namespace CloudNative.CloudEvents
+namespace CloudNative.CloudEvents;
+
+/// <summary>
+/// Extension methods on collections. Some of these already exist in newer
+/// framework versions.
+/// </summary>
+internal static class CollectionExtensions
 {
-    /// <summary>
-    /// Extension methods on collections. Some of these already exist in newer
-    /// framework versions.
-    /// </summary>
-    internal static class CollectionExtensions
-    {
-        // Note: this is a bit more specialized than the versoin in the framework, to make defaulting simpler to handle.
-        internal static TValue? GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key)
-            where TValue : class =>
-            dictionary.TryGetValue(key, out var value) ? value : default(TValue?);
-    }
+    // Note: this is a bit more specialized than the versoin in the framework, to make defaulting simpler to handle.
+    internal static TValue? GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key)
+        where TValue : class =>
+        dictionary.TryGetValue(key, out var value) ? value : default(TValue?);
 }

--- a/src/CloudNative.CloudEvents/ContentMode.cs
+++ b/src/CloudNative.CloudEvents/ContentMode.cs
@@ -2,20 +2,19 @@
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
-namespace CloudNative.CloudEvents
+namespace CloudNative.CloudEvents;
+
+/// <summary>
+/// ContentMode enumeration for protocol bindings.
+/// </summary>
+public enum ContentMode
 {
     /// <summary>
-    /// ContentMode enumeration for protocol bindings.
+    /// Structured mode. The complete CloudEvent is contained in the transport body
     /// </summary>
-    public enum ContentMode
-    {
-        /// <summary>
-        /// Structured mode. The complete CloudEvent is contained in the transport body
-        /// </summary>
-        Structured,
-        /// <summary>
-        /// Binary mode. The CloudEvent is projected onto the transport frame
-        /// </summary>
-        Binary
-    }
+    Structured,
+    /// <summary>
+    /// Binary mode. The CloudEvent is projected onto the transport frame
+    /// </summary>
+    Binary
 }

--- a/src/CloudNative.CloudEvents/Core/BinaryDataUtilities.cs
+++ b/src/CloudNative.CloudEvents/Core/BinaryDataUtilities.cs
@@ -8,124 +8,123 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace CloudNative.CloudEvents.Core
+namespace CloudNative.CloudEvents.Core;
+
+/// <summary>
+/// Utilities methods for dealing with binary data, converting between
+/// streams, arrays, Memory{T} etc.
+/// </summary>
+public static class BinaryDataUtilities
 {
     /// <summary>
-    /// Utilities methods for dealing with binary data, converting between
-    /// streams, arrays, Memory{T} etc.
+    /// Asynchronously consumes the remaining content of the given stream, returning
+    /// it as a read-only memory segment.
     /// </summary>
-    public static class BinaryDataUtilities
+    /// <param name="stream">The stream to read from. Must not be null.</param>
+    /// <returns>The content of the stream (from its original position), as a read-only memory segment.</returns>
+    public static async Task<ReadOnlyMemory<byte>> ToReadOnlyMemoryAsync(Stream stream)
     {
-        /// <summary>
-        /// Asynchronously consumes the remaining content of the given stream, returning
-        /// it as a read-only memory segment.
-        /// </summary>
-        /// <param name="stream">The stream to read from. Must not be null.</param>
-        /// <returns>The content of the stream (from its original position), as a read-only memory segment.</returns>
-        public static async Task<ReadOnlyMemory<byte>> ToReadOnlyMemoryAsync(Stream stream)
-        {
-            Validation.CheckNotNull(stream, nameof(stream));
-            // TODO: Optimize if it's already a MemoryStream? Will only work in some cases,
-            // and is most likely to occur in tests, where the efficiency doesn't matter as much.
-            var memory = new MemoryStream();
-            await stream.CopyToAsync(memory).ConfigureAwait(false);
-            // It's safe to use memory.GetBuffer() and memory.Position here, as this is a stream
-            // we've created using the parameterless constructor.
-            var buffer = memory.GetBuffer();
-            return new ReadOnlyMemory<byte>(buffer, 0, (int) memory.Position);
-        }
-
-        /// <summary>
-        /// Consumes the remaining content of the given stream, returning
-        /// it as a read-only memory segment.
-        /// </summary>
-        /// <param name="stream">The stream to read from. Must not be null.</param>
-        /// <returns>The content of the stream (from its original position), as a read-only memory segment.</returns>
-        public static ReadOnlyMemory<byte> ToReadOnlyMemory(Stream stream)
-        {
-            Validation.CheckNotNull(stream, nameof(stream));
-            // TODO: Optimize if it's already a MemoryStream? Will only work in some cases,
-            // and is most likely to occur in tests, where the efficiency doesn't matter as much.
-            var memory = new MemoryStream();
-            stream.CopyTo(memory);
-            // It's safe to use memory.GetBuffer() and memory.Position here, as this is a stream
-            // we've created using the parameterless constructor.
-            var buffer = memory.GetBuffer();
-            return new ReadOnlyMemory<byte>(buffer, 0, (int) memory.Position);
-        }
-
-        /// <summary>
-        /// Returns a read-only <see cref="MemoryStream"/> view over the given memory where
-        /// possible, or over a copy of the data if the memory cannot be read as an array segment.
-        /// This method should be used with care, due to the "sometimes shared, sometimes not"
-        /// nature of the result.
-        /// </summary>
-        /// <param name="memory">The memory to create a stream view over.</param>
-        /// <returns>A read-only stream view over <paramref name="memory"/>.</returns>
-        public static MemoryStream AsStream(ReadOnlyMemory<byte> memory)
-        {
-            var segment = GetArraySegment(memory);
-            return new MemoryStream(segment.Array!, segment.Offset, segment.Count, false);
-        }
-
-        /// <summary>
-        /// Decodes the given memory as a string, using the specified encoding.
-        /// </summary>
-        /// <param name="memory">The memory to decode.</param>
-        /// <param name="encoding">The encoding to use. Must not be null.</param>
-        public static string GetString(ReadOnlyMemory<byte> memory, Encoding encoding)
-        {
-            Validation.CheckNotNull(encoding, nameof(encoding));
-
-            // TODO: If we introduce an additional netstandard2.1 target, we can use encoding.GetString(memory.Span)
-            var segment = GetArraySegment(memory);
-            return encoding.GetString(segment.Array!, segment.Offset, segment.Count);
-        }
-
-        /// <summary>
-        /// Copies the given memory to a stream, asynchronously.
-        /// </summary>
-        /// <param name="source">The source memory to copy from.</param>
-        /// <param name="destination">The stream to copy to. Must not be null.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        public static async Task CopyToStreamAsync(ReadOnlyMemory<byte> source, Stream destination)
-        {
-            Validation.CheckNotNull(destination, nameof(destination));
-            var segment = GetArraySegment(source);
-            await destination.WriteAsync(segment.Array!, segment.Offset, segment.Count).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Returns the data from <paramref name="memory"/> as a byte array, return the underlying array
-        /// if there is one, or creating a copy otherwise. This method should be used with care, due to the
-        /// "sometimes shared, sometimes not" nature of the result. (It is generally safe to use this with the result
-        /// of encoding a CloudEvent, assuming the same memory is not used elsewhere.)
-        /// </summary>
-        /// <param name="memory">The memory to obtain the data from.</param>
-        /// <returns>The data in <paramref name="memory"/> as an array.</returns>
-        public static byte[] AsArray(ReadOnlyMemory<byte> memory)
-        {
-            var segment = GetArraySegment(memory);
-            // We probably don't actually need to check the offset: if the count is the same as the length,
-            // I can't see how the offset can be non-zero. But it doesn't *hurt* as a check.
-            return segment.Offset == 0 && segment.Count == segment.Array!.Length
-                ? segment.Array
-                : memory.ToArray();
-        }
-
-        // Note: when this returns, the Array property of the returned segment is guaranteed not to be null.
-
-        /// <summary>
-        /// Returns the data from <paramref name="memory"/> as a byte array, return the underlying array
-        /// if there is one, or creating a copy otherwise. This method should be used with care, due to the
-        /// "sometimes shared, sometimes not" nature of the result. (It is generally safe to use this with the result
-        /// of encoding a CloudEvent, assuming the same memory is not used elsewhere.)
-        /// </summary>
-        /// <param name="memory">The memory to obtain the data from.</param>
-        /// <returns>The data in <paramref name="memory"/> as an array segment.</returns>
-        public static ArraySegment<byte> GetArraySegment(ReadOnlyMemory<byte> memory) =>
-            MemoryMarshal.TryGetArray(memory, out var segment) && segment.Array is not null
-                ? segment
-                : new ArraySegment<byte>(memory.ToArray());
+        Validation.CheckNotNull(stream, nameof(stream));
+        // TODO: Optimize if it's already a MemoryStream? Will only work in some cases,
+        // and is most likely to occur in tests, where the efficiency doesn't matter as much.
+        var memory = new MemoryStream();
+        await stream.CopyToAsync(memory).ConfigureAwait(false);
+        // It's safe to use memory.GetBuffer() and memory.Position here, as this is a stream
+        // we've created using the parameterless constructor.
+        var buffer = memory.GetBuffer();
+        return new ReadOnlyMemory<byte>(buffer, 0, (int) memory.Position);
     }
+
+    /// <summary>
+    /// Consumes the remaining content of the given stream, returning
+    /// it as a read-only memory segment.
+    /// </summary>
+    /// <param name="stream">The stream to read from. Must not be null.</param>
+    /// <returns>The content of the stream (from its original position), as a read-only memory segment.</returns>
+    public static ReadOnlyMemory<byte> ToReadOnlyMemory(Stream stream)
+    {
+        Validation.CheckNotNull(stream, nameof(stream));
+        // TODO: Optimize if it's already a MemoryStream? Will only work in some cases,
+        // and is most likely to occur in tests, where the efficiency doesn't matter as much.
+        var memory = new MemoryStream();
+        stream.CopyTo(memory);
+        // It's safe to use memory.GetBuffer() and memory.Position here, as this is a stream
+        // we've created using the parameterless constructor.
+        var buffer = memory.GetBuffer();
+        return new ReadOnlyMemory<byte>(buffer, 0, (int) memory.Position);
+    }
+
+    /// <summary>
+    /// Returns a read-only <see cref="MemoryStream"/> view over the given memory where
+    /// possible, or over a copy of the data if the memory cannot be read as an array segment.
+    /// This method should be used with care, due to the "sometimes shared, sometimes not"
+    /// nature of the result.
+    /// </summary>
+    /// <param name="memory">The memory to create a stream view over.</param>
+    /// <returns>A read-only stream view over <paramref name="memory"/>.</returns>
+    public static MemoryStream AsStream(ReadOnlyMemory<byte> memory)
+    {
+        var segment = GetArraySegment(memory);
+        return new MemoryStream(segment.Array!, segment.Offset, segment.Count, false);
+    }
+
+    /// <summary>
+    /// Decodes the given memory as a string, using the specified encoding.
+    /// </summary>
+    /// <param name="memory">The memory to decode.</param>
+    /// <param name="encoding">The encoding to use. Must not be null.</param>
+    public static string GetString(ReadOnlyMemory<byte> memory, Encoding encoding)
+    {
+        Validation.CheckNotNull(encoding, nameof(encoding));
+
+        // TODO: If we introduce an additional netstandard2.1 target, we can use encoding.GetString(memory.Span)
+        var segment = GetArraySegment(memory);
+        return encoding.GetString(segment.Array!, segment.Offset, segment.Count);
+    }
+
+    /// <summary>
+    /// Copies the given memory to a stream, asynchronously.
+    /// </summary>
+    /// <param name="source">The source memory to copy from.</param>
+    /// <param name="destination">The stream to copy to. Must not be null.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task CopyToStreamAsync(ReadOnlyMemory<byte> source, Stream destination)
+    {
+        Validation.CheckNotNull(destination, nameof(destination));
+        var segment = GetArraySegment(source);
+        await destination.WriteAsync(segment.Array!, segment.Offset, segment.Count).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the data from <paramref name="memory"/> as a byte array, return the underlying array
+    /// if there is one, or creating a copy otherwise. This method should be used with care, due to the
+    /// "sometimes shared, sometimes not" nature of the result. (It is generally safe to use this with the result
+    /// of encoding a CloudEvent, assuming the same memory is not used elsewhere.)
+    /// </summary>
+    /// <param name="memory">The memory to obtain the data from.</param>
+    /// <returns>The data in <paramref name="memory"/> as an array.</returns>
+    public static byte[] AsArray(ReadOnlyMemory<byte> memory)
+    {
+        var segment = GetArraySegment(memory);
+        // We probably don't actually need to check the offset: if the count is the same as the length,
+        // I can't see how the offset can be non-zero. But it doesn't *hurt* as a check.
+        return segment.Offset == 0 && segment.Count == segment.Array!.Length
+            ? segment.Array
+            : memory.ToArray();
+    }
+
+    // Note: when this returns, the Array property of the returned segment is guaranteed not to be null.
+
+    /// <summary>
+    /// Returns the data from <paramref name="memory"/> as a byte array, return the underlying array
+    /// if there is one, or creating a copy otherwise. This method should be used with care, due to the
+    /// "sometimes shared, sometimes not" nature of the result. (It is generally safe to use this with the result
+    /// of encoding a CloudEvent, assuming the same memory is not used elsewhere.)
+    /// </summary>
+    /// <param name="memory">The memory to obtain the data from.</param>
+    /// <returns>The data in <paramref name="memory"/> as an array segment.</returns>
+    public static ArraySegment<byte> GetArraySegment(ReadOnlyMemory<byte> memory) =>
+        MemoryMarshal.TryGetArray(memory, out var segment) && segment.Array is not null
+            ? segment
+            : new ArraySegment<byte>(memory.ToArray());
 }

--- a/src/CloudNative.CloudEvents/Core/CloudEventAttributeTypeOrdinal.cs
+++ b/src/CloudNative.CloudEvents/Core/CloudEventAttributeTypeOrdinal.cs
@@ -2,46 +2,45 @@
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
-namespace CloudNative.CloudEvents.Core
-{
-    /// <summary>
-    /// Enum of attribute types, to allow efficient switching over <see cref="CloudEventAttributeType"/>.
-    /// Each attribute type has a unique value, returned by <see cref="CloudEventAttributeType.Ordinal"/>.
-    /// </summary>
-    /// <remarks>
-    /// This type is in the "Core" namespace and exposed via CloudEventAttributeTypes as relatively few consumers will need to use it.
-    /// </remarks>
-    public enum CloudEventAttributeTypeOrdinal
-    {
-        // Note: changing the values here is a breaking change.
+namespace CloudNative.CloudEvents.Core;
 
-        /// <summary>
-        /// Ordinal for <see cref="CloudEventAttributeType.Binary"/>
-        /// </summary>
-        Binary = 0,
-        /// <summary>
-        /// Ordinal for <see cref="CloudEventAttributeType.Boolean"/>
-        /// </summary>
-        Boolean = 1,
-        /// <summary>
-        /// Ordinal for <see cref="CloudEventAttributeType.Integer"/>
-        /// </summary>
-        Integer = 2,
-        /// <summary>
-        /// Ordinal for <see cref="CloudEventAttributeType.String"/>
-        /// </summary>
-        String = 3,
-        /// <summary>
-        /// Ordinal for <see cref="CloudEventAttributeType.Uri"/>
-        /// </summary>
-        Uri = 4,
-        /// <summary>
-        /// Ordinal for <see cref="CloudEventAttributeType.UriReference"/>
-        /// </summary>
-        UriReference = 5,
-        /// <summary>
-        /// Ordinal for <see cref="CloudEventAttributeType.Timestamp"/>
-        /// </summary>
-        Timestamp = 6
-    }
+/// <summary>
+/// Enum of attribute types, to allow efficient switching over <see cref="CloudEventAttributeType"/>.
+/// Each attribute type has a unique value, returned by <see cref="CloudEventAttributeType.Ordinal"/>.
+/// </summary>
+/// <remarks>
+/// This type is in the "Core" namespace and exposed via CloudEventAttributeTypes as relatively few consumers will need to use it.
+/// </remarks>
+public enum CloudEventAttributeTypeOrdinal
+{
+    // Note: changing the values here is a breaking change.
+
+    /// <summary>
+    /// Ordinal for <see cref="CloudEventAttributeType.Binary"/>
+    /// </summary>
+    Binary = 0,
+    /// <summary>
+    /// Ordinal for <see cref="CloudEventAttributeType.Boolean"/>
+    /// </summary>
+    Boolean = 1,
+    /// <summary>
+    /// Ordinal for <see cref="CloudEventAttributeType.Integer"/>
+    /// </summary>
+    Integer = 2,
+    /// <summary>
+    /// Ordinal for <see cref="CloudEventAttributeType.String"/>
+    /// </summary>
+    String = 3,
+    /// <summary>
+    /// Ordinal for <see cref="CloudEventAttributeType.Uri"/>
+    /// </summary>
+    Uri = 4,
+    /// <summary>
+    /// Ordinal for <see cref="CloudEventAttributeType.UriReference"/>
+    /// </summary>
+    UriReference = 5,
+    /// <summary>
+    /// Ordinal for <see cref="CloudEventAttributeType.Timestamp"/>
+    /// </summary>
+    Timestamp = 6
 }

--- a/src/CloudNative.CloudEvents/Core/CloudEventAttributeTypes.cs
+++ b/src/CloudNative.CloudEvents/Core/CloudEventAttributeTypes.cs
@@ -2,25 +2,24 @@
 // Licensed under the Apache 2.0 license.
 // See LICENSE file in the project root for full license information.
 
-namespace CloudNative.CloudEvents.Core
+namespace CloudNative.CloudEvents.Core;
+
+/// <summary>
+/// Utility methods for working with <see cref="CloudEventAttributeType"/>, in contexts
+/// where the functionality is required by formatter/protocol binding implementations,
+/// but we want to obscure it from other users.
+/// </summary>
+public static class CloudEventAttributeTypes
 {
     /// <summary>
-    /// Utility methods for working with <see cref="CloudEventAttributeType"/>, in contexts
-    /// where the functionality is required by formatter/protocol binding implementations,
-    /// but we want to obscure it from other users.
+    /// Returns the <see cref="CloudEventAttributeTypeOrdinal"/> associated with <paramref name="type"/>,
+    /// for convenient switching over attribute types.
     /// </summary>
-    public static class CloudEventAttributeTypes
+    /// <param name="type">The attribute type. Must not be null.</param>
+    /// <returns>The ordinal enum value associated with the attribute type.</returns>
+    public static CloudEventAttributeTypeOrdinal GetOrdinal(CloudEventAttributeType type)
     {
-        /// <summary>
-        /// Returns the <see cref="CloudEventAttributeTypeOrdinal"/> associated with <paramref name="type"/>,
-        /// for convenient switching over attribute types.
-        /// </summary>
-        /// <param name="type">The attribute type. Must not be null.</param>
-        /// <returns>The ordinal enum value associated with the attribute type.</returns>
-        public static CloudEventAttributeTypeOrdinal GetOrdinal(CloudEventAttributeType type)
-        {
-            Validation.CheckNotNull(type, nameof(type));
-            return type.Ordinal;
-        }
+        Validation.CheckNotNull(type, nameof(type));
+        return type.Ordinal;
     }
 }

--- a/src/CloudNative.CloudEvents/Core/MimeUtilities.cs
+++ b/src/CloudNative.CloudEvents/Core/MimeUtilities.cs
@@ -8,86 +8,85 @@ using System.Net.Http.Headers;
 using System.Net.Mime;
 using System.Text;
 
-namespace CloudNative.CloudEvents.Core
+namespace CloudNative.CloudEvents.Core;
+
+/// <summary>
+/// Utility methods around MIME.
+/// </summary>
+public static class MimeUtilities
 {
     /// <summary>
-    /// Utility methods around MIME.
+    /// The media type (also known as MIME type) for CloudEvents. Related media types
+    /// (e.g. for a batch of CloudEvents, or with a specific format) usually begin with this string.
     /// </summary>
-    public static class MimeUtilities
+    public static string MediaType { get; } = "application/cloudevents";
+
+    /// <summary>
+    /// The media type to use for batch mode. This is usually suffixed with a format-specific
+    /// type, e.g. "+json".
+    /// </summary>
+    public static string BatchMediaType { get; } = MediaType + "-batch";
+
+    /// <summary>
+    /// Returns an encoding from a content type, defaulting to UTF-8.
+    /// </summary>
+    /// <param name="contentType">The content type, or null if no content type is known.</param>
+    /// <returns>An encoding suitable for the charset specified in <paramref name="contentType"/>,
+    /// or UTF-8 if no charset has been specified.</returns>
+    public static Encoding GetEncoding(ContentType? contentType) =>
+        contentType?.CharSet is string charSet ? Encoding.GetEncoding(charSet) : Encoding.UTF8;
+
+    /// <summary>
+    /// Converts a <see cref="MediaTypeHeaderValue"/> into a <see cref="ContentType"/>.
+    /// </summary>
+    /// <param name="headerValue">The header value to convert. May be null.</param>
+    /// <returns>The converted content type, or null if <paramref name="headerValue"/> is null.</returns>
+    public static ContentType? ToContentType(MediaTypeHeaderValue? headerValue) =>
+        headerValue is null ? null : new ContentType(headerValue.ToString());
+
+    /// <summary>
+    /// Converts a <see cref="ContentType"/> into a <see cref="MediaTypeHeaderValue"/>.
+    /// </summary>
+    /// <param name="contentType">The content type to convert. May be null.</param>
+    /// <returns>The converted media type header value, or null if <paramref name="contentType"/> is null.</returns>
+    public static MediaTypeHeaderValue? ToMediaTypeHeaderValue(ContentType? contentType)
     {
-        /// <summary>
-        /// The media type (also known as MIME type) for CloudEvents. Related media types
-        /// (e.g. for a batch of CloudEvents, or with a specific format) usually begin with this string.
-        /// </summary>
-        public static string MediaType { get; } = "application/cloudevents";
-
-        /// <summary>
-        /// The media type to use for batch mode. This is usually suffixed with a format-specific
-        /// type, e.g. "+json".
-        /// </summary>
-        public static string BatchMediaType { get; } = MediaType + "-batch";
-
-        /// <summary>
-        /// Returns an encoding from a content type, defaulting to UTF-8.
-        /// </summary>
-        /// <param name="contentType">The content type, or null if no content type is known.</param>
-        /// <returns>An encoding suitable for the charset specified in <paramref name="contentType"/>,
-        /// or UTF-8 if no charset has been specified.</returns>
-        public static Encoding GetEncoding(ContentType? contentType) =>
-            contentType?.CharSet is string charSet ? Encoding.GetEncoding(charSet) : Encoding.UTF8;
-
-        /// <summary>
-        /// Converts a <see cref="MediaTypeHeaderValue"/> into a <see cref="ContentType"/>.
-        /// </summary>
-        /// <param name="headerValue">The header value to convert. May be null.</param>
-        /// <returns>The converted content type, or null if <paramref name="headerValue"/> is null.</returns>
-        public static ContentType? ToContentType(MediaTypeHeaderValue? headerValue) =>
-            headerValue is null ? null : new ContentType(headerValue.ToString());
-
-        /// <summary>
-        /// Converts a <see cref="ContentType"/> into a <see cref="MediaTypeHeaderValue"/>.
-        /// </summary>
-        /// <param name="contentType">The content type to convert. May be null.</param>
-        /// <returns>The converted media type header value, or null if <paramref name="contentType"/> is null.</returns>
-        public static MediaTypeHeaderValue? ToMediaTypeHeaderValue(ContentType? contentType)
+        if (contentType is null)
         {
-            if (contentType is null)
-            {
-                return null;
-            }
-            var header = new MediaTypeHeaderValue(contentType.MediaType);
-            foreach (string parameterName in contentType.Parameters.Keys)
-            {
-                header.Parameters.Add(new NameValueHeaderValue(parameterName, contentType.Parameters[parameterName]));
-            }
-            return header;
+            return null;
         }
-
-        /// <summary>
-        /// Creates a <see cref="ContentType"/> from the given value, or returns null
-        /// if the input is null.
-        /// </summary>
-        /// <param name="contentType">The content type textual value. May be null.</param>
-        /// <returns>The converted content type, or null if <paramref name="contentType"/> is null.</returns>
-        public static ContentType? CreateContentTypeOrNull(string? contentType) =>
-            contentType is null ? null : new ContentType(contentType);
-
-        /// <summary>
-        /// Determines whether the given content type denotes a (non-batch) CloudEvent.
-        /// </summary>
-        /// <param name="contentType">The content type to check. May be null, in which case the result is false.</param>
-        /// <returns>true if the given content type denotes a (non-batch) CloudEvent; false otherwise</returns>
-        public static bool IsCloudEventsContentType([NotNullWhen(true)] string? contentType) =>
-            contentType is string &&
-            contentType.StartsWith(MediaType, StringComparison.InvariantCultureIgnoreCase) &&
-            !contentType.StartsWith(BatchMediaType, StringComparison.InvariantCultureIgnoreCase);
-
-        /// <summary>
-        /// Determines whether the given content type denotes a CloudEvent batch.
-        /// </summary>
-        /// <param name="contentType">The content type to check. May be null, in which case the result is false.</param>
-        /// <returns>true if the given content type represents a CloudEvent batch; false otherwise</returns>
-        public static bool IsCloudEventsBatchContentType([NotNullWhen(true)] string? contentType) =>
-            contentType is string && contentType.StartsWith(BatchMediaType, StringComparison.InvariantCultureIgnoreCase);
+        var header = new MediaTypeHeaderValue(contentType.MediaType);
+        foreach (string parameterName in contentType.Parameters.Keys)
+        {
+            header.Parameters.Add(new NameValueHeaderValue(parameterName, contentType.Parameters[parameterName]));
+        }
+        return header;
     }
+
+    /// <summary>
+    /// Creates a <see cref="ContentType"/> from the given value, or returns null
+    /// if the input is null.
+    /// </summary>
+    /// <param name="contentType">The content type textual value. May be null.</param>
+    /// <returns>The converted content type, or null if <paramref name="contentType"/> is null.</returns>
+    public static ContentType? CreateContentTypeOrNull(string? contentType) =>
+        contentType is null ? null : new ContentType(contentType);
+
+    /// <summary>
+    /// Determines whether the given content type denotes a (non-batch) CloudEvent.
+    /// </summary>
+    /// <param name="contentType">The content type to check. May be null, in which case the result is false.</param>
+    /// <returns>true if the given content type denotes a (non-batch) CloudEvent; false otherwise</returns>
+    public static bool IsCloudEventsContentType([NotNullWhen(true)] string? contentType) =>
+        contentType is string &&
+        contentType.StartsWith(MediaType, StringComparison.InvariantCultureIgnoreCase) &&
+        !contentType.StartsWith(BatchMediaType, StringComparison.InvariantCultureIgnoreCase);
+
+    /// <summary>
+    /// Determines whether the given content type denotes a CloudEvent batch.
+    /// </summary>
+    /// <param name="contentType">The content type to check. May be null, in which case the result is false.</param>
+    /// <returns>true if the given content type represents a CloudEvent batch; false otherwise</returns>
+    public static bool IsCloudEventsBatchContentType([NotNullWhen(true)] string? contentType) =>
+        contentType is string && contentType.StartsWith(BatchMediaType, StringComparison.InvariantCultureIgnoreCase);
 }

--- a/src/CloudNative.CloudEvents/Core/Validation.cs
+++ b/src/CloudNative.CloudEvents/Core/Validation.cs
@@ -7,124 +7,123 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
-namespace CloudNative.CloudEvents.Core
+namespace CloudNative.CloudEvents.Core;
+
+/// <summary>
+/// Validation methods which are typically convenient for implementers of CloudEvent formatters
+/// and protocol bindings.
+/// </summary>
+public static class Validation
 {
     /// <summary>
-    /// Validation methods which are typically convenient for implementers of CloudEvent formatters
-    /// and protocol bindings.
+    /// Validates that the given reference is non-null.
     /// </summary>
-    public static class Validation
+    /// <typeparam name="T">Type of the value to check</typeparam>
+    /// <param name="value">The reference to check for nullity</param>
+    /// <param name="paramName">The parameter name to use in the exception if <paramref name="value"/> is null.
+    /// May be null.</param>
+    /// <returns>The value of <paramref name="value"/>, for convenient method chaining or assignment.</returns>
+    public static T CheckNotNull<T>(T value, string? paramName) where T : class =>
+        value ?? throw new ArgumentNullException(paramName);
+
+    /// <summary>
+    /// Validates an argument-dependent condition, throwing an exception if the check fails.
+    /// </summary>
+    /// <param name="condition">The condition to validate; this method will throw an <see cref="ArgumentException"/> if this is false.</param>
+    /// <param name="paramName">The name of the parameter being validated. May be null.</param>
+    /// <param name="message">The message to use in the exception, if one is thrown.</param>
+    public static void CheckArgument([DoesNotReturnIf(false)] bool condition, string paramName, string message)
     {
-        /// <summary>
-        /// Validates that the given reference is non-null.
-        /// </summary>
-        /// <typeparam name="T">Type of the value to check</typeparam>
-        /// <param name="value">The reference to check for nullity</param>
-        /// <param name="paramName">The parameter name to use in the exception if <paramref name="value"/> is null.
-        /// May be null.</param>
-        /// <returns>The value of <paramref name="value"/>, for convenient method chaining or assignment.</returns>
-        public static T CheckNotNull<T>(T value, string? paramName) where T : class =>
-            value ?? throw new ArgumentNullException(paramName);
-
-        /// <summary>
-        /// Validates an argument-dependent condition, throwing an exception if the check fails.
-        /// </summary>
-        /// <param name="condition">The condition to validate; this method will throw an <see cref="ArgumentException"/> if this is false.</param>
-        /// <param name="paramName">The name of the parameter being validated. May be null.</param>
-        /// <param name="message">The message to use in the exception, if one is thrown.</param>
-        public static void CheckArgument([DoesNotReturnIf(false)] bool condition, string paramName, string message)
+        if (!condition)
         {
-            if (!condition)
-            {
-                throw new ArgumentException(message, paramName);
-            }
+            throw new ArgumentException(message, paramName);
         }
+    }
 
-        /// <summary>
-        /// Validates an argument-dependent condition, throwing an exception if the check fails.
-        /// </summary>
-        /// <param name="condition">The condition to validate; this method will throw an <see cref="ArgumentException"/> if this is false.</param>
-        /// <param name="paramName">The name of the parameter being validated. May be null.</param>
-        /// <param name="messageFunc">A func that returns the message to use in the exception, if one is thrown.</param>
-        internal static void CheckArgument([DoesNotReturnIf(false)] bool condition, string paramName, Func<string> messageFunc)
+    /// <summary>
+    /// Validates an argument-dependent condition, throwing an exception if the check fails.
+    /// </summary>
+    /// <param name="condition">The condition to validate; this method will throw an <see cref="ArgumentException"/> if this is false.</param>
+    /// <param name="paramName">The name of the parameter being validated. May be null.</param>
+    /// <param name="messageFunc">A func that returns the message to use in the exception, if one is thrown.</param>
+    internal static void CheckArgument([DoesNotReturnIf(false)] bool condition, string paramName, Func<string> messageFunc)
+    {
+        if (!condition)
         {
-            if (!condition)
-            {
-                throw new ArgumentException(messageFunc(), paramName);
-            }
+            throw new ArgumentException(messageFunc(), paramName);
         }
+    }
 
-        /// <summary>
-        /// Validates an argument-dependent condition, throwing an exception if the check fails.
-        /// </summary>
-        /// <param name="condition">The condition to validate; this method will throw an <see cref="ArgumentException"/> if this is false.</param>
-        /// <param name="paramName">The name of the parameter being validated. May be null.</param>
-        /// <param name="messageFormat">The string format to use in the exception message, if one is thrown.</param>
-        /// <param name="arg1">The first argument in the string format.</param>
-        public static void CheckArgument([DoesNotReturnIf(false)] bool condition, string paramName, string messageFormat,
-            object? arg1)
+    /// <summary>
+    /// Validates an argument-dependent condition, throwing an exception if the check fails.
+    /// </summary>
+    /// <param name="condition">The condition to validate; this method will throw an <see cref="ArgumentException"/> if this is false.</param>
+    /// <param name="paramName">The name of the parameter being validated. May be null.</param>
+    /// <param name="messageFormat">The string format to use in the exception message, if one is thrown.</param>
+    /// <param name="arg1">The first argument in the string format.</param>
+    public static void CheckArgument([DoesNotReturnIf(false)] bool condition, string paramName, string messageFormat,
+        object? arg1)
+    {
+        if (!condition)
         {
-            if (!condition)
-            {
-                throw new ArgumentException(string.Format(messageFormat, arg1), paramName);
-            }
+            throw new ArgumentException(string.Format(messageFormat, arg1), paramName);
         }
+    }
 
-        /// <summary>
-        /// Validates an argument-dependent condition, throwing an exception if the check fails.
-        /// </summary>
-        /// <param name="condition">The condition to validate; this method will throw an <see cref="ArgumentException"/> if this is false.</param>
-        /// <param name="paramName">The name of the parameter being validated. May be null.</param>
-        /// <param name="messageFormat">The string format to use in the exception message, if one is thrown.</param>
-        /// <param name="arg1">The first argument in the string format.</param>
-        /// <param name="arg2">The second argument in the string format.</param>
-        public static void CheckArgument(bool condition, string paramName, string messageFormat,
-            object? arg1, object? arg2)
+    /// <summary>
+    /// Validates an argument-dependent condition, throwing an exception if the check fails.
+    /// </summary>
+    /// <param name="condition">The condition to validate; this method will throw an <see cref="ArgumentException"/> if this is false.</param>
+    /// <param name="paramName">The name of the parameter being validated. May be null.</param>
+    /// <param name="messageFormat">The string format to use in the exception message, if one is thrown.</param>
+    /// <param name="arg1">The first argument in the string format.</param>
+    /// <param name="arg2">The second argument in the string format.</param>
+    public static void CheckArgument(bool condition, string paramName, string messageFormat,
+        object? arg1, object? arg2)
+    {
+        if (!condition)
         {
-            if (!condition)
-            {
-                throw new ArgumentException(string.Format(messageFormat, arg1, arg2), paramName);
-            }
+            throw new ArgumentException(string.Format(messageFormat, arg1, arg2), paramName);
         }
+    }
 
-        /// <summary>
-        /// Validates that the specified CloudEvent is valid in the same way as <see cref="CloudEvent.IsValid"/>,
-        /// but throwing an <see cref="ArgumentException"/> using the given parameter name
-        /// if the event is invalid. This is typically used within protocol bindings or event formatters
-        /// as the last step in decoding an event, or as the first step when encoding an event.
-        /// </summary>
-        /// <param name="cloudEvent">The event to validate.</param>
-        /// <param name="paramName">The parameter name to use in the exception if <paramref name="cloudEvent"/> is null or invalid.
-        /// May be null.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="cloudEvent"/> is null.</exception>
-        /// <exception cref="ArgumentException">The event is invalid.</exception>
-        /// <returns>A reference to the same object, for simplicity of method chaining.</returns>
-        public static CloudEvent CheckCloudEventArgument(CloudEvent cloudEvent, string? paramName)
+    /// <summary>
+    /// Validates that the specified CloudEvent is valid in the same way as <see cref="CloudEvent.IsValid"/>,
+    /// but throwing an <see cref="ArgumentException"/> using the given parameter name
+    /// if the event is invalid. This is typically used within protocol bindings or event formatters
+    /// as the last step in decoding an event, or as the first step when encoding an event.
+    /// </summary>
+    /// <param name="cloudEvent">The event to validate.</param>
+    /// <param name="paramName">The parameter name to use in the exception if <paramref name="cloudEvent"/> is null or invalid.
+    /// May be null.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="cloudEvent"/> is null.</exception>
+    /// <exception cref="ArgumentException">The event is invalid.</exception>
+    /// <returns>A reference to the same object, for simplicity of method chaining.</returns>
+    public static CloudEvent CheckCloudEventArgument(CloudEvent cloudEvent, string? paramName)
+    {
+        CheckNotNull(cloudEvent, paramName);
+        if (cloudEvent.IsValid)
         {
-            CheckNotNull(cloudEvent, paramName);
-            if (cloudEvent.IsValid)
-            {
-                return cloudEvent;
-            }
-            var missing = cloudEvent.SpecVersion.RequiredAttributes.Where(attr => cloudEvent[attr] is null).ToList();
-            string joinedMissing = string.Join(", ", missing);
-            throw new ArgumentException($"CloudEvent is missing required attributes: {joinedMissing}", paramName);
+            return cloudEvent;
         }
+        var missing = cloudEvent.SpecVersion.RequiredAttributes.Where(attr => cloudEvent[attr] is null).ToList();
+        string joinedMissing = string.Join(", ", missing);
+        throw new ArgumentException($"CloudEvent is missing required attributes: {joinedMissing}", paramName);
+    }
 
-        /// <summary>
-        /// Validates that the specified batch is valid, by asserting that it is non-null,
-        /// and that it only contains non-null references to valid CloudEvents.
-        /// </summary>
-        /// <param name="cloudEvents">The event batch to validate.</param>
-        /// <param name="paramName">The parameter name to use in the exception if <paramref name="cloudEvents"/> is null or invalid.
-        /// May be null.</param>
-        public static void CheckCloudEventBatchArgument(IReadOnlyList<CloudEvent> cloudEvents, string? paramName)
+    /// <summary>
+    /// Validates that the specified batch is valid, by asserting that it is non-null,
+    /// and that it only contains non-null references to valid CloudEvents.
+    /// </summary>
+    /// <param name="cloudEvents">The event batch to validate.</param>
+    /// <param name="paramName">The parameter name to use in the exception if <paramref name="cloudEvents"/> is null or invalid.
+    /// May be null.</param>
+    public static void CheckCloudEventBatchArgument(IReadOnlyList<CloudEvent> cloudEvents, string? paramName)
+    {
+        CheckNotNull(cloudEvents, paramName);
+        foreach (var cloudEvent in cloudEvents)
         {
-            CheckNotNull(cloudEvents, paramName);
-            foreach (var cloudEvent in cloudEvents)
-            {
-                CheckCloudEventArgument(cloudEvent, paramName);
-            }
+            CheckCloudEventArgument(cloudEvent, paramName);
         }
     }
 }

--- a/src/CloudNative.CloudEvents/Extensions/Partitioning.cs
+++ b/src/CloudNative.CloudEvents/Extensions/Partitioning.cs
@@ -6,46 +6,45 @@ using CloudNative.CloudEvents.Core;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace CloudNative.CloudEvents.Extensions
+namespace CloudNative.CloudEvents.Extensions;
+
+/// <summary>
+/// Support for the <see href="https://github.com/cloudevents/spec/tree/main/cloudevents/extensions/partitioning.md">partitioning</see>
+/// CloudEvent extension.
+/// </summary>
+public static class Partitioning
 {
     /// <summary>
-    /// Support for the <see href="https://github.com/cloudevents/spec/tree/main/cloudevents/extensions/partitioning.md">partitioning</see>
-    /// CloudEvent extension.
+    /// <see cref="CloudEventAttribute"/> representing the 'partitionkey' extension attribute.
     /// </summary>
-    public static class Partitioning
+    public static CloudEventAttribute PartitionKeyAttribute { get; } =
+        CloudEventAttribute.CreateExtension("partitionkey", CloudEventAttributeType.String);
+
+    /// <summary>
+    /// A read-only sequence of all attributes related to the partitioning extension.
+    /// </summary>
+    public static IEnumerable<CloudEventAttribute> AllAttributes { get; } =
+        new[] { PartitionKeyAttribute }.ToList().AsReadOnly();
+
+    /// <summary>
+    /// Sets the <see cref="PartitionKeyAttribute"/> on the given <see cref="CloudEvent"/>.
+    /// </summary>
+    /// <param name="cloudEvent">The CloudEvent on which to set the attribute. Must not be null.</param>
+    /// <param name="partitionKey">The partition key to set. May be null, in which case the attribute is
+    /// removed from <paramref name="cloudEvent"/>.</param>
+    /// <returns><paramref name="cloudEvent"/>, for convenient method chaining.</returns>
+    public static CloudEvent SetPartitionKey(this CloudEvent cloudEvent, string? partitionKey)
     {
-        /// <summary>
-        /// <see cref="CloudEventAttribute"/> representing the 'partitionkey' extension attribute.
-        /// </summary>
-        public static CloudEventAttribute PartitionKeyAttribute { get; } =
-            CloudEventAttribute.CreateExtension("partitionkey", CloudEventAttributeType.String);
-
-        /// <summary>
-        /// A read-only sequence of all attributes related to the partitioning extension.
-        /// </summary>
-        public static IEnumerable<CloudEventAttribute> AllAttributes { get; } =
-            new[] { PartitionKeyAttribute }.ToList().AsReadOnly();
-
-        /// <summary>
-        /// Sets the <see cref="PartitionKeyAttribute"/> on the given <see cref="CloudEvent"/>.
-        /// </summary>
-        /// <param name="cloudEvent">The CloudEvent on which to set the attribute. Must not be null.</param>
-        /// <param name="partitionKey">The partition key to set. May be null, in which case the attribute is
-        /// removed from <paramref name="cloudEvent"/>.</param>
-        /// <returns><paramref name="cloudEvent"/>, for convenient method chaining.</returns>
-        public static CloudEvent SetPartitionKey(this CloudEvent cloudEvent, string? partitionKey)
-        {
-            Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
-            cloudEvent[PartitionKeyAttribute] = partitionKey;
-            return cloudEvent;
-        }
-
-        /// <summary>
-        /// Retrieves the <see cref="PartitionKeyAttribute"/> from the given <see cref="CloudEvent"/>.
-        /// </summary>
-        /// <param name="cloudEvent">The CloudEvent from which to retrieve the attribute. Must not be null.</param>
-        /// <returns>The partition key, or null if <paramref name="cloudEvent"/> does not have a partition key set.</returns>
-        public static string? GetPartitionKey(this CloudEvent cloudEvent) =>
-            (string?) Validation.CheckNotNull(cloudEvent, nameof(cloudEvent))[PartitionKeyAttribute];
+        Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
+        cloudEvent[PartitionKeyAttribute] = partitionKey;
+        return cloudEvent;
     }
+
+    /// <summary>
+    /// Retrieves the <see cref="PartitionKeyAttribute"/> from the given <see cref="CloudEvent"/>.
+    /// </summary>
+    /// <param name="cloudEvent">The CloudEvent from which to retrieve the attribute. Must not be null.</param>
+    /// <returns>The partition key, or null if <paramref name="cloudEvent"/> does not have a partition key set.</returns>
+    public static string? GetPartitionKey(this CloudEvent cloudEvent) =>
+        (string?) Validation.CheckNotNull(cloudEvent, nameof(cloudEvent))[PartitionKeyAttribute];
 }

--- a/src/CloudNative.CloudEvents/Extensions/Sampling.cs
+++ b/src/CloudNative.CloudEvents/Extensions/Sampling.cs
@@ -7,54 +7,53 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace CloudNative.CloudEvents.Extensions
+namespace CloudNative.CloudEvents.Extensions;
+
+/// <summary>
+/// Support for the <see href="https://github.com/cloudevents/spec/tree/main/cloudevents/extensions/sampledrate.md">sampling</see>
+/// CloudEvent extension.
+/// </summary>
+public static class Sampling
 {
     /// <summary>
-    /// Support for the <see href="https://github.com/cloudevents/spec/tree/main/cloudevents/extensions/sampledrate.md">sampling</see>
-    /// CloudEvent extension.
+    /// <see cref="CloudEventAttribute"/> representing the 'sampledrate' extension attribute.
     /// </summary>
-    public static class Sampling
+    public static CloudEventAttribute SampledRateAttribute { get; } =
+        CloudEventAttribute.CreateExtension("sampledrate", CloudEventAttributeType.Integer, PositiveInteger);
+
+    /// <summary>
+    /// A read-only sequence of all attributes related to the sampling extension.
+    /// </summary>
+    public static IEnumerable<CloudEventAttribute> AllAttributes { get; } =
+        new[] { SampledRateAttribute }.ToList().AsReadOnly();
+
+    /// <summary>
+    /// Sets the <see cref="SampledRateAttribute"/> on the given <see cref="CloudEvent"/>.
+    /// </summary>
+    /// <param name="cloudEvent">The CloudEvent on which to set the attribute. Must not be null.</param>
+    /// <param name="sampledRate">The sampled rate to set. May be null, in which case the attribute is
+    /// removed from <paramref name="cloudEvent"/>. If this value is non-null, it must be positive.</param>
+    /// <returns><paramref name="cloudEvent"/>, for convenient method chaining.</returns>
+    public static CloudEvent SetSampledRate(this CloudEvent cloudEvent, int? sampledRate)
     {
-        /// <summary>
-        /// <see cref="CloudEventAttribute"/> representing the 'sampledrate' extension attribute.
-        /// </summary>
-        public static CloudEventAttribute SampledRateAttribute { get; } =
-            CloudEventAttribute.CreateExtension("sampledrate", CloudEventAttributeType.Integer, PositiveInteger);
+        Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
+        cloudEvent[SampledRateAttribute] = sampledRate;
+        return cloudEvent;
+    }
 
-        /// <summary>
-        /// A read-only sequence of all attributes related to the sampling extension.
-        /// </summary>
-        public static IEnumerable<CloudEventAttribute> AllAttributes { get; } =
-            new[] { SampledRateAttribute }.ToList().AsReadOnly();
+    /// <summary>
+    /// Retrieves the <see cref="SampledRateAttribute"/> from the given <see cref="CloudEvent"/>.
+    /// </summary>
+    /// <param name="cloudEvent">The CloudEvent from which to retrieve the attribute. Must not be null.</param>
+    /// <returns>The sampled rate, or null if <paramref name="cloudEvent"/> does not have a sampled rate set.</returns>
+    public static int? GetSampledRate(this CloudEvent cloudEvent) =>
+        (int?) Validation.CheckNotNull(cloudEvent, nameof(cloudEvent))[SampledRateAttribute];
 
-        /// <summary>
-        /// Sets the <see cref="SampledRateAttribute"/> on the given <see cref="CloudEvent"/>.
-        /// </summary>
-        /// <param name="cloudEvent">The CloudEvent on which to set the attribute. Must not be null.</param>
-        /// <param name="sampledRate">The sampled rate to set. May be null, in which case the attribute is
-        /// removed from <paramref name="cloudEvent"/>. If this value is non-null, it must be positive.</param>
-        /// <returns><paramref name="cloudEvent"/>, for convenient method chaining.</returns>
-        public static CloudEvent SetSampledRate(this CloudEvent cloudEvent, int? sampledRate)
+    private static void PositiveInteger(object value)
+    {
+        if ((int) value <= 0)
         {
-            Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
-            cloudEvent[SampledRateAttribute] = sampledRate;
-            return cloudEvent;
-        }
-
-        /// <summary>
-        /// Retrieves the <see cref="SampledRateAttribute"/> from the given <see cref="CloudEvent"/>.
-        /// </summary>
-        /// <param name="cloudEvent">The CloudEvent from which to retrieve the attribute. Must not be null.</param>
-        /// <returns>The sampled rate, or null if <paramref name="cloudEvent"/> does not have a sampled rate set.</returns>
-        public static int? GetSampledRate(this CloudEvent cloudEvent) =>
-            (int?) Validation.CheckNotNull(cloudEvent, nameof(cloudEvent))[SampledRateAttribute];
-
-        private static void PositiveInteger(object value)
-        {
-            if ((int) value <= 0)
-            {
-                throw new ArgumentOutOfRangeException("Sampled rate must be positive.");
-            }
+            throw new ArgumentOutOfRangeException("Sampled rate must be positive.");
         }
     }
 }

--- a/src/CloudNative.CloudEvents/Extensions/Sequence.cs
+++ b/src/CloudNative.CloudEvents/Extensions/Sequence.cs
@@ -7,115 +7,114 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace CloudNative.CloudEvents.Extensions
+namespace CloudNative.CloudEvents.Extensions;
+
+/// <summary>
+/// Support for the <see href="https://github.com/cloudevents/spec/tree/main/cloudevents/extensions/sequence.md">sequence</see>
+/// CloudEvent extension.
+/// </summary>
+public static class Sequence
 {
+    // TODO: Potentially make it public. But public constants make me nervous.
+    private const string IntegerType = "Integer";
+
     /// <summary>
-    /// Support for the <see href="https://github.com/cloudevents/spec/tree/main/cloudevents/extensions/sequence.md">sequence</see>
-    /// CloudEvent extension.
+    /// <see cref="CloudEventAttribute"/> representing the 'sequence' extension attribute.
     /// </summary>
-    public static class Sequence
+    public static CloudEventAttribute SequenceAttribute { get; } =
+        CloudEventAttribute.CreateExtension("sequence", CloudEventAttributeType.String);
+
+    /// <summary>
+    /// <see cref="CloudEventAttribute"/> representing the 'sequencetype' extension attribute.
+    /// </summary>
+    public static CloudEventAttribute SequenceTypeAttribute { get; } =
+        CloudEventAttribute.CreateExtension("sequencetype", CloudEventAttributeType.String);
+
+    private static CloudEventAttribute SurrogateIntegerAttribute { get; } =
+        CloudEventAttribute.CreateExtension("int", CloudEventAttributeType.Integer);
+
+    /// <summary>
+    /// A read-only sequence of all attributes related to the sequence extension.
+    /// </summary>
+    public static IEnumerable<CloudEventAttribute> AllAttributes { get; } =
+        new[] { SequenceAttribute, SequenceTypeAttribute }.ToList().AsReadOnly();
+
+    /// <summary>
+    /// Sets both <see cref="SequenceAttribute"/> and <see cref="SequenceTypeAttribute"/> attributes based on the specified value.
+    /// </summary>
+    /// <param name="cloudEvent">The CloudEvent on which to set the attributes. Must not be null.</param>
+    /// <param name="value">The sequence value to set. May be null, in which case both attributes are removed from
+    /// <paramref name="cloudEvent"/>.</param>
+    /// <exception cref="ArgumentException"><paramref name="value"/> is a non-null value for an unsupported sequence type.</exception>
+    /// <returns><paramref name="cloudEvent"/>, for convenient method chaining.</returns>
+    public static CloudEvent SetSequence(this CloudEvent cloudEvent, object? value)
     {
-        // TODO: Potentially make it public. But public constants make me nervous.
-        private const string IntegerType = "Integer";
-
-        /// <summary>
-        /// <see cref="CloudEventAttribute"/> representing the 'sequence' extension attribute.
-        /// </summary>
-        public static CloudEventAttribute SequenceAttribute { get; } =
-            CloudEventAttribute.CreateExtension("sequence", CloudEventAttributeType.String);
-
-        /// <summary>
-        /// <see cref="CloudEventAttribute"/> representing the 'sequencetype' extension attribute.
-        /// </summary>
-        public static CloudEventAttribute SequenceTypeAttribute { get; } =
-            CloudEventAttribute.CreateExtension("sequencetype", CloudEventAttributeType.String);
-
-        private static CloudEventAttribute SurrogateIntegerAttribute { get; } =
-            CloudEventAttribute.CreateExtension("int", CloudEventAttributeType.Integer);
-
-        /// <summary>
-        /// A read-only sequence of all attributes related to the sequence extension.
-        /// </summary>
-        public static IEnumerable<CloudEventAttribute> AllAttributes { get; } =
-            new[] { SequenceAttribute, SequenceTypeAttribute }.ToList().AsReadOnly();
-
-        /// <summary>
-        /// Sets both <see cref="SequenceAttribute"/> and <see cref="SequenceTypeAttribute"/> attributes based on the specified value.
-        /// </summary>
-        /// <param name="cloudEvent">The CloudEvent on which to set the attributes. Must not be null.</param>
-        /// <param name="value">The sequence value to set. May be null, in which case both attributes are removed from
-        /// <paramref name="cloudEvent"/>.</param>
-        /// <exception cref="ArgumentException"><paramref name="value"/> is a non-null value for an unsupported sequence type.</exception>
-        /// <returns><paramref name="cloudEvent"/>, for convenient method chaining.</returns>
-        public static CloudEvent SetSequence(this CloudEvent cloudEvent, object? value)
+        Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
+        if (value is null)
         {
-            Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
-            if (value is null)
-            {
-                cloudEvent[SequenceAttribute] = null;
-                cloudEvent[SequenceTypeAttribute] = null;
-            }
-            else if (value is int)
-            {
-                // TODO: Validation? Would be nice to get a sort of "surrogate" attribute here...
-                cloudEvent[SequenceAttribute] = SurrogateIntegerAttribute.Format(value);
-                cloudEvent[SequenceTypeAttribute] = IntegerType;
-            }
-            else
-            {
-                throw new ArgumentException($"No sequence type known for type {value.GetType()}");
-            }
-            return cloudEvent;
+            cloudEvent[SequenceAttribute] = null;
+            cloudEvent[SequenceTypeAttribute] = null;
         }
-
-        // TODO: Naming of these extension methods
-
-        /// <summary>
-        /// Retrieves the <see cref="SequenceAttribute"/> value from the event, without any
-        /// further transformation.
-        /// </summary>
-        /// <param name="cloudEvent">The CloudEvent from which to retrieve the attribute. Must not be null.</param>
-        /// <returns>The <see cref="SequenceAttribute"/> value, as a string, or null if the attribute is not set.</returns>
-        public static string? GetSequenceString(this CloudEvent cloudEvent) =>
-            (string?) Validation.CheckNotNull(cloudEvent, nameof(cloudEvent))[SequenceAttribute];
-
-        /// <summary>
-        /// Retrieves the <see cref="SequenceTypeAttribute"/> value from the event, without any
-        /// further transformation.
-        /// </summary>
-        /// <param name="cloudEvent">The CloudEvent from which to retrieve the attribute. Must not be null.</param>
-        /// <returns>The <see cref="SequenceTypeAttribute"/> value, as a string, or null if the attribute is not set.</returns>
-        public static string? GetSequenceType(this CloudEvent cloudEvent) =>
-            (string?) Validation.CheckNotNull(cloudEvent, nameof(cloudEvent))[SequenceTypeAttribute];
-
-        /// <summary>
-        /// Retrieves the <see cref="SequenceAttribute"/> value from the event,
-        /// parsing it according to the value of <see cref="SequenceTypeAttribute"/>.
-        /// If no type is present in the event, the string value is
-        /// returned without further transformation.
-        /// </summary>
-        /// <param name="cloudEvent"></param>
-        /// <returns>The value of <see cref="SequenceAttribute"/> from <paramref name="cloudEvent"/>, transformed
-        /// based on the value of <see cref="SequenceTypeAttribute"/>, or null if the attribute is not set.</returns>
-        /// <exception cref="InvalidOperationException">The <see cref="SequenceTypeAttribute"/> is present, but unknown to this library.</exception>
-        public static object? GetSequenceValue(this CloudEvent cloudEvent)
+        else if (value is int)
         {
-            Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
-            var sequence = GetSequenceString(cloudEvent);
-            if (sequence is null)
-            {
-                return null;
-            }
-            var type = GetSequenceType(cloudEvent);
-            if (type == null)
-            {
-                return sequence;
-            }
-            if (type == IntegerType)
-            {
-                return SurrogateIntegerAttribute.Parse(sequence);
-            }
-            throw new InvalidOperationException($"Unknown sequence type '{type}'");
+            // TODO: Validation? Would be nice to get a sort of "surrogate" attribute here...
+            cloudEvent[SequenceAttribute] = SurrogateIntegerAttribute.Format(value);
+            cloudEvent[SequenceTypeAttribute] = IntegerType;
         }
+        else
+        {
+            throw new ArgumentException($"No sequence type known for type {value.GetType()}");
+        }
+        return cloudEvent;
+    }
+
+    // TODO: Naming of these extension methods
+
+    /// <summary>
+    /// Retrieves the <see cref="SequenceAttribute"/> value from the event, without any
+    /// further transformation.
+    /// </summary>
+    /// <param name="cloudEvent">The CloudEvent from which to retrieve the attribute. Must not be null.</param>
+    /// <returns>The <see cref="SequenceAttribute"/> value, as a string, or null if the attribute is not set.</returns>
+    public static string? GetSequenceString(this CloudEvent cloudEvent) =>
+        (string?) Validation.CheckNotNull(cloudEvent, nameof(cloudEvent))[SequenceAttribute];
+
+    /// <summary>
+    /// Retrieves the <see cref="SequenceTypeAttribute"/> value from the event, without any
+    /// further transformation.
+    /// </summary>
+    /// <param name="cloudEvent">The CloudEvent from which to retrieve the attribute. Must not be null.</param>
+    /// <returns>The <see cref="SequenceTypeAttribute"/> value, as a string, or null if the attribute is not set.</returns>
+    public static string? GetSequenceType(this CloudEvent cloudEvent) =>
+        (string?) Validation.CheckNotNull(cloudEvent, nameof(cloudEvent))[SequenceTypeAttribute];
+
+    /// <summary>
+    /// Retrieves the <see cref="SequenceAttribute"/> value from the event,
+    /// parsing it according to the value of <see cref="SequenceTypeAttribute"/>.
+    /// If no type is present in the event, the string value is
+    /// returned without further transformation.
+    /// </summary>
+    /// <param name="cloudEvent"></param>
+    /// <returns>The value of <see cref="SequenceAttribute"/> from <paramref name="cloudEvent"/>, transformed
+    /// based on the value of <see cref="SequenceTypeAttribute"/>, or null if the attribute is not set.</returns>
+    /// <exception cref="InvalidOperationException">The <see cref="SequenceTypeAttribute"/> is present, but unknown to this library.</exception>
+    public static object? GetSequenceValue(this CloudEvent cloudEvent)
+    {
+        Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
+        var sequence = GetSequenceString(cloudEvent);
+        if (sequence is null)
+        {
+            return null;
+        }
+        var type = GetSequenceType(cloudEvent);
+        if (type == null)
+        {
+            return sequence;
+        }
+        if (type == IntegerType)
+        {
+            return SurrogateIntegerAttribute.Parse(sequence);
+        }
+        throw new InvalidOperationException($"Unknown sequence type '{type}'");
     }
 }

--- a/src/CloudNative.CloudEvents/Http/HttpClientExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpClientExtensions.cs
@@ -13,341 +13,340 @@ using System.Net.Mime;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
-namespace CloudNative.CloudEvents.Http
+namespace CloudNative.CloudEvents.Http;
+
+/// <summary>
+/// Extension methods for <see cref="HttpClient"/> and related classes
+/// (<see cref="HttpRequestMessage"/>, <see cref="HttpResponseMessage"/>, <see cref="HttpContent"/> etc).
+/// </summary>
+public static class HttpClientExtensions
 {
+    // TODO: CloudEvent.ToHttpRequestMessage?
+    // TODO: CloudEvent.ToHttpResponseMessage?
+
     /// <summary>
-    /// Extension methods for <see cref="HttpClient"/> and related classes
-    /// (<see cref="HttpRequestMessage"/>, <see cref="HttpResponseMessage"/>, <see cref="HttpContent"/> etc).
+    /// Indicates whether this <see cref="HttpRequestMessage"/> holds a single CloudEvent.
     /// </summary>
-    public static class HttpClientExtensions
+    /// <remarks>
+    /// This method returns false for batch requests, as they need to be parsed differently.
+    /// </remarks>
+    /// <param name="httpRequestMessage">The message to check for the presence of a CloudEvent. Must not be null.</param>
+    /// <returns>true, if the request is a CloudEvent</returns>
+    public static bool IsCloudEvent(this HttpRequestMessage httpRequestMessage)
     {
-        // TODO: CloudEvent.ToHttpRequestMessage?
-        // TODO: CloudEvent.ToHttpResponseMessage?
+        Validation.CheckNotNull(httpRequestMessage, nameof(httpRequestMessage));
+        return HasCloudEventsContentType(httpRequestMessage.Content) ||
+            (MaybeGetVersionId(httpRequestMessage.Headers) ?? MaybeGetVersionId(httpRequestMessage.Content?.Headers)) is not null;
+    }
 
-        /// <summary>
-        /// Indicates whether this <see cref="HttpRequestMessage"/> holds a single CloudEvent.
-        /// </summary>
-        /// <remarks>
-        /// This method returns false for batch requests, as they need to be parsed differently.
-        /// </remarks>
-        /// <param name="httpRequestMessage">The message to check for the presence of a CloudEvent. Must not be null.</param>
-        /// <returns>true, if the request is a CloudEvent</returns>
-        public static bool IsCloudEvent(this HttpRequestMessage httpRequestMessage)
+    /// <summary>
+    /// Indicates whether this <see cref="HttpResponseMessage"/> holds a single CloudEvent.
+    /// </summary>
+    /// <param name="httpResponseMessage">The message to check for the presence of a CloudEvent. Must not be null.</param>
+    /// <returns>true, if the response is a CloudEvent</returns>
+    public static bool IsCloudEvent(this HttpResponseMessage httpResponseMessage)
+    {
+        Validation.CheckNotNull(httpResponseMessage, nameof(httpResponseMessage));
+        return HasCloudEventsContentType(httpResponseMessage.Content) ||
+            (MaybeGetVersionId(httpResponseMessage.Headers) ?? MaybeGetVersionId(httpResponseMessage.Content?.Headers)) is not null;
+    }
+
+    /// <summary>
+    /// Indicates whether this <see cref="HttpRequestMessage"/> holds a batch of CloudEvents.
+    /// </summary>
+    /// <param name="httpRequestMessage">The message to check for the presence of a CloudEvent batch. Must not be null.</param>
+    /// <returns>true, if the request is a CloudEvent batch</returns>
+    public static bool IsCloudEventBatch(this HttpRequestMessage httpRequestMessage)
+    {
+        Validation.CheckNotNull(httpRequestMessage, nameof(httpRequestMessage));
+        return HasCloudEventsBatchContentType(httpRequestMessage.Content);
+    }
+
+    /// <summary>
+    /// Indicates whether this <see cref="HttpResponseMessage"/> holds a batch of CloudEvents.
+    /// </summary>
+    /// <param name="httpResponseMessage">The message to check for the presence of a CloudEvent batch. Must not be null.</param>
+    /// <returns>true, if the response is a CloudEvent batch</returns>
+    public static bool IsCloudEventBatch(this HttpResponseMessage httpResponseMessage)
+    {
+        Validation.CheckNotNull(httpResponseMessage, nameof(httpResponseMessage));
+        return HasCloudEventsBatchContentType(httpResponseMessage.Content);
+    }
+
+    /// <summary>
+    /// Converts this HTTP response message into a CloudEvent object
+    /// </summary>
+    /// <param name="httpResponseMessage">The HTTP response message to convert. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
+    /// <returns>A reference to a validated CloudEvent instance.</returns>
+    public static Task<CloudEvent> ToCloudEventAsync(
+        this HttpResponseMessage httpResponseMessage,
+        CloudEventFormatter formatter,
+        params CloudEventAttribute[]? extensionAttributes) =>
+        ToCloudEventAsync(httpResponseMessage, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
+
+    /// <summary>
+    /// Converts this HTTP response message into a CloudEvent object
+    /// </summary>
+    /// <param name="httpResponseMessage">The HTTP response message to convert. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
+    /// <returns>A reference to a validated CloudEvent instance.</returns>
+    public static Task<CloudEvent> ToCloudEventAsync(
+        this HttpResponseMessage httpResponseMessage,
+        CloudEventFormatter formatter,
+        IEnumerable<CloudEventAttribute>? extensionAttributes)
+    {
+        Validation.CheckNotNull(httpResponseMessage, nameof(httpResponseMessage));
+        return ToCloudEventInternalAsync(httpResponseMessage.Headers, httpResponseMessage.Content, formatter, extensionAttributes, nameof(httpResponseMessage));
+    }
+
+    /// <summary>
+    /// Converts this HTTP request message into a CloudEvent object.
+    /// </summary>
+    /// <param name="httpRequestMessage">The HTTP request message to convert. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
+    /// <returns>A reference to a validated CloudEvent instance.</returns>
+    public static Task<CloudEvent> ToCloudEventAsync(
+        this HttpRequestMessage httpRequestMessage,
+        CloudEventFormatter formatter,
+        params CloudEventAttribute[]? extensionAttributes) =>
+        ToCloudEventAsync(httpRequestMessage, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
+
+    /// <summary>
+    /// Converts this HTTP request message into a CloudEvent object.
+    /// </summary>
+    /// <param name="httpRequestMessage">The HTTP request message to convert. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
+    /// <returns>A reference to a validated CloudEvent instance.</returns>
+    public static Task<CloudEvent> ToCloudEventAsync(
+        this HttpRequestMessage httpRequestMessage,
+        CloudEventFormatter formatter,
+        IEnumerable<CloudEventAttribute>? extensionAttributes)
+    {
+        Validation.CheckNotNull(httpRequestMessage, nameof(httpRequestMessage));
+        return ToCloudEventInternalAsync(httpRequestMessage.Headers, httpRequestMessage.Content, formatter, extensionAttributes, nameof(httpRequestMessage));
+    }
+
+    private static async Task<CloudEvent> ToCloudEventInternalAsync(HttpHeaders headers, HttpContent? content,
+        CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes, string paramName)
+    {
+        Validation.CheckNotNull(formatter, nameof(formatter));
+
+        if (HasCloudEventsContentType(content))
         {
-            Validation.CheckNotNull(httpRequestMessage, nameof(httpRequestMessage));
-            return HasCloudEventsContentType(httpRequestMessage.Content) ||
-                (MaybeGetVersionId(httpRequestMessage.Headers) ?? MaybeGetVersionId(httpRequestMessage.Content?.Headers)) is not null;
+            var stream = await content.ReadAsStreamAsync().ConfigureAwait(false);
+            return await formatter.DecodeStructuredModeMessageAsync(stream, MimeUtilities.ToContentType(content.Headers.ContentType), extensionAttributes).ConfigureAwait(false);
         }
-
-        /// <summary>
-        /// Indicates whether this <see cref="HttpResponseMessage"/> holds a single CloudEvent.
-        /// </summary>
-        /// <param name="httpResponseMessage">The message to check for the presence of a CloudEvent. Must not be null.</param>
-        /// <returns>true, if the response is a CloudEvent</returns>
-        public static bool IsCloudEvent(this HttpResponseMessage httpResponseMessage)
+        else
         {
-            Validation.CheckNotNull(httpResponseMessage, nameof(httpResponseMessage));
-            return HasCloudEventsContentType(httpResponseMessage.Content) ||
-                (MaybeGetVersionId(httpResponseMessage.Headers) ?? MaybeGetVersionId(httpResponseMessage.Content?.Headers)) is not null;
-        }
-
-        /// <summary>
-        /// Indicates whether this <see cref="HttpRequestMessage"/> holds a batch of CloudEvents.
-        /// </summary>
-        /// <param name="httpRequestMessage">The message to check for the presence of a CloudEvent batch. Must not be null.</param>
-        /// <returns>true, if the request is a CloudEvent batch</returns>
-        public static bool IsCloudEventBatch(this HttpRequestMessage httpRequestMessage)
-        {
-            Validation.CheckNotNull(httpRequestMessage, nameof(httpRequestMessage));
-            return HasCloudEventsBatchContentType(httpRequestMessage.Content);
-        }
-
-        /// <summary>
-        /// Indicates whether this <see cref="HttpResponseMessage"/> holds a batch of CloudEvents.
-        /// </summary>
-        /// <param name="httpResponseMessage">The message to check for the presence of a CloudEvent batch. Must not be null.</param>
-        /// <returns>true, if the response is a CloudEvent batch</returns>
-        public static bool IsCloudEventBatch(this HttpResponseMessage httpResponseMessage)
-        {
-            Validation.CheckNotNull(httpResponseMessage, nameof(httpResponseMessage));
-            return HasCloudEventsBatchContentType(httpResponseMessage.Content);
-        }
-
-        /// <summary>
-        /// Converts this HTTP response message into a CloudEvent object
-        /// </summary>
-        /// <param name="httpResponseMessage">The HTTP response message to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
-        /// <returns>A reference to a validated CloudEvent instance.</returns>
-        public static Task<CloudEvent> ToCloudEventAsync(
-            this HttpResponseMessage httpResponseMessage,
-            CloudEventFormatter formatter,
-            params CloudEventAttribute[]? extensionAttributes) =>
-            ToCloudEventAsync(httpResponseMessage, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
-
-        /// <summary>
-        /// Converts this HTTP response message into a CloudEvent object
-        /// </summary>
-        /// <param name="httpResponseMessage">The HTTP response message to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
-        /// <returns>A reference to a validated CloudEvent instance.</returns>
-        public static Task<CloudEvent> ToCloudEventAsync(
-            this HttpResponseMessage httpResponseMessage,
-            CloudEventFormatter formatter,
-            IEnumerable<CloudEventAttribute>? extensionAttributes)
-        {
-            Validation.CheckNotNull(httpResponseMessage, nameof(httpResponseMessage));
-            return ToCloudEventInternalAsync(httpResponseMessage.Headers, httpResponseMessage.Content, formatter, extensionAttributes, nameof(httpResponseMessage));
-        }
-
-        /// <summary>
-        /// Converts this HTTP request message into a CloudEvent object.
-        /// </summary>
-        /// <param name="httpRequestMessage">The HTTP request message to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
-        /// <returns>A reference to a validated CloudEvent instance.</returns>
-        public static Task<CloudEvent> ToCloudEventAsync(
-            this HttpRequestMessage httpRequestMessage,
-            CloudEventFormatter formatter,
-            params CloudEventAttribute[]? extensionAttributes) =>
-            ToCloudEventAsync(httpRequestMessage, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
-
-        /// <summary>
-        /// Converts this HTTP request message into a CloudEvent object.
-        /// </summary>
-        /// <param name="httpRequestMessage">The HTTP request message to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
-        /// <returns>A reference to a validated CloudEvent instance.</returns>
-        public static Task<CloudEvent> ToCloudEventAsync(
-            this HttpRequestMessage httpRequestMessage,
-            CloudEventFormatter formatter,
-            IEnumerable<CloudEventAttribute>? extensionAttributes)
-        {
-            Validation.CheckNotNull(httpRequestMessage, nameof(httpRequestMessage));
-            return ToCloudEventInternalAsync(httpRequestMessage.Headers, httpRequestMessage.Content, formatter, extensionAttributes, nameof(httpRequestMessage));
-        }
-
-        private static async Task<CloudEvent> ToCloudEventInternalAsync(HttpHeaders headers, HttpContent? content,
-            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes, string paramName)
-        {
-            Validation.CheckNotNull(formatter, nameof(formatter));
-
-            if (HasCloudEventsContentType(content))
+            string? versionId = MaybeGetVersionId(headers) ?? MaybeGetVersionId(content?.Headers);
+            if (versionId is null)
             {
-                var stream = await content.ReadAsStreamAsync().ConfigureAwait(false);
-                return await formatter.DecodeStructuredModeMessageAsync(stream, MimeUtilities.ToContentType(content.Headers.ContentType), extensionAttributes).ConfigureAwait(false);
+                throw new ArgumentException($"Request does not represent a CloudEvent. It has neither a {HttpUtilities.SpecVersionHttpHeader} header, nor a suitable content type.", nameof(paramName));
             }
-            else
+            var version = CloudEventsSpecVersion.FromVersionId(versionId)
+                ?? throw new ArgumentException($"Unknown CloudEvents spec version '{versionId}'", paramName);
+
+            var cloudEvent = new CloudEvent(version, extensionAttributes);
+            var allHeaders = content is null ? headers : headers.Concat(content.Headers);
+            foreach (var header in allHeaders)
             {
-                string? versionId = MaybeGetVersionId(headers) ?? MaybeGetVersionId(content?.Headers);
-                if (versionId is null)
-                {
-                    throw new ArgumentException($"Request does not represent a CloudEvent. It has neither a {HttpUtilities.SpecVersionHttpHeader} header, nor a suitable content type.", nameof(paramName));
-                }
-                var version = CloudEventsSpecVersion.FromVersionId(versionId)
-                    ?? throw new ArgumentException($"Unknown CloudEvents spec version '{versionId}'", paramName);
-
-                var cloudEvent = new CloudEvent(version, extensionAttributes);
-                var allHeaders = content is null ? headers : headers.Concat(content.Headers);
-                foreach (var header in allHeaders)
-                {
-                    string? attributeName = HttpUtilities.GetAttributeNameFromHeaderName(header.Key);
-                    if (attributeName is null || attributeName == CloudEventsSpecVersion.SpecVersionAttribute.Name)
-                    {
-                        continue;
-                    }
-                    string attributeValue = HttpUtilities.DecodeHeaderValue(header.Value.First());
-
-                    cloudEvent.SetAttributeFromString(attributeName, attributeValue);
-                }
-                if (content is object)
-                {
-                    // TODO: Should this just be the media type? We probably need to take a full audit of this...
-                    cloudEvent.DataContentType = content.Headers?.ContentType?.ToString();
-                    var data = await content.ReadAsByteArrayAsync().ConfigureAwait(false);
-                    formatter.DecodeBinaryModeEventData(data, cloudEvent);
-                }
-                return Validation.CheckCloudEventArgument(cloudEvent, paramName);
-            }
-        }
-
-        /// <summary>
-        /// Converts this HTTP response message into a CloudEvent batch.
-        /// </summary>
-        /// <param name="httpResponseMessage">The HTTP response message to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvents. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvents. May be null.</param>
-        /// <returns>The decoded batch of CloudEvents.</returns>
-        public static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
-            this HttpResponseMessage httpResponseMessage,
-            CloudEventFormatter formatter,
-            params CloudEventAttribute[] extensionAttributes) =>
-            ToCloudEventBatchAsync(httpResponseMessage, formatter, (IEnumerable<CloudEventAttribute>) extensionAttributes);
-
-        /// <summary>
-        /// Converts this HTTP response message into a CloudEvent batch.
-        /// </summary>
-        /// <param name="httpResponseMessage">The HTTP response message to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvents. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvents. May be null.</param>
-        /// <returns>The decoded batch of CloudEvents.</returns>
-        public static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
-            this HttpResponseMessage httpResponseMessage,
-            CloudEventFormatter formatter,
-            IEnumerable<CloudEventAttribute> extensionAttributes)
-        {
-            Validation.CheckNotNull(httpResponseMessage, nameof(httpResponseMessage));
-            return ToCloudEventBatchInternalAsync(httpResponseMessage.Content, formatter, extensionAttributes, nameof(httpResponseMessage));
-        }
-
-        /// <summary>
-        /// Converts this HTTP request message into a CloudEvent batch.
-        /// </summary>
-        /// <param name="httpRequestMessage">The HTTP request message to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvents. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvents. May be null.</param>
-        /// <returns>The decoded batch of CloudEvents.</returns>
-        public static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
-            this HttpRequestMessage httpRequestMessage,
-            CloudEventFormatter formatter,
-            params CloudEventAttribute[] extensionAttributes) =>
-            ToCloudEventBatchAsync(httpRequestMessage, formatter, (IEnumerable<CloudEventAttribute>) extensionAttributes);
-
-        /// <summary>
-        /// Converts this HTTP request message into a CloudEvent batch.
-        /// </summary>
-        /// <param name="httpRequestMessage">The HTTP request message to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvents. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvents. May be null.</param>
-        /// <returns>The decoded batch of CloudEvents.</returns>
-        public static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
-            this HttpRequestMessage httpRequestMessage,
-            CloudEventFormatter formatter,
-            IEnumerable<CloudEventAttribute>? extensionAttributes)
-        {
-            Validation.CheckNotNull(httpRequestMessage, nameof(httpRequestMessage));
-            return ToCloudEventBatchInternalAsync(httpRequestMessage.Content, formatter, extensionAttributes, nameof(httpRequestMessage));
-        }
-
-        private static async Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchInternalAsync(HttpContent? content,
-            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes, string paramName)
-        {
-            Validation.CheckNotNull(formatter, nameof(formatter));
-
-            if (HasCloudEventsBatchContentType(content))
-            {
-                var stream = await content.ReadAsStreamAsync().ConfigureAwait(false);
-                return await formatter
-                    .DecodeBatchModeMessageAsync(stream, MimeUtilities.ToContentType(content.Headers.ContentType), extensionAttributes)
-                    .ConfigureAwait(false);
-            }
-            else
-            {
-                throw new ArgumentException("HTTP message does not represent a CloudEvents batch.", paramName);
-            }
-        }
-
-        /// <summary>
-        /// Converts a CloudEvent to <see cref="HttpContent"/>.
-        /// </summary>
-        /// <param name="cloudEvent">The CloudEvent to convert. Must not be null, and must be a valid CloudEvent.</param>
-        /// <param name="contentMode">Content mode. Structured or binary.</param>
-        /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
-        public static HttpContent ToHttpContent(this CloudEvent cloudEvent, ContentMode contentMode, CloudEventFormatter formatter)
-        {
-            Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
-            Validation.CheckNotNull(formatter, nameof(formatter));
-
-            ReadOnlyMemory<byte> content;
-            // The content type to include in the ContentType header - may be the data content type, or the formatter's content type.
-            ContentType? contentType;
-            switch (contentMode)
-            {
-                case ContentMode.Structured:
-                    content = formatter.EncodeStructuredModeMessage(cloudEvent, out contentType);
-                    break;
-                case ContentMode.Binary:
-                    content = formatter.EncodeBinaryModeEventData(cloudEvent);
-                    contentType = MimeUtilities.CreateContentTypeOrNull(formatter.GetOrInferDataContentType(cloudEvent));
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(contentMode), $"Unsupported content mode: {contentMode}");
-            }
-            ByteArrayContent ret = ToByteArrayContent(content);
-            if (contentType is object)
-            {
-                ret.Headers.ContentType = MimeUtilities.ToMediaTypeHeaderValue(contentType);
-            }
-            else if (content.Length != 0)
-            {
-                throw new ArgumentException(Strings.ErrorContentTypeUnspecified, nameof(cloudEvent));
-            }
-
-            // Map headers in either mode.
-            // Including the headers in structured mode is optional in the spec (as they're already within the body) but
-            // can be useful.
-            ret.Headers.Add(HttpUtilities.SpecVersionHttpHeader, HttpUtilities.EncodeHeaderValue(cloudEvent.SpecVersion.VersionId));
-            foreach (var attributeAndValue in cloudEvent.GetPopulatedAttributes())
-            {
-                CloudEventAttribute attribute = attributeAndValue.Key;
-                string headerName = HttpUtilities.HttpHeaderPrefix + attribute.Name;
-                object value = attributeAndValue.Value;
-
-                // Skip the data content type attribute in binary mode, because it's already in the content type header.
-                if (attribute == cloudEvent.SpecVersion.DataContentTypeAttribute && contentMode == ContentMode.Binary)
+                string? attributeName = HttpUtilities.GetAttributeNameFromHeaderName(header.Key);
+                if (attributeName is null || attributeName == CloudEventsSpecVersion.SpecVersionAttribute.Name)
                 {
                     continue;
                 }
-                else
-                {
-                    string headerValue = HttpUtilities.EncodeHeaderValue(attribute.Format(value));
-                    ret.Headers.Add(headerName, headerValue);
-                }
+                string attributeValue = HttpUtilities.DecodeHeaderValue(header.Value.First());
+
+                cloudEvent.SetAttributeFromString(attributeName, attributeValue);
             }
-            return ret;
+            if (content is object)
+            {
+                // TODO: Should this just be the media type? We probably need to take a full audit of this...
+                cloudEvent.DataContentType = content.Headers?.ContentType?.ToString();
+                var data = await content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                formatter.DecodeBinaryModeEventData(data, cloudEvent);
+            }
+            return Validation.CheckCloudEventArgument(cloudEvent, paramName);
         }
-
-        /// <summary>
-        /// Converts a CloudEvent batch to <see cref="HttpContent"/>.
-        /// </summary>
-        /// <param name="cloudEvents">The CloudEvent batch to convert. Must not be null, and every element must be non-null reference to a valid CloudEvent.</param>
-        /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
-        public static HttpContent ToHttpContent(this IReadOnlyList<CloudEvent> cloudEvents, CloudEventFormatter formatter)
-        {
-            Validation.CheckCloudEventBatchArgument(cloudEvents, nameof(cloudEvents));
-            Validation.CheckNotNull(formatter, nameof(formatter));
-
-            // TODO: Validate that all events in the batch have the same version?
-            // See https://github.com/cloudevents/spec/issues/807
-
-            ReadOnlyMemory<byte> content = formatter.EncodeBatchModeMessage(cloudEvents, out var contentType);
-
-            // Note: we don't populate any other headers for batch mode.
-            var ret = ToByteArrayContent(content);
-            ret.Headers.ContentType = MimeUtilities.ToMediaTypeHeaderValue(contentType);
-            return ret;
-        }
-
-        private static ByteArrayContent ToByteArrayContent(ReadOnlyMemory<byte> content) =>
-            MemoryMarshal.TryGetArray(content, out var segment) && segment.Array is not null
-            ? new ByteArrayContent(segment.Array, segment.Offset, segment.Count)
-            // TODO: Just throw?
-            : new ByteArrayContent(content.ToArray());
-
-        // TODO: This would include "application/cloudeventsarerubbish" for example...
-        private static bool HasCloudEventsContentType([NotNullWhen(true)] HttpContent? content) =>
-            MimeUtilities.IsCloudEventsContentType(content?.Headers?.ContentType?.MediaType);
-
-        private static bool HasCloudEventsBatchContentType([NotNullWhen(true)] HttpContent? content) =>
-            MimeUtilities.IsCloudEventsBatchContentType(content?.Headers?.ContentType?.MediaType);
-
-        private static string? MaybeGetVersionId(HttpHeaders? headers) =>
-            headers is not null && headers.Contains(HttpUtilities.SpecVersionHttpHeader)
-            ? headers.GetValues(HttpUtilities.SpecVersionHttpHeader).First()
-            : null;
     }
+
+    /// <summary>
+    /// Converts this HTTP response message into a CloudEvent batch.
+    /// </summary>
+    /// <param name="httpResponseMessage">The HTTP response message to convert. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to parse the CloudEvents. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvents. May be null.</param>
+    /// <returns>The decoded batch of CloudEvents.</returns>
+    public static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
+        this HttpResponseMessage httpResponseMessage,
+        CloudEventFormatter formatter,
+        params CloudEventAttribute[] extensionAttributes) =>
+        ToCloudEventBatchAsync(httpResponseMessage, formatter, (IEnumerable<CloudEventAttribute>) extensionAttributes);
+
+    /// <summary>
+    /// Converts this HTTP response message into a CloudEvent batch.
+    /// </summary>
+    /// <param name="httpResponseMessage">The HTTP response message to convert. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to parse the CloudEvents. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvents. May be null.</param>
+    /// <returns>The decoded batch of CloudEvents.</returns>
+    public static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
+        this HttpResponseMessage httpResponseMessage,
+        CloudEventFormatter formatter,
+        IEnumerable<CloudEventAttribute> extensionAttributes)
+    {
+        Validation.CheckNotNull(httpResponseMessage, nameof(httpResponseMessage));
+        return ToCloudEventBatchInternalAsync(httpResponseMessage.Content, formatter, extensionAttributes, nameof(httpResponseMessage));
+    }
+
+    /// <summary>
+    /// Converts this HTTP request message into a CloudEvent batch.
+    /// </summary>
+    /// <param name="httpRequestMessage">The HTTP request message to convert. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to parse the CloudEvents. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvents. May be null.</param>
+    /// <returns>The decoded batch of CloudEvents.</returns>
+    public static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
+        this HttpRequestMessage httpRequestMessage,
+        CloudEventFormatter formatter,
+        params CloudEventAttribute[] extensionAttributes) =>
+        ToCloudEventBatchAsync(httpRequestMessage, formatter, (IEnumerable<CloudEventAttribute>) extensionAttributes);
+
+    /// <summary>
+    /// Converts this HTTP request message into a CloudEvent batch.
+    /// </summary>
+    /// <param name="httpRequestMessage">The HTTP request message to convert. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to parse the CloudEvents. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvents. May be null.</param>
+    /// <returns>The decoded batch of CloudEvents.</returns>
+    public static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
+        this HttpRequestMessage httpRequestMessage,
+        CloudEventFormatter formatter,
+        IEnumerable<CloudEventAttribute>? extensionAttributes)
+    {
+        Validation.CheckNotNull(httpRequestMessage, nameof(httpRequestMessage));
+        return ToCloudEventBatchInternalAsync(httpRequestMessage.Content, formatter, extensionAttributes, nameof(httpRequestMessage));
+    }
+
+    private static async Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchInternalAsync(HttpContent? content,
+        CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes, string paramName)
+    {
+        Validation.CheckNotNull(formatter, nameof(formatter));
+
+        if (HasCloudEventsBatchContentType(content))
+        {
+            var stream = await content.ReadAsStreamAsync().ConfigureAwait(false);
+            return await formatter
+                .DecodeBatchModeMessageAsync(stream, MimeUtilities.ToContentType(content.Headers.ContentType), extensionAttributes)
+                .ConfigureAwait(false);
+        }
+        else
+        {
+            throw new ArgumentException("HTTP message does not represent a CloudEvents batch.", paramName);
+        }
+    }
+
+    /// <summary>
+    /// Converts a CloudEvent to <see cref="HttpContent"/>.
+    /// </summary>
+    /// <param name="cloudEvent">The CloudEvent to convert. Must not be null, and must be a valid CloudEvent.</param>
+    /// <param name="contentMode">Content mode. Structured or binary.</param>
+    /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
+    public static HttpContent ToHttpContent(this CloudEvent cloudEvent, ContentMode contentMode, CloudEventFormatter formatter)
+    {
+        Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
+        Validation.CheckNotNull(formatter, nameof(formatter));
+
+        ReadOnlyMemory<byte> content;
+        // The content type to include in the ContentType header - may be the data content type, or the formatter's content type.
+        ContentType? contentType;
+        switch (contentMode)
+        {
+            case ContentMode.Structured:
+                content = formatter.EncodeStructuredModeMessage(cloudEvent, out contentType);
+                break;
+            case ContentMode.Binary:
+                content = formatter.EncodeBinaryModeEventData(cloudEvent);
+                contentType = MimeUtilities.CreateContentTypeOrNull(formatter.GetOrInferDataContentType(cloudEvent));
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(contentMode), $"Unsupported content mode: {contentMode}");
+        }
+        ByteArrayContent ret = ToByteArrayContent(content);
+        if (contentType is object)
+        {
+            ret.Headers.ContentType = MimeUtilities.ToMediaTypeHeaderValue(contentType);
+        }
+        else if (content.Length != 0)
+        {
+            throw new ArgumentException(Strings.ErrorContentTypeUnspecified, nameof(cloudEvent));
+        }
+
+        // Map headers in either mode.
+        // Including the headers in structured mode is optional in the spec (as they're already within the body) but
+        // can be useful.
+        ret.Headers.Add(HttpUtilities.SpecVersionHttpHeader, HttpUtilities.EncodeHeaderValue(cloudEvent.SpecVersion.VersionId));
+        foreach (var attributeAndValue in cloudEvent.GetPopulatedAttributes())
+        {
+            CloudEventAttribute attribute = attributeAndValue.Key;
+            string headerName = HttpUtilities.HttpHeaderPrefix + attribute.Name;
+            object value = attributeAndValue.Value;
+
+            // Skip the data content type attribute in binary mode, because it's already in the content type header.
+            if (attribute == cloudEvent.SpecVersion.DataContentTypeAttribute && contentMode == ContentMode.Binary)
+            {
+                continue;
+            }
+            else
+            {
+                string headerValue = HttpUtilities.EncodeHeaderValue(attribute.Format(value));
+                ret.Headers.Add(headerName, headerValue);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>
+    /// Converts a CloudEvent batch to <see cref="HttpContent"/>.
+    /// </summary>
+    /// <param name="cloudEvents">The CloudEvent batch to convert. Must not be null, and every element must be non-null reference to a valid CloudEvent.</param>
+    /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
+    public static HttpContent ToHttpContent(this IReadOnlyList<CloudEvent> cloudEvents, CloudEventFormatter formatter)
+    {
+        Validation.CheckCloudEventBatchArgument(cloudEvents, nameof(cloudEvents));
+        Validation.CheckNotNull(formatter, nameof(formatter));
+
+        // TODO: Validate that all events in the batch have the same version?
+        // See https://github.com/cloudevents/spec/issues/807
+
+        ReadOnlyMemory<byte> content = formatter.EncodeBatchModeMessage(cloudEvents, out var contentType);
+
+        // Note: we don't populate any other headers for batch mode.
+        var ret = ToByteArrayContent(content);
+        ret.Headers.ContentType = MimeUtilities.ToMediaTypeHeaderValue(contentType);
+        return ret;
+    }
+
+    private static ByteArrayContent ToByteArrayContent(ReadOnlyMemory<byte> content) =>
+        MemoryMarshal.TryGetArray(content, out var segment) && segment.Array is not null
+        ? new ByteArrayContent(segment.Array, segment.Offset, segment.Count)
+        // TODO: Just throw?
+        : new ByteArrayContent(content.ToArray());
+
+    // TODO: This would include "application/cloudeventsarerubbish" for example...
+    private static bool HasCloudEventsContentType([NotNullWhen(true)] HttpContent? content) =>
+        MimeUtilities.IsCloudEventsContentType(content?.Headers?.ContentType?.MediaType);
+
+    private static bool HasCloudEventsBatchContentType([NotNullWhen(true)] HttpContent? content) =>
+        MimeUtilities.IsCloudEventsBatchContentType(content?.Headers?.ContentType?.MediaType);
+
+    private static string? MaybeGetVersionId(HttpHeaders? headers) =>
+        headers is not null && headers.Contains(HttpUtilities.SpecVersionHttpHeader)
+        ? headers.GetValues(HttpUtilities.SpecVersionHttpHeader).First()
+        : null;
 }

--- a/src/CloudNative.CloudEvents/Http/HttpListenerExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpListenerExtensions.cs
@@ -9,290 +9,289 @@ using System.Net;
 using System.Net.Mime;
 using System.Threading.Tasks;
 
-namespace CloudNative.CloudEvents.Http
+namespace CloudNative.CloudEvents.Http;
+
+/// <summary>
+/// Extension methods for <see cref="HttpListener"/> and related classes
+/// (<see cref="HttpListenerResponse"/> etc).
+/// </summary>
+public static class HttpListenerExtensions
 {
     /// <summary>
-    /// Extension methods for <see cref="HttpListener"/> and related classes
-    /// (<see cref="HttpListenerResponse"/> etc).
+    /// Copies a <see cref="CloudEvent"/> into an <see cref="HttpListenerResponse" />.
     /// </summary>
-    public static class HttpListenerExtensions
+    /// <param name="cloudEvent">The CloudEvent to copy. Must not be null, and must be a valid CloudEvent.</param>
+    /// <param name="destination">The response to copy the CloudEvent to. Must not be null.</param>
+    /// <param name="contentMode">Content mode (structured or binary)</param>
+    /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task CopyToHttpListenerResponseAsync(this CloudEvent cloudEvent, HttpListenerResponse destination,
+        ContentMode contentMode, CloudEventFormatter formatter)
     {
-        /// <summary>
-        /// Copies a <see cref="CloudEvent"/> into an <see cref="HttpListenerResponse" />.
-        /// </summary>
-        /// <param name="cloudEvent">The CloudEvent to copy. Must not be null, and must be a valid CloudEvent.</param>
-        /// <param name="destination">The response to copy the CloudEvent to. Must not be null.</param>
-        /// <param name="contentMode">Content mode (structured or binary)</param>
-        /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        public static async Task CopyToHttpListenerResponseAsync(this CloudEvent cloudEvent, HttpListenerResponse destination,
-            ContentMode contentMode, CloudEventFormatter formatter)
+        Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
+        Validation.CheckNotNull(destination, nameof(destination));
+        Validation.CheckNotNull(formatter, nameof(formatter));
+
+        ReadOnlyMemory<byte> content;
+        ContentType? contentType;
+        switch (contentMode)
         {
-            Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
-            Validation.CheckNotNull(destination, nameof(destination));
-            Validation.CheckNotNull(formatter, nameof(formatter));
-
-            ReadOnlyMemory<byte> content;
-            ContentType? contentType;
-            switch (contentMode)
-            {
-                case ContentMode.Structured:
-                    content = formatter.EncodeStructuredModeMessage(cloudEvent, out contentType);
-                    break;
-                case ContentMode.Binary:
-                    content = formatter.EncodeBinaryModeEventData(cloudEvent);
-                    contentType = MimeUtilities.CreateContentTypeOrNull(formatter.GetOrInferDataContentType(cloudEvent));
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(contentMode), $"Unsupported content mode: {contentMode}");
-            }
-            if (contentType is object)
-            {
-                destination.ContentType = contentType.ToString();
-            }
-            else if (content.Length != 0)
-            {
-                throw new ArgumentException(Strings.ErrorContentTypeUnspecified, nameof(cloudEvent));
-            }
-
-            // Map headers in either mode.
-            // Including the headers in structured mode is optional in the spec (as they're already within the body) but
-            // can be useful.            
-            destination.Headers.Add(HttpUtilities.SpecVersionHttpHeader, HttpUtilities.EncodeHeaderValue(cloudEvent.SpecVersion.VersionId));
-            foreach (var attributeAndValue in cloudEvent.GetPopulatedAttributes())
-            {
-                var attribute = attributeAndValue.Key;
-                var value = attributeAndValue.Value;
-                // The content type is already handled based on the content mode.
-                if (attribute != cloudEvent.SpecVersion.DataContentTypeAttribute)
-                {
-                    string headerValue = HttpUtilities.EncodeHeaderValue(attribute.Format(value));
-                    destination.Headers.Add(HttpUtilities.HttpHeaderPrefix + attribute.Name, headerValue);
-                }
-            }
-
-            await BinaryDataUtilities.CopyToStreamAsync(content, destination.OutputStream).ConfigureAwait(false);
+            case ContentMode.Structured:
+                content = formatter.EncodeStructuredModeMessage(cloudEvent, out contentType);
+                break;
+            case ContentMode.Binary:
+                content = formatter.EncodeBinaryModeEventData(cloudEvent);
+                contentType = MimeUtilities.CreateContentTypeOrNull(formatter.GetOrInferDataContentType(cloudEvent));
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(contentMode), $"Unsupported content mode: {contentMode}");
         }
-
-        /// <summary>
-        /// Copies a <see cref="CloudEvent"/> batch into an <see cref="HttpListenerResponse" />.
-        /// </summary>
-        /// <param name="cloudEvents">The CloudEvent batch to copy. Must not be null, and must be a valid CloudEvent.</param>
-        /// <param name="destination">The response to copy the CloudEvent to. Must not be null.</param>
-        /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        public static async Task CopyToHttpListenerResponseAsync(this IReadOnlyList<CloudEvent> cloudEvents,
-            HttpListenerResponse destination, CloudEventFormatter formatter)
+        if (contentType is object)
         {
-            Validation.CheckCloudEventBatchArgument(cloudEvents, nameof(cloudEvents));
-            Validation.CheckNotNull(destination, nameof(destination));
-            Validation.CheckNotNull(formatter, nameof(formatter));
-
-            // TODO: Validate that all events in the batch have the same version?
-            // See https://github.com/cloudevents/spec/issues/807
-
-            ReadOnlyMemory<byte> content = formatter.EncodeBatchModeMessage(cloudEvents, out var contentType);
             destination.ContentType = contentType.ToString();
-            await BinaryDataUtilities.CopyToStreamAsync(content, destination.OutputStream).ConfigureAwait(false);
+        }
+        else if (content.Length != 0)
+        {
+            throw new ArgumentException(Strings.ErrorContentTypeUnspecified, nameof(cloudEvent));
         }
 
-        /// <summary>
-        /// Indicates whether this HttpListenerRequest holds a single CloudEvent.
-        /// </summary>
-        /// <param name="httpListenerRequest">The request to check for the presence of a single CloudEvent. Must not be null.</param>
-        public static bool IsCloudEvent(this HttpListenerRequest httpListenerRequest)
+        // Map headers in either mode.
+        // Including the headers in structured mode is optional in the spec (as they're already within the body) but
+        // can be useful.            
+        destination.Headers.Add(HttpUtilities.SpecVersionHttpHeader, HttpUtilities.EncodeHeaderValue(cloudEvent.SpecVersion.VersionId));
+        foreach (var attributeAndValue in cloudEvent.GetPopulatedAttributes())
         {
-            Validation.CheckNotNull(httpListenerRequest, nameof(httpListenerRequest));
-            return HasCloudEventsContentType(httpListenerRequest) ||
-                httpListenerRequest.Headers[HttpUtilities.SpecVersionHttpHeader] is object;
-        }
-
-        /// <summary>
-        /// Indicates whether this <see cref="HttpListenerRequest"/> holds a batch of CloudEvents.
-        /// </summary>
-        /// <param name="httpListenerRequest">The message to check for the presence of a CloudEvent batch. Must not be null.</param>
-        /// <returns>true, if the request is a CloudEvent batch</returns>
-        public static bool IsCloudEventBatch(this HttpListenerRequest httpListenerRequest)
-        {
-            Validation.CheckNotNull(httpListenerRequest, nameof(httpListenerRequest));
-            return HasCloudEventsBatchContentType(httpListenerRequest);
-        }
-
-        /// <summary>
-        /// Converts this listener request into a CloudEvent object, with the given extension attributes.
-        /// </summary>
-        /// <param name="httpListenerRequest">The listener request to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
-        /// <returns>A reference to a validated CloudEvent instance.</returns>
-        public static Task<CloudEvent> ToCloudEventAsync(this HttpListenerRequest httpListenerRequest,
-            CloudEventFormatter formatter, params CloudEventAttribute[]? extensionAttributes) =>
-            // No async/await here, as the delegation is to *such* a similar method (same name, same parameter names)
-            // that the stack trace will still be very easy to understand.
-            ToCloudEventAsync(httpListenerRequest, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
-
-        /// <summary>
-        /// Converts this listener request into a CloudEvent object, with the given extension attributes.
-        /// </summary>
-        /// <param name="httpListenerRequest">The listener request to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
-        /// <returns>A reference to a validated CloudEvent instance.</returns>
-        public static async Task<CloudEvent> ToCloudEventAsync(this HttpListenerRequest httpListenerRequest,
-            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
-            await ToCloudEventAsyncImpl(httpListenerRequest, formatter, extensionAttributes, async: true).ConfigureAwait(false);
-
-        /// <summary>
-        /// Converts this listener request into a CloudEvent object, with the given extension attributes.
-        /// </summary>
-        /// <param name="httpListenerRequest">The listener request to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
-        /// <returns>A reference to a validated CloudEvent instance.</returns>
-        public static CloudEvent ToCloudEvent(this HttpListenerRequest httpListenerRequest,
-            CloudEventFormatter formatter, params CloudEventAttribute[]? extensionAttributes) =>
-            ToCloudEvent(httpListenerRequest, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
-
-        /// <summary>
-        /// Converts this listener request into a CloudEvent object, with the given extension attributes.
-        /// </summary>
-        /// <param name="httpListenerRequest">The listener request to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
-        /// <returns>A reference to a validated CloudEvent instance.</returns>
-        public static CloudEvent ToCloudEvent(this HttpListenerRequest httpListenerRequest,
-            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
-            ToCloudEventAsyncImpl(httpListenerRequest, formatter, extensionAttributes, async: false).GetAwaiter().GetResult();
-
-        private static async Task<CloudEvent> ToCloudEventAsyncImpl(HttpListenerRequest httpListenerRequest,
-            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes, bool async)
-        {
-            Validation.CheckNotNull(httpListenerRequest, nameof(httpListenerRequest));
-            Validation.CheckNotNull(formatter, nameof(formatter));
-            var stream = httpListenerRequest.InputStream;
-            if (HasCloudEventsContentType(httpListenerRequest))
+            var attribute = attributeAndValue.Key;
+            var value = attributeAndValue.Value;
+            // The content type is already handled based on the content mode.
+            if (attribute != cloudEvent.SpecVersion.DataContentTypeAttribute)
             {
-                var contentType = MimeUtilities.CreateContentTypeOrNull(httpListenerRequest.ContentType);
-                return async
-                    ? await formatter.DecodeStructuredModeMessageAsync(stream, contentType, extensionAttributes).ConfigureAwait(false)
-                    : formatter.DecodeStructuredModeMessage(stream, contentType, extensionAttributes);
-            }
-            else
-            {
-                string? versionId = httpListenerRequest.Headers[HttpUtilities.SpecVersionHttpHeader];
-                if (versionId is null)
-                {
-                    throw new ArgumentException($"Request does not represent a CloudEvent. It has neither a {HttpUtilities.SpecVersionHttpHeader} header, nor a suitable content type.", nameof(httpListenerRequest));
-                }
-                var version = CloudEventsSpecVersion.FromVersionId(versionId)
-                    ?? throw new ArgumentException($"Unknown CloudEvents spec version '{versionId}'", nameof(httpListenerRequest));
-
-                var cloudEvent = new CloudEvent(version, extensionAttributes);
-                var headers = httpListenerRequest.Headers;
-                foreach (var key in headers.AllKeys)
-                {
-                    // It would be highly unusual for either the key or the value to be null, but
-                    // the contract claims it's possible. Skip it if so.
-                    if (key is null || headers[key] is not string headerValue)
-                    {
-                        continue;
-                    }
-                    string? attributeName = HttpUtilities.GetAttributeNameFromHeaderName(key);
-                    if (attributeName is null || attributeName == CloudEventsSpecVersion.SpecVersionAttribute.Name)
-                    {
-                        continue;
-                    }
-                    string attributeValue = HttpUtilities.DecodeHeaderValue(headerValue);
-                    cloudEvent.SetAttributeFromString(attributeName, attributeValue);
-                }
-
-                // The data content type should not have been set via a "ce-" header; instead,
-                // it's in the regular content type.
-                cloudEvent.DataContentType = httpListenerRequest.ContentType;
-
-                ReadOnlyMemory<byte> data = async
-                    ? await BinaryDataUtilities.ToReadOnlyMemoryAsync(stream).ConfigureAwait(false)
-                    : BinaryDataUtilities.ToReadOnlyMemory(stream);
-                formatter.DecodeBinaryModeEventData(data, cloudEvent);
-                return Validation.CheckCloudEventArgument(cloudEvent, nameof(httpListenerRequest));
+                string headerValue = HttpUtilities.EncodeHeaderValue(attribute.Format(value));
+                destination.Headers.Add(HttpUtilities.HttpHeaderPrefix + attribute.Name, headerValue);
             }
         }
 
-        /// <summary>
-        /// Converts this HTTP request message into a CloudEvent batch.
-        /// </summary>
-        /// <param name="httpListenerRequest">The HTTP request to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvents. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvents. May be null.</param>
-        /// <returns>The decoded batch of CloudEvents.</returns>
-        public static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
-            this HttpListenerRequest httpListenerRequest,
-            CloudEventFormatter formatter,
-            params CloudEventAttribute[]? extensionAttributes) =>
-            ToCloudEventBatchAsync(httpListenerRequest, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
-
-        /// <summary>
-        /// Converts this HTTP request message into a CloudEvent batch.
-        /// </summary>
-        /// <param name="httpListenerRequest">The HTTP request to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
-        /// <returns>The decoded batch of CloudEvents.</returns>
-        public static async Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
-            this HttpListenerRequest httpListenerRequest,
-            CloudEventFormatter formatter,
-            IEnumerable<CloudEventAttribute>? extensionAttributes) =>
-            await ToCloudEventBatchInternalAsync(httpListenerRequest, formatter, extensionAttributes, async: true).ConfigureAwait(false);
-
-        /// <summary>
-        /// Converts this HTTP request message into a CloudEvent batch.
-        /// </summary>
-        /// <param name="httpListenerRequest">The HTTP request to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvents. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvents. May be null.</param>
-        /// <returns>The decoded batch of CloudEvents.</returns>
-        public static IReadOnlyList<CloudEvent> ToCloudEventBatch(
-            this HttpListenerRequest httpListenerRequest,
-            CloudEventFormatter formatter,
-            params CloudEventAttribute[]? extensionAttributes) =>
-            ToCloudEventBatch(httpListenerRequest, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
-
-        /// <summary>
-        /// Converts this HTTP request message into a CloudEvent batch.
-        /// </summary>
-        /// <param name="httpListenerRequest">The HTTP request to convert. Must not be null.</param>
-        /// <param name="formatter">The event formatter to use to parse the CloudEvents. Must not be null.</param>
-        /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvents. May be null.</param>
-        /// <returns>The decoded batch of CloudEvents.</returns>
-        public static IReadOnlyList<CloudEvent> ToCloudEventBatch(
-            this HttpListenerRequest httpListenerRequest,
-            CloudEventFormatter formatter,
-            IEnumerable<CloudEventAttribute>? extensionAttributes) =>
-            ToCloudEventBatchInternalAsync(httpListenerRequest, formatter, extensionAttributes, async: false).GetAwaiter().GetResult();
-
-        private static async Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchInternalAsync(HttpListenerRequest httpListenerRequest,
-            CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes, bool async)
-        {
-            Validation.CheckNotNull(httpListenerRequest, nameof(httpListenerRequest));
-            Validation.CheckNotNull(formatter, nameof(formatter));
-
-            if (HasCloudEventsBatchContentType(httpListenerRequest))
-            {
-                var contentType = MimeUtilities.CreateContentTypeOrNull(httpListenerRequest.ContentType);
-                return async
-                    ? await formatter.DecodeBatchModeMessageAsync(httpListenerRequest.InputStream, contentType, extensionAttributes).ConfigureAwait(false)
-                    : formatter.DecodeBatchModeMessage(httpListenerRequest.InputStream, contentType, extensionAttributes);
-            }
-            else
-            {
-                throw new ArgumentException("HTTP message does not represent a CloudEvents batch.", nameof(httpListenerRequest));
-            }
-        }
-
-        private static bool HasCloudEventsContentType(HttpListenerRequest request) =>
-            MimeUtilities.IsCloudEventsContentType(request.ContentType);
-
-        private static bool HasCloudEventsBatchContentType(HttpListenerRequest request) =>
-            MimeUtilities.IsCloudEventsBatchContentType(request.ContentType);
+        await BinaryDataUtilities.CopyToStreamAsync(content, destination.OutputStream).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// Copies a <see cref="CloudEvent"/> batch into an <see cref="HttpListenerResponse" />.
+    /// </summary>
+    /// <param name="cloudEvents">The CloudEvent batch to copy. Must not be null, and must be a valid CloudEvent.</param>
+    /// <param name="destination">The response to copy the CloudEvent to. Must not be null.</param>
+    /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task CopyToHttpListenerResponseAsync(this IReadOnlyList<CloudEvent> cloudEvents,
+        HttpListenerResponse destination, CloudEventFormatter formatter)
+    {
+        Validation.CheckCloudEventBatchArgument(cloudEvents, nameof(cloudEvents));
+        Validation.CheckNotNull(destination, nameof(destination));
+        Validation.CheckNotNull(formatter, nameof(formatter));
+
+        // TODO: Validate that all events in the batch have the same version?
+        // See https://github.com/cloudevents/spec/issues/807
+
+        ReadOnlyMemory<byte> content = formatter.EncodeBatchModeMessage(cloudEvents, out var contentType);
+        destination.ContentType = contentType.ToString();
+        await BinaryDataUtilities.CopyToStreamAsync(content, destination.OutputStream).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Indicates whether this HttpListenerRequest holds a single CloudEvent.
+    /// </summary>
+    /// <param name="httpListenerRequest">The request to check for the presence of a single CloudEvent. Must not be null.</param>
+    public static bool IsCloudEvent(this HttpListenerRequest httpListenerRequest)
+    {
+        Validation.CheckNotNull(httpListenerRequest, nameof(httpListenerRequest));
+        return HasCloudEventsContentType(httpListenerRequest) ||
+            httpListenerRequest.Headers[HttpUtilities.SpecVersionHttpHeader] is object;
+    }
+
+    /// <summary>
+    /// Indicates whether this <see cref="HttpListenerRequest"/> holds a batch of CloudEvents.
+    /// </summary>
+    /// <param name="httpListenerRequest">The message to check for the presence of a CloudEvent batch. Must not be null.</param>
+    /// <returns>true, if the request is a CloudEvent batch</returns>
+    public static bool IsCloudEventBatch(this HttpListenerRequest httpListenerRequest)
+    {
+        Validation.CheckNotNull(httpListenerRequest, nameof(httpListenerRequest));
+        return HasCloudEventsBatchContentType(httpListenerRequest);
+    }
+
+    /// <summary>
+    /// Converts this listener request into a CloudEvent object, with the given extension attributes.
+    /// </summary>
+    /// <param name="httpListenerRequest">The listener request to convert. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
+    /// <returns>A reference to a validated CloudEvent instance.</returns>
+    public static Task<CloudEvent> ToCloudEventAsync(this HttpListenerRequest httpListenerRequest,
+        CloudEventFormatter formatter, params CloudEventAttribute[]? extensionAttributes) =>
+        // No async/await here, as the delegation is to *such* a similar method (same name, same parameter names)
+        // that the stack trace will still be very easy to understand.
+        ToCloudEventAsync(httpListenerRequest, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
+
+    /// <summary>
+    /// Converts this listener request into a CloudEvent object, with the given extension attributes.
+    /// </summary>
+    /// <param name="httpListenerRequest">The listener request to convert. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
+    /// <returns>A reference to a validated CloudEvent instance.</returns>
+    public static async Task<CloudEvent> ToCloudEventAsync(this HttpListenerRequest httpListenerRequest,
+        CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
+        await ToCloudEventAsyncImpl(httpListenerRequest, formatter, extensionAttributes, async: true).ConfigureAwait(false);
+
+    /// <summary>
+    /// Converts this listener request into a CloudEvent object, with the given extension attributes.
+    /// </summary>
+    /// <param name="httpListenerRequest">The listener request to convert. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
+    /// <returns>A reference to a validated CloudEvent instance.</returns>
+    public static CloudEvent ToCloudEvent(this HttpListenerRequest httpListenerRequest,
+        CloudEventFormatter formatter, params CloudEventAttribute[]? extensionAttributes) =>
+        ToCloudEvent(httpListenerRequest, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
+
+    /// <summary>
+    /// Converts this listener request into a CloudEvent object, with the given extension attributes.
+    /// </summary>
+    /// <param name="httpListenerRequest">The listener request to convert. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
+    /// <returns>A reference to a validated CloudEvent instance.</returns>
+    public static CloudEvent ToCloudEvent(this HttpListenerRequest httpListenerRequest,
+        CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
+        ToCloudEventAsyncImpl(httpListenerRequest, formatter, extensionAttributes, async: false).GetAwaiter().GetResult();
+
+    private static async Task<CloudEvent> ToCloudEventAsyncImpl(HttpListenerRequest httpListenerRequest,
+        CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes, bool async)
+    {
+        Validation.CheckNotNull(httpListenerRequest, nameof(httpListenerRequest));
+        Validation.CheckNotNull(formatter, nameof(formatter));
+        var stream = httpListenerRequest.InputStream;
+        if (HasCloudEventsContentType(httpListenerRequest))
+        {
+            var contentType = MimeUtilities.CreateContentTypeOrNull(httpListenerRequest.ContentType);
+            return async
+                ? await formatter.DecodeStructuredModeMessageAsync(stream, contentType, extensionAttributes).ConfigureAwait(false)
+                : formatter.DecodeStructuredModeMessage(stream, contentType, extensionAttributes);
+        }
+        else
+        {
+            string? versionId = httpListenerRequest.Headers[HttpUtilities.SpecVersionHttpHeader];
+            if (versionId is null)
+            {
+                throw new ArgumentException($"Request does not represent a CloudEvent. It has neither a {HttpUtilities.SpecVersionHttpHeader} header, nor a suitable content type.", nameof(httpListenerRequest));
+            }
+            var version = CloudEventsSpecVersion.FromVersionId(versionId)
+                ?? throw new ArgumentException($"Unknown CloudEvents spec version '{versionId}'", nameof(httpListenerRequest));
+
+            var cloudEvent = new CloudEvent(version, extensionAttributes);
+            var headers = httpListenerRequest.Headers;
+            foreach (var key in headers.AllKeys)
+            {
+                // It would be highly unusual for either the key or the value to be null, but
+                // the contract claims it's possible. Skip it if so.
+                if (key is null || headers[key] is not string headerValue)
+                {
+                    continue;
+                }
+                string? attributeName = HttpUtilities.GetAttributeNameFromHeaderName(key);
+                if (attributeName is null || attributeName == CloudEventsSpecVersion.SpecVersionAttribute.Name)
+                {
+                    continue;
+                }
+                string attributeValue = HttpUtilities.DecodeHeaderValue(headerValue);
+                cloudEvent.SetAttributeFromString(attributeName, attributeValue);
+            }
+
+            // The data content type should not have been set via a "ce-" header; instead,
+            // it's in the regular content type.
+            cloudEvent.DataContentType = httpListenerRequest.ContentType;
+
+            ReadOnlyMemory<byte> data = async
+                ? await BinaryDataUtilities.ToReadOnlyMemoryAsync(stream).ConfigureAwait(false)
+                : BinaryDataUtilities.ToReadOnlyMemory(stream);
+            formatter.DecodeBinaryModeEventData(data, cloudEvent);
+            return Validation.CheckCloudEventArgument(cloudEvent, nameof(httpListenerRequest));
+        }
+    }
+
+    /// <summary>
+    /// Converts this HTTP request message into a CloudEvent batch.
+    /// </summary>
+    /// <param name="httpListenerRequest">The HTTP request to convert. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to parse the CloudEvents. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvents. May be null.</param>
+    /// <returns>The decoded batch of CloudEvents.</returns>
+    public static Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
+        this HttpListenerRequest httpListenerRequest,
+        CloudEventFormatter formatter,
+        params CloudEventAttribute[]? extensionAttributes) =>
+        ToCloudEventBatchAsync(httpListenerRequest, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
+
+    /// <summary>
+    /// Converts this HTTP request message into a CloudEvent batch.
+    /// </summary>
+    /// <param name="httpListenerRequest">The HTTP request to convert. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to parse the CloudEvent. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvent. May be null.</param>
+    /// <returns>The decoded batch of CloudEvents.</returns>
+    public static async Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchAsync(
+        this HttpListenerRequest httpListenerRequest,
+        CloudEventFormatter formatter,
+        IEnumerable<CloudEventAttribute>? extensionAttributes) =>
+        await ToCloudEventBatchInternalAsync(httpListenerRequest, formatter, extensionAttributes, async: true).ConfigureAwait(false);
+
+    /// <summary>
+    /// Converts this HTTP request message into a CloudEvent batch.
+    /// </summary>
+    /// <param name="httpListenerRequest">The HTTP request to convert. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to parse the CloudEvents. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvents. May be null.</param>
+    /// <returns>The decoded batch of CloudEvents.</returns>
+    public static IReadOnlyList<CloudEvent> ToCloudEventBatch(
+        this HttpListenerRequest httpListenerRequest,
+        CloudEventFormatter formatter,
+        params CloudEventAttribute[]? extensionAttributes) =>
+        ToCloudEventBatch(httpListenerRequest, formatter, (IEnumerable<CloudEventAttribute>?) extensionAttributes);
+
+    /// <summary>
+    /// Converts this HTTP request message into a CloudEvent batch.
+    /// </summary>
+    /// <param name="httpListenerRequest">The HTTP request to convert. Must not be null.</param>
+    /// <param name="formatter">The event formatter to use to parse the CloudEvents. Must not be null.</param>
+    /// <param name="extensionAttributes">The extension attributes to use when parsing the CloudEvents. May be null.</param>
+    /// <returns>The decoded batch of CloudEvents.</returns>
+    public static IReadOnlyList<CloudEvent> ToCloudEventBatch(
+        this HttpListenerRequest httpListenerRequest,
+        CloudEventFormatter formatter,
+        IEnumerable<CloudEventAttribute>? extensionAttributes) =>
+        ToCloudEventBatchInternalAsync(httpListenerRequest, formatter, extensionAttributes, async: false).GetAwaiter().GetResult();
+
+    private static async Task<IReadOnlyList<CloudEvent>> ToCloudEventBatchInternalAsync(HttpListenerRequest httpListenerRequest,
+        CloudEventFormatter formatter, IEnumerable<CloudEventAttribute>? extensionAttributes, bool async)
+    {
+        Validation.CheckNotNull(httpListenerRequest, nameof(httpListenerRequest));
+        Validation.CheckNotNull(formatter, nameof(formatter));
+
+        if (HasCloudEventsBatchContentType(httpListenerRequest))
+        {
+            var contentType = MimeUtilities.CreateContentTypeOrNull(httpListenerRequest.ContentType);
+            return async
+                ? await formatter.DecodeBatchModeMessageAsync(httpListenerRequest.InputStream, contentType, extensionAttributes).ConfigureAwait(false)
+                : formatter.DecodeBatchModeMessage(httpListenerRequest.InputStream, contentType, extensionAttributes);
+        }
+        else
+        {
+            throw new ArgumentException("HTTP message does not represent a CloudEvents batch.", nameof(httpListenerRequest));
+        }
+    }
+
+    private static bool HasCloudEventsContentType(HttpListenerRequest request) =>
+        MimeUtilities.IsCloudEventsContentType(request.ContentType);
+
+    private static bool HasCloudEventsBatchContentType(HttpListenerRequest request) =>
+        MimeUtilities.IsCloudEventsBatchContentType(request.ContentType);
 }

--- a/src/CloudNative.CloudEvents/Http/HttpUtilities.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpUtilities.cs
@@ -6,284 +6,283 @@ using CloudNative.CloudEvents.Core;
 using System;
 using System.Text;
 
-namespace CloudNative.CloudEvents.Http
+namespace CloudNative.CloudEvents.Http;
+
+/// <summary>
+/// Common functionality used by all HTTP code. This is public to enable reuse by other packages,
+/// e.g. ASP.NET Core code.
+/// </summary>
+public static class HttpUtilities
 {
     /// <summary>
-    /// Common functionality used by all HTTP code. This is public to enable reuse by other packages,
-    /// e.g. ASP.NET Core code.
+    /// The prefix used by all CloudEvents HTTP headers.
     /// </summary>
-    public static class HttpUtilities
+    public static string HttpHeaderPrefix { get; } = "ce-";
+
+    /// <summary>
+    /// The name of the HTTP header used to specify the CloudEvents specification version in an HTTP message.
+    /// </summary>
+    public static string SpecVersionHttpHeader { get; } = HttpHeaderPrefix + "specversion";
+
+    /// <summary>
+    /// Checks whether the given HTTP header name starts with "ce-", and if so, converts it into
+    /// a lower-case attribute name.
+    /// </summary>
+    /// <param name="headerName">The name of the header to check. Must not be null.</param>
+    /// <returns>The corresponding attribute name if the header name matches the CloudEvents header prefix;
+    /// null otherwise.</returns>
+    public static string? GetAttributeNameFromHeaderName(string headerName) =>
+        Validation.CheckNotNull(headerName, nameof(headerName)).StartsWith(HttpHeaderPrefix, StringComparison.InvariantCultureIgnoreCase)
+        ? headerName.Substring(HttpHeaderPrefix.Length).ToLowerInvariant()
+        : null;
+
+    /// <summary>
+    /// Encodes the given value so that it is suitable to use as a header encoding,
+    /// using percent-encoding for all non-ASCII values, as well as space, percent and double-quote.
+    /// </summary>
+    /// <param name="value">The header value to encode. Must not be null.</param>
+    /// <returns>The encoded header value.</returns>
+    public static string EncodeHeaderValue(string value)
     {
-        /// <summary>
-        /// The prefix used by all CloudEvents HTTP headers.
-        /// </summary>
-        public static string HttpHeaderPrefix { get; } = "ce-";
+        Validation.CheckNotNull(value, nameof(value));
 
-        /// <summary>
-        /// The name of the HTTP header used to specify the CloudEvents specification version in an HTTP message.
-        /// </summary>
-        public static string SpecVersionHttpHeader { get; } = HttpHeaderPrefix + "specversion";
-
-        /// <summary>
-        /// Checks whether the given HTTP header name starts with "ce-", and if so, converts it into
-        /// a lower-case attribute name.
-        /// </summary>
-        /// <param name="headerName">The name of the header to check. Must not be null.</param>
-        /// <returns>The corresponding attribute name if the header name matches the CloudEvents header prefix;
-        /// null otherwise.</returns>
-        public static string? GetAttributeNameFromHeaderName(string headerName) =>
-            Validation.CheckNotNull(headerName, nameof(headerName)).StartsWith(HttpHeaderPrefix, StringComparison.InvariantCultureIgnoreCase)
-            ? headerName.Substring(HttpHeaderPrefix.Length).ToLowerInvariant()
-            : null;
-
-        /// <summary>
-        /// Encodes the given value so that it is suitable to use as a header encoding,
-        /// using percent-encoding for all non-ASCII values, as well as space, percent and double-quote.
-        /// </summary>
-        /// <param name="value">The header value to encode. Must not be null.</param>
-        /// <returns>The encoded header value.</returns>
-        public static string EncodeHeaderValue(string value)
+        var builder = new StringBuilder(value.Length);
+        for (int i = 0; i < value.Length; i++)
         {
-            Validation.CheckNotNull(value, nameof(value));
+            int codePoint = char.ConvertToUtf32(value, i);
 
-            var builder = new StringBuilder(value.Length);
-            for (int i = 0; i < value.Length; i++)
+            // Encode: non-printable-ASCII, non-ASCII, space, percent, double-quote.
+            // Start by handling the ASCII special cases which are all hard-coded (and most common)
+            switch (codePoint)
             {
-                int codePoint = char.ConvertToUtf32(value, i);
-
-                // Encode: non-printable-ASCII, non-ASCII, space, percent, double-quote.
-                // Start by handling the ASCII special cases which are all hard-coded (and most common)
-                switch (codePoint)
-                {
-                    case ' ':
-                        builder.Append("%20");
-                        continue;
-                    case '"':
-                        builder.Append("%22");
-                        continue;
-                    case '%':
-                        builder.Append("%25");
-                        continue;
-                }
-                // Now check for simple ASCII that doesn't need to be encoded
-                if (codePoint > 0x20 && codePoint < 0x7f)
-                {
-                    builder.Append((char) codePoint);
+                case ' ':
+                    builder.Append("%20");
                     continue;
-                }
-
-                // Full-on UTF-8 encoding now... it's simple enough to inline this
-                // code, avoiding any allocation for Encoding.UTF8.GetBytes.
-                // The Wikipedia page on UTF-8 is helpful for understanding this: https://en.wikipedia.org/wiki/UTF-8
-                if (codePoint < 0x80)
-                {
-                    AppendPercentEncodedByte(codePoint);
-                }
-                else if (codePoint < 0x800)
-                {
-                    AppendPercentEncodedByte(0b11000000 | (codePoint >> 6));
-                    AppendPercentEncodedByte(0b10000000 | (codePoint & 0b111111));
-                }
-                else if (codePoint < 0x10000)
-                {
-                    AppendPercentEncodedByte(0b11100000 | (codePoint >> 12));
-                    AppendPercentEncodedByte(0b10000000 | ((codePoint >> 6) & 0b111111));
-                    AppendPercentEncodedByte(0b10000000 | (codePoint & 0b111111));
-                }
-                else
-                {
-                    AppendPercentEncodedByte(0b11110000 | (codePoint >> 18));
-                    AppendPercentEncodedByte(0b10000000 | ((codePoint >> 12) & 0b111111));
-                    AppendPercentEncodedByte(0b10000000 | ((codePoint >> 6) & 0b111111));
-                    AppendPercentEncodedByte(0b10000000 | (codePoint & 0b111111));
-                    // Non-BMP character: this will have been represented as a surrogate
-                    // pair in the input string, so skip over the second UTF-16 code unit.
-                    i++;
-                }
+                case '"':
+                    builder.Append("%22");
+                    continue;
+                case '%':
+                    builder.Append("%25");
+                    continue;
             }
-            return builder.ToString();
-
-            // Note: parameter is int rather than byte to avoid lots of casts in the call site.
-            void AppendPercentEncodedByte(int b)
+            // Now check for simple ASCII that doesn't need to be encoded
+            if (codePoint > 0x20 && codePoint < 0x7f)
             {
-                const string HexDigits = "0123456789ABCDEF";
-                builder.Append('%');
-                builder.Append(HexDigits[b >> 4]);
-                builder.Append(HexDigits[b & 0x0f]);
+                builder.Append((char) codePoint);
+                continue;
+            }
+
+            // Full-on UTF-8 encoding now... it's simple enough to inline this
+            // code, avoiding any allocation for Encoding.UTF8.GetBytes.
+            // The Wikipedia page on UTF-8 is helpful for understanding this: https://en.wikipedia.org/wiki/UTF-8
+            if (codePoint < 0x80)
+            {
+                AppendPercentEncodedByte(codePoint);
+            }
+            else if (codePoint < 0x800)
+            {
+                AppendPercentEncodedByte(0b11000000 | (codePoint >> 6));
+                AppendPercentEncodedByte(0b10000000 | (codePoint & 0b111111));
+            }
+            else if (codePoint < 0x10000)
+            {
+                AppendPercentEncodedByte(0b11100000 | (codePoint >> 12));
+                AppendPercentEncodedByte(0b10000000 | ((codePoint >> 6) & 0b111111));
+                AppendPercentEncodedByte(0b10000000 | (codePoint & 0b111111));
+            }
+            else
+            {
+                AppendPercentEncodedByte(0b11110000 | (codePoint >> 18));
+                AppendPercentEncodedByte(0b10000000 | ((codePoint >> 12) & 0b111111));
+                AppendPercentEncodedByte(0b10000000 | ((codePoint >> 6) & 0b111111));
+                AppendPercentEncodedByte(0b10000000 | (codePoint & 0b111111));
+                // Non-BMP character: this will have been represented as a surrogate
+                // pair in the input string, so skip over the second UTF-16 code unit.
+                i++;
             }
         }
+        return builder.ToString();
 
-        /// <summary>
-        /// Decodes the given HTTP header value, first decoding any double-quoted strings,
-        /// then performing percent-decoding.
-        /// </summary>
-        /// <param name="value">The header value to decode. Must not be null.</param>
-        /// <returns>The decoded header value.</returns>
-        public static string DecodeHeaderValue(string value)
+        // Note: parameter is int rather than byte to avoid lots of casts in the call site.
+        void AppendPercentEncodedByte(int b)
         {
-            Validation.CheckNotNull(value, nameof(value));
-            value = DecodeDoubleQuoted(value);
+            const string HexDigits = "0123456789ABCDEF";
+            builder.Append('%');
+            builder.Append(HexDigits[b >> 4]);
+            builder.Append(HexDigits[b & 0x0f]);
+        }
+    }
 
-            // Common case: no percent-encoding to decode.
-            if (value.IndexOf('%') == -1)
+    /// <summary>
+    /// Decodes the given HTTP header value, first decoding any double-quoted strings,
+    /// then performing percent-decoding.
+    /// </summary>
+    /// <param name="value">The header value to decode. Must not be null.</param>
+    /// <returns>The decoded header value.</returns>
+    public static string DecodeHeaderValue(string value)
+    {
+        Validation.CheckNotNull(value, nameof(value));
+        value = DecodeDoubleQuoted(value);
+
+        // Common case: no percent-encoding to decode.
+        if (value.IndexOf('%') == -1)
+        {
+            return value;
+        }
+
+        var builder = new StringBuilder(value.Length);
+        for (int i = 0; i < value.Length; i++)
+        {
+            char c = value[i];
+            if (c != '%')
             {
-                return value;
+                builder.Append(c);
+                continue;
             }
 
-            var builder = new StringBuilder(value.Length);
-            for (int i = 0; i < value.Length; i++)
+            // Percent encoding is remarkably complex to handle correctly and efficiently.
+            if (i + 2 >= value.Length)
             {
-                char c = value[i];
-                if (c != '%')
-                {
-                    builder.Append(c);
-                    continue;
-                }
-
-                // Percent encoding is remarkably complex to handle correctly and efficiently.
-                if (i + 2 >= value.Length)
-                {
-                    throw new ArgumentException("Invalid HTTP header value for CloudEvent attribute: percent is not followed by two hex digits");
-                }
-                byte byte1 = DecodePercentEncodedByte(i);
-
-                // Use the first byte to work out how long the character is in bytes.
-                int byteCount = byte1 < 0x80 ? 1
-                    : byte1 >= 0b11000000 && byte1 <= 0b11011111 ? 2
-                    : byte1 >= 0b11100000 && byte1 <= 0b11101111 ? 3
-                    : byte1 >= 0b11110000 && byte1 <= 0b11110111 ? 4
-                    : throw new ArgumentException("Invalid HTTP header value for CloudEvent attribute: percent-encoded value is invalid UTF-8");
-
-                // Note: we could allocate a byte array here and delegate to Encoding.UTF8, but for the common case of non-emoji, that
-                // would allocate pointlessly - and it's not immediately obvious whether it performs all the validation we want.
-                // With comprehensive conformance tests, we can tweak this.
-                int utf32 = byteCount switch
-                {
-                    1 => byte1,
-                    2 => ((byte1 & 0b11111) << 6) | DecodeUtf8ContinuationByte(i + 3),
-                    3 => ((byte1 & 0b1111) << 12) | (DecodeUtf8ContinuationByte(i + 3) << 6) | DecodeUtf8ContinuationByte(i + 6),
-                    4 => ((byte1 & 0b111) << 18) | (DecodeUtf8ContinuationByte(i + 3) << 12) | (DecodeUtf8ContinuationByte(i + 6) << 6) | DecodeUtf8ContinuationByte(i + 9),
-                    _ => throw new InvalidOperationException("Can't get here due to previous switch statement")
-                };
-                // Validate the UTF-32 value:
-                // - Not a high/low surrogate
-                // - Not represented using an "overlong" encoding
-
-                // Validate we don't have a high/low surrogate on its own.
-                if (utf32 >= 0xd800 && utf32 <= 0xdfff)
-                {
-                    throw new ArgumentException("Invalid HTTP header value for CloudEvent attribute: percent-encoded value is invalid UTF-8");
-                }
-
-                // Validate we don't have an overlong sequence
-                int expectedByteCount = utf32 < 0x80 ? 1
-                    : utf32 < 0x800 ? 2
-                    : utf32 < 0x10000 ? 3
-                    : 4;
-
-                if (expectedByteCount != byteCount)
-                {
-                    throw new ArgumentException("Invalid HTTP header value for CloudEvent attribute: percent-encoded value is invalid UTF-8");
-                }
-
-                // Finally, append the result of the percent-decoding
-                if (utf32 < 0x10000)
-                {
-                    builder.Append((char) utf32);
-                }
-                else
-                {
-                    // Note: we could do this more efficiently, without allocating a string, but
-                    // it's simpler to delegate to ConvertFromUtf32.
-                    builder.Append(char.ConvertFromUtf32(utf32));
-                }
-                // Skip over the characters we've now handled.
-                i += byteCount * 3 - 1;
-            }
-            return builder.ToString();
-
-            int DecodeUtf8ContinuationByte(int index)
-            {
-                if (index >= value.Length || value[index] != '%')
-                {
-                    throw new ArgumentException("Invalid HTTP header value for CloudEvent attribute: percent-encoded value is invalid UTF-8");
-                }
-                byte result = DecodePercentEncodedByte(index);
-                // Validate that top bit is set, and next bit is clear.
-                // (The other six bits are the actual value.)
-                if ((result >> 6) != 2)
-                {
-                    throw new ArgumentException("Invalid HTTP header value for CloudEvent attribute: percent-encoded value is invalid UTF-8");
-                }
-                return result & 0b0011_1111;
-            }
-
-            byte DecodePercentEncodedByte(int index)
-            {
-                if (index + 2 >= value.Length)
-                {
-                    throw new ArgumentException("Invalid HTTP header value for CloudEvent attribute: percent is not followed by two hex digits");
-                }
-                char high = value[index + 1];
-                char low = value[index + 2];
-                return (byte) ((ParseNybble(high) << 4) | ParseNybble(low));
-            }
-
-            static int ParseNybble(char nybble)
-            {
-                if (nybble >= '0' && nybble <= '9')
-                {
-                    return nybble - '0';
-                }
-                if (nybble >= 'A' && nybble <= 'F')
-                {
-                    return nybble - 'A' + 10;
-                }
-                if (nybble >= 'a' && nybble <= 'f')
-                {
-                    return nybble - 'a' + 10;
-                }
                 throw new ArgumentException("Invalid HTTP header value for CloudEvent attribute: percent is not followed by two hex digits");
             }
+            byte byte1 = DecodePercentEncodedByte(i);
+
+            // Use the first byte to work out how long the character is in bytes.
+            int byteCount = byte1 < 0x80 ? 1
+                : byte1 >= 0b11000000 && byte1 <= 0b11011111 ? 2
+                : byte1 >= 0b11100000 && byte1 <= 0b11101111 ? 3
+                : byte1 >= 0b11110000 && byte1 <= 0b11110111 ? 4
+                : throw new ArgumentException("Invalid HTTP header value for CloudEvent attribute: percent-encoded value is invalid UTF-8");
+
+            // Note: we could allocate a byte array here and delegate to Encoding.UTF8, but for the common case of non-emoji, that
+            // would allocate pointlessly - and it's not immediately obvious whether it performs all the validation we want.
+            // With comprehensive conformance tests, we can tweak this.
+            int utf32 = byteCount switch
+            {
+                1 => byte1,
+                2 => ((byte1 & 0b11111) << 6) | DecodeUtf8ContinuationByte(i + 3),
+                3 => ((byte1 & 0b1111) << 12) | (DecodeUtf8ContinuationByte(i + 3) << 6) | DecodeUtf8ContinuationByte(i + 6),
+                4 => ((byte1 & 0b111) << 18) | (DecodeUtf8ContinuationByte(i + 3) << 12) | (DecodeUtf8ContinuationByte(i + 6) << 6) | DecodeUtf8ContinuationByte(i + 9),
+                _ => throw new InvalidOperationException("Can't get here due to previous switch statement")
+            };
+            // Validate the UTF-32 value:
+            // - Not a high/low surrogate
+            // - Not represented using an "overlong" encoding
+
+            // Validate we don't have a high/low surrogate on its own.
+            if (utf32 >= 0xd800 && utf32 <= 0xdfff)
+            {
+                throw new ArgumentException("Invalid HTTP header value for CloudEvent attribute: percent-encoded value is invalid UTF-8");
+            }
+
+            // Validate we don't have an overlong sequence
+            int expectedByteCount = utf32 < 0x80 ? 1
+                : utf32 < 0x800 ? 2
+                : utf32 < 0x10000 ? 3
+                : 4;
+
+            if (expectedByteCount != byteCount)
+            {
+                throw new ArgumentException("Invalid HTTP header value for CloudEvent attribute: percent-encoded value is invalid UTF-8");
+            }
+
+            // Finally, append the result of the percent-decoding
+            if (utf32 < 0x10000)
+            {
+                builder.Append((char) utf32);
+            }
+            else
+            {
+                // Note: we could do this more efficiently, without allocating a string, but
+                // it's simpler to delegate to ConvertFromUtf32.
+                builder.Append(char.ConvertFromUtf32(utf32));
+            }
+            // Skip over the characters we've now handled.
+            i += byteCount * 3 - 1;
+        }
+        return builder.ToString();
+
+        int DecodeUtf8ContinuationByte(int index)
+        {
+            if (index >= value.Length || value[index] != '%')
+            {
+                throw new ArgumentException("Invalid HTTP header value for CloudEvent attribute: percent-encoded value is invalid UTF-8");
+            }
+            byte result = DecodePercentEncodedByte(index);
+            // Validate that top bit is set, and next bit is clear.
+            // (The other six bits are the actual value.)
+            if ((result >> 6) != 2)
+            {
+                throw new ArgumentException("Invalid HTTP header value for CloudEvent attribute: percent-encoded value is invalid UTF-8");
+            }
+            return result & 0b0011_1111;
         }
 
-        /// <summary>
-        /// Applies the double-quoting part of https://tools.ietf.org/html/rfc7230#section-3.2.6 in reverse.
-        /// </summary>
-        private static string DecodeDoubleQuoted(string value)
+        byte DecodePercentEncodedByte(int index)
         {
-            if (value.IndexOf('\"') == -1)
+            if (index + 2 >= value.Length)
             {
-                return value;
+                throw new ArgumentException("Invalid HTTP header value for CloudEvent attribute: percent is not followed by two hex digits");
             }
-            StringBuilder builder = new StringBuilder();
-            bool inQuotes = false;
-            for (int i = 0; i < value.Length; i++)
-            {
-                char c = value[i];
-                if (c == '\"')
-                {
-                    inQuotes = !inQuotes;
-                }
-                else if (c == '\\' && inQuotes)
-                {
-                    if (i + 1 == value.Length)
-                    {
-                        throw new ArgumentException("Invalid HTTP header value for CloudEvent attribute: unterminated backslash escape");
-                    }
-                    builder.Append(value[i + 1]);
-                    i++;
-                }
-                else
-                {
-                    builder.Append(c);
-                }
-            }
-            if (inQuotes)
-            {
-                throw new ArgumentException("Invalid HTTP header value for CloudEvent attribute: unterminated quoted string");
-            }
-            return builder.ToString();
+            char high = value[index + 1];
+            char low = value[index + 2];
+            return (byte) ((ParseNybble(high) << 4) | ParseNybble(low));
         }
+
+        static int ParseNybble(char nybble)
+        {
+            if (nybble >= '0' && nybble <= '9')
+            {
+                return nybble - '0';
+            }
+            if (nybble >= 'A' && nybble <= 'F')
+            {
+                return nybble - 'A' + 10;
+            }
+            if (nybble >= 'a' && nybble <= 'f')
+            {
+                return nybble - 'a' + 10;
+            }
+            throw new ArgumentException("Invalid HTTP header value for CloudEvent attribute: percent is not followed by two hex digits");
+        }
+    }
+
+    /// <summary>
+    /// Applies the double-quoting part of https://tools.ietf.org/html/rfc7230#section-3.2.6 in reverse.
+    /// </summary>
+    private static string DecodeDoubleQuoted(string value)
+    {
+        if (value.IndexOf('\"') == -1)
+        {
+            return value;
+        }
+        StringBuilder builder = new StringBuilder();
+        bool inQuotes = false;
+        for (int i = 0; i < value.Length; i++)
+        {
+            char c = value[i];
+            if (c == '\"')
+            {
+                inQuotes = !inQuotes;
+            }
+            else if (c == '\\' && inQuotes)
+            {
+                if (i + 1 == value.Length)
+                {
+                    throw new ArgumentException("Invalid HTTP header value for CloudEvent attribute: unterminated backslash escape");
+                }
+                builder.Append(value[i + 1]);
+                i++;
+            }
+            else
+            {
+                builder.Append(c);
+            }
+        }
+        if (inQuotes)
+        {
+            throw new ArgumentException("Invalid HTTP header value for CloudEvent attribute: unterminated quoted string");
+        }
+        return builder.ToString();
     }
 }

--- a/src/CloudNative.CloudEvents/Http/HttpWebExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpWebExtensions.cs
@@ -9,90 +9,89 @@ using System.Net;
 using System.Net.Mime;
 using System.Threading.Tasks;
 
-namespace CloudNative.CloudEvents.Http
+namespace CloudNative.CloudEvents.Http;
+
+/// <summary>
+/// Extension methods for <see cref="HttpWebRequest"/> and related types.
+/// </summary>
+public static class HttpWebExtensions
 {
+    // TODO: HttpWebResponse as well?
+
     /// <summary>
-    /// Extension methods for <see cref="HttpWebRequest"/> and related types.
+    /// Copies a <see cref="CloudEvent"/> into the specified <see cref="HttpWebRequest"/>.
     /// </summary>
-    public static class HttpWebExtensions
+    /// <param name="cloudEvent">CloudEvent to copy. Must not be null, and must be a valid CloudEvent.</param>
+    /// <param name="destination">The request to populate. Must not be null.</param>
+    /// <param name="contentMode">Content mode (structured or binary)</param>
+    /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task CopyToHttpWebRequestAsync(this CloudEvent cloudEvent, HttpWebRequest destination,
+        ContentMode contentMode, CloudEventFormatter formatter)
     {
-        // TODO: HttpWebResponse as well?
+        Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
+        Validation.CheckNotNull(destination, nameof(destination));
+        Validation.CheckNotNull(formatter, nameof(formatter));
 
-        /// <summary>
-        /// Copies a <see cref="CloudEvent"/> into the specified <see cref="HttpWebRequest"/>.
-        /// </summary>
-        /// <param name="cloudEvent">CloudEvent to copy. Must not be null, and must be a valid CloudEvent.</param>
-        /// <param name="destination">The request to populate. Must not be null.</param>
-        /// <param name="contentMode">Content mode (structured or binary)</param>
-        /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        public static async Task CopyToHttpWebRequestAsync(this CloudEvent cloudEvent, HttpWebRequest destination,
-            ContentMode contentMode, CloudEventFormatter formatter)
+        ReadOnlyMemory<byte> content;
+        // The content type to include in the ContentType header - may be the data content type, or the formatter's content type.
+        ContentType? contentType;
+        switch (contentMode)
         {
-            Validation.CheckCloudEventArgument(cloudEvent, nameof(cloudEvent));
-            Validation.CheckNotNull(destination, nameof(destination));
-            Validation.CheckNotNull(formatter, nameof(formatter));
-
-            ReadOnlyMemory<byte> content;
-            // The content type to include in the ContentType header - may be the data content type, or the formatter's content type.
-            ContentType? contentType;
-            switch (contentMode)
-            {
-                case ContentMode.Structured:
-                    content = formatter.EncodeStructuredModeMessage(cloudEvent, out contentType);
-                    break;
-                case ContentMode.Binary:
-                    content = formatter.EncodeBinaryModeEventData(cloudEvent);
-                    contentType = MimeUtilities.CreateContentTypeOrNull(formatter.GetOrInferDataContentType(cloudEvent));
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(contentMode), $"Unsupported content mode: {contentMode}");
-            }
-
-            if (contentType is object)
-            {
-                destination.ContentType = contentType.ToString();
-            }
-            else if (content.Length != 0)
-            {
-                throw new ArgumentException(Strings.ErrorContentTypeUnspecified, nameof(cloudEvent));
-            }
-
-            // Map headers in either mode.
-            // Including the headers in structured mode is optional in the spec (as they're already within the body) but
-            // can be useful.            
-            destination.Headers.Add(HttpUtilities.SpecVersionHttpHeader, HttpUtilities.EncodeHeaderValue(cloudEvent.SpecVersion.VersionId));
-            foreach (var attributeAndValue in cloudEvent.GetPopulatedAttributes())
-            {
-                var attribute = attributeAndValue.Key;
-                var value = attributeAndValue.Value;
-                if (attribute != cloudEvent.SpecVersion.DataContentTypeAttribute)
-                {
-                    string headerValue = HttpUtilities.EncodeHeaderValue(attribute.Format(value));
-                    destination.Headers.Add(HttpUtilities.HttpHeaderPrefix + attribute.Name, headerValue);
-                }
-            }
-            await BinaryDataUtilities.CopyToStreamAsync(content, destination.GetRequestStream()).ConfigureAwait(false);
+            case ContentMode.Structured:
+                content = formatter.EncodeStructuredModeMessage(cloudEvent, out contentType);
+                break;
+            case ContentMode.Binary:
+                content = formatter.EncodeBinaryModeEventData(cloudEvent);
+                contentType = MimeUtilities.CreateContentTypeOrNull(formatter.GetOrInferDataContentType(cloudEvent));
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(contentMode), $"Unsupported content mode: {contentMode}");
         }
 
-        /// <summary>
-        /// Copies a <see cref="CloudEvent"/> batch into the specified <see cref="HttpWebRequest"/>.
-        /// </summary>
-        /// <param name="cloudEvents">CloudEvent batch to copy. Must not be null, and must be a valid CloudEvent.</param>
-        /// <param name="destination">The request to populate. Must not be null.</param>
-        /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        public static async Task CopyToHttpWebRequestAsync(this IReadOnlyList<CloudEvent> cloudEvents,
-            HttpWebRequest destination,
-            CloudEventFormatter formatter)
+        if (contentType is object)
         {
-            Validation.CheckCloudEventBatchArgument(cloudEvents, nameof(cloudEvents));
-            Validation.CheckNotNull(destination, nameof(destination));
-            Validation.CheckNotNull(formatter, nameof(formatter));
-
-            ReadOnlyMemory<byte> content = formatter.EncodeBatchModeMessage(cloudEvents, out var contentType);
             destination.ContentType = contentType.ToString();
-            await BinaryDataUtilities.CopyToStreamAsync(content, destination.GetRequestStream()).ConfigureAwait(false);
         }
+        else if (content.Length != 0)
+        {
+            throw new ArgumentException(Strings.ErrorContentTypeUnspecified, nameof(cloudEvent));
+        }
+
+        // Map headers in either mode.
+        // Including the headers in structured mode is optional in the spec (as they're already within the body) but
+        // can be useful.            
+        destination.Headers.Add(HttpUtilities.SpecVersionHttpHeader, HttpUtilities.EncodeHeaderValue(cloudEvent.SpecVersion.VersionId));
+        foreach (var attributeAndValue in cloudEvent.GetPopulatedAttributes())
+        {
+            var attribute = attributeAndValue.Key;
+            var value = attributeAndValue.Value;
+            if (attribute != cloudEvent.SpecVersion.DataContentTypeAttribute)
+            {
+                string headerValue = HttpUtilities.EncodeHeaderValue(attribute.Format(value));
+                destination.Headers.Add(HttpUtilities.HttpHeaderPrefix + attribute.Name, headerValue);
+            }
+        }
+        await BinaryDataUtilities.CopyToStreamAsync(content, destination.GetRequestStream()).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Copies a <see cref="CloudEvent"/> batch into the specified <see cref="HttpWebRequest"/>.
+    /// </summary>
+    /// <param name="cloudEvents">CloudEvent batch to copy. Must not be null, and must be a valid CloudEvent.</param>
+    /// <param name="destination">The request to populate. Must not be null.</param>
+    /// <param name="formatter">The formatter to use within the conversion. Must not be null.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task CopyToHttpWebRequestAsync(this IReadOnlyList<CloudEvent> cloudEvents,
+        HttpWebRequest destination,
+        CloudEventFormatter formatter)
+    {
+        Validation.CheckCloudEventBatchArgument(cloudEvents, nameof(cloudEvents));
+        Validation.CheckNotNull(destination, nameof(destination));
+        Validation.CheckNotNull(formatter, nameof(formatter));
+
+        ReadOnlyMemory<byte> content = formatter.EncodeBatchModeMessage(cloudEvents, out var contentType);
+        destination.ContentType = contentType.ToString();
+        await BinaryDataUtilities.CopyToStreamAsync(content, destination.GetRequestStream()).ConfigureAwait(false);
     }
 }

--- a/src/CloudNative.CloudEvents/Timestamps.cs
+++ b/src/CloudNative.CloudEvents/Timestamps.cs
@@ -6,193 +6,192 @@ using CloudNative.CloudEvents.Core;
 using System;
 using System.Globalization;
 
-namespace CloudNative.CloudEvents
+namespace CloudNative.CloudEvents;
+
+/// <summary>
+/// Helper methods for CloudEvent timestamp attributes, which are represented
+/// as <see cref="DateTimeOffset"/> values within the SDK, and use RFC-3339
+/// for string representations (e.g. in headers).
+/// </summary>
+internal static class Timestamps
 {
+    private const long TicksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
+
     /// <summary>
-    /// Helper methods for CloudEvent timestamp attributes, which are represented
-    /// as <see cref="DateTimeOffset"/> values within the SDK, and use RFC-3339
-    /// for string representations (e.g. in headers).
+    /// Length of shortest valid value ("yyyy-MM-ddTHH:mm:ssZ")
     /// </summary>
-    internal static class Timestamps
+    private const int MinLength = 20;
+
+    /// <summary>
+    /// Earliest position of UTC offset indicator in a valid timestamp.
+    /// </summary>
+    private const int MinOffsetIndex = 19;
+
+    /// <summary>
+    /// Length of longest the date/time part of valid value that we'll actually parse
+    /// ("yyyy-MM-ddTHH:mm:ss.FFFFFFF"). Further subsecond digits may be present, but
+    /// we'll ignore them.
+    /// </summary>
+    private const int MaxDateTimeParseLength = 27;
+
+    /// <summary>
+    /// Maximum number of minutes in an offset: DateTimeOffset only handles up to +/- 14 hours.
+    /// </summary>
+    private const int MaxOffsetMinutes = 14 * 60;
+
+    private static readonly char[] offsetLeadingCharacters = { 'Z', '+', '-' };
+
+    /// <summary>
+    /// Attempts to parse a string as an RFC-3339-formatted date/time and UTC offset.
+    /// </summary>
+    /// <param name="input">A string to be parsed as a <see cref="DateTimeOffset"/>.</param>
+    /// <param name="result">A <see cref="DateTimeOffset"/> parsed from the <paramref name="input"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="input"/> was parsed successfully, <see langword="false"/> otherwise.</returns>
+    internal static bool TryParse(string input, out DateTimeOffset result)
     {
-        private const long TicksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
+        Validation.CheckNotNull(input, nameof(input));
 
-        /// <summary>
-        /// Length of shortest valid value ("yyyy-MM-ddTHH:mm:ssZ")
-        /// </summary>
-        private const int MinLength = 20;
-
-        /// <summary>
-        /// Earliest position of UTC offset indicator in a valid timestamp.
-        /// </summary>
-        private const int MinOffsetIndex = 19;
-
-        /// <summary>
-        /// Length of longest the date/time part of valid value that we'll actually parse
-        /// ("yyyy-MM-ddTHH:mm:ss.FFFFFFF"). Further subsecond digits may be present, but
-        /// we'll ignore them.
-        /// </summary>
-        private const int MaxDateTimeParseLength = 27;
-
-        /// <summary>
-        /// Maximum number of minutes in an offset: DateTimeOffset only handles up to +/- 14 hours.
-        /// </summary>
-        private const int MaxOffsetMinutes = 14 * 60;
-
-        private static readonly char[] offsetLeadingCharacters = { 'Z', '+', '-' };
-
-        /// <summary>
-        /// Attempts to parse a string as an RFC-3339-formatted date/time and UTC offset.
-        /// </summary>
-        /// <param name="input">A string to be parsed as a <see cref="DateTimeOffset"/>.</param>
-        /// <param name="result">A <see cref="DateTimeOffset"/> parsed from the <paramref name="input"/>.</param>
-        /// <returns><see langword="true"/> if <paramref name="input"/> was parsed successfully, <see langword="false"/> otherwise.</returns>
-        internal static bool TryParse(string input, out DateTimeOffset result)
+        if (input.Length < MinLength) // "yyyy-MM-ddTHH:mm:ssZ" is the shortest possible value.
         {
-            Validation.CheckNotNull(input, nameof(input));
-
-            if (input.Length < MinLength) // "yyyy-MM-ddTHH:mm:ssZ" is the shortest possible value.
-            {
-                result = default;
-                return false;
-            }
-            // Find the UTC offset indicator, by starting at index 19 (the earliest possible index)
-            // and looking for Z, + or -.
-            int offsetIndex = input.IndexOfAny(offsetLeadingCharacters, MinOffsetIndex);
-            if (offsetIndex == -1)
-            {
-                result = default;
-                return false;
-            }
-            if (!TryParseLocalPart(input, offsetIndex, out var localPart) ||
-                !TryParseOffset(input, offsetIndex, out var offset))
-            {
-                result = default;
-                return false;
-            }
-            result = new DateTimeOffset(localPart, offset);
-            return true;
+            result = default;
+            return false;
         }
-
-        private static bool TryParseLocalPart(string input, int offsetIndex, out DateTime localPart)
+        // Find the UTC offset indicator, by starting at index 19 (the earliest possible index)
+        // and looking for Z, + or -.
+        int offsetIndex = input.IndexOfAny(offsetLeadingCharacters, MinOffsetIndex);
+        if (offsetIndex == -1)
         {
-            // Find the end of the text we want to parse with DateTime.TryParseExact.
-            // We truncate timestamps that have sub-tick precision, but we need to validate that any later characters are digits.
-            string textToParse;
-            if (offsetIndex <= MaxDateTimeParseLength)
+            result = default;
+            return false;
+        }
+        if (!TryParseLocalPart(input, offsetIndex, out var localPart) ||
+            !TryParseOffset(input, offsetIndex, out var offset))
+        {
+            result = default;
+            return false;
+        }
+        result = new DateTimeOffset(localPart, offset);
+        return true;
+    }
+
+    private static bool TryParseLocalPart(string input, int offsetIndex, out DateTime localPart)
+    {
+        // Find the end of the text we want to parse with DateTime.TryParseExact.
+        // We truncate timestamps that have sub-tick precision, but we need to validate that any later characters are digits.
+        string textToParse;
+        if (offsetIndex <= MaxDateTimeParseLength)
+        {
+            textToParse = input.Substring(0, offsetIndex);
+        }
+        else
+        {
+            for (int index = MaxDateTimeParseLength; index < offsetIndex; index++)
             {
-                textToParse = input.Substring(0, offsetIndex);
-            }
-            else
-            {
-                for (int index = MaxDateTimeParseLength; index < offsetIndex; index++)
+                if (!IsAsciiDigit(input[index]))
                 {
-                    if (!IsAsciiDigit(input[index]))
-                    {
-                        localPart = default;
-                        return false;
-                    }
+                    localPart = default;
+                    return false;
                 }
-                textToParse = input.Substring(0, MaxDateTimeParseLength);
             }
-            return DateTime.TryParseExact(
-                textToParse, "yyyy-MM-dd'T'HH:mm:ss.FFFFFFF",
-                CultureInfo.InvariantCulture, DateTimeStyles.None,
-                out localPart);
+            textToParse = input.Substring(0, MaxDateTimeParseLength);
         }
+        return DateTime.TryParseExact(
+            textToParse, "yyyy-MM-dd'T'HH:mm:ss.FFFFFFF",
+            CultureInfo.InvariantCulture, DateTimeStyles.None,
+            out localPart);
+    }
 
-        private static bool TryParseOffset(string input, int offsetIndex, out TimeSpan offset)
+    private static bool TryParseOffset(string input, int offsetIndex, out TimeSpan offset)
+    {
+        char prefix = input[offsetIndex]; // We already know this will be Z, + or -
+        if (prefix == 'Z')
         {
-            char prefix = input[offsetIndex]; // We already know this will be Z, + or -
-            if (prefix == 'Z')
-            {
-                offset = TimeSpan.Zero; // This is the value we want whether or not the length is right
-                return input.Length == offsetIndex + 1; // We expect the Z to be the end of the string
-            }
-            // Non-Z offsets much be exactly in the format +XX:YY or -XX:YY, so we can check the length and
-            // expected characters very straightforwardly.
-            if (input.Length != offsetIndex + 6 ||
-                !IsAsciiDigit(input[offsetIndex + 1]) ||
-                !IsAsciiDigit(input[offsetIndex + 2]) ||
-                input[offsetIndex + 3] != ':' ||
-                !IsAsciiDigit(input[offsetIndex + 4]) ||
-                !IsAsciiDigit(input[offsetIndex + 5]))
-            {
-                offset = default;
-                return false;
-            }
-
-            // Parse the digits as simply as possible.
-            int hours = ParseDigit(input[offsetIndex + 1]) * 10 + ParseDigit(input[offsetIndex + 2]);
-            int minutes = ParseDigit(input[offsetIndex + 4]) * 10 + ParseDigit(input[offsetIndex + 5]);
-            int totalMinutes = hours * 60 + minutes;
-            if (minutes >= 60 || totalMinutes > MaxOffsetMinutes)
-            {
-                offset = default;
-                return false;
-            }
-
-            // Handle the sign
-            if (input[offsetIndex] == '-')
-            {
-                totalMinutes = -totalMinutes;
-            }
-
-            offset = TimeSpan.FromMinutes(totalMinutes);
-            return true;
-
-            static int ParseDigit(char c) => c - '0';
+            offset = TimeSpan.Zero; // This is the value we want whether or not the length is right
+            return input.Length == offsetIndex + 1; // We expect the Z to be the end of the string
         }
-
-        private static bool IsAsciiDigit(char c) => c >= '0' && c <= '9';
-
-        /// <summary>
-        /// Parses a string as an RFC-3339-formatted date/time and UTC offset.
-        /// </summary>
-        /// <param name="input"></param>
-        /// <returns></returns>
-        public static DateTimeOffset Parse(string input) =>
-            TryParse(input, out var result) ? result : throw new FormatException("Invalid timestamp");
-
-        /// <summary>
-        /// Converts a <see cref="DateTimeOffset"/> value to a string using RFC-3339 format.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The sub-second precision in the result is determined by the first of the following conditions
-        /// to be met:
-        /// If the value is a whole number of seconds, the result contains no fractional-second
-        /// indicator at all.
-        /// If the sub-second value is a whole number of milliseconds, the result will contain three
-        /// digits of sub-second precision.
-        /// If the sub-second value is a whole number of microseconds, the result will contain six
-        /// digits of sub-second precision.
-        /// Otherwise, the result will contain 7 digits of sub-second precision. (This is the maximum
-        /// precision of <see cref="DateTimeOffset"/>.)
-        /// </para>
-        /// <para>
-        /// If the UTC offset is zero, this is represented as a suffix of 'Z';
-        /// otherwise, the offset is represented in the "+HH:mm" or "-HH:mm" format.
-        /// </para>
-        /// </remarks>
-        /// <param name="value">The value to convert to an RFC-3339 format string.</param>
-        /// <returns>The formatted string.</returns>
-        public static string Format(DateTimeOffset value)
+        // Non-Z offsets much be exactly in the format +XX:YY or -XX:YY, so we can check the length and
+        // expected characters very straightforwardly.
+        if (input.Length != offsetIndex + 6 ||
+            !IsAsciiDigit(input[offsetIndex + 1]) ||
+            !IsAsciiDigit(input[offsetIndex + 2]) ||
+            input[offsetIndex + 3] != ':' ||
+            !IsAsciiDigit(input[offsetIndex + 4]) ||
+            !IsAsciiDigit(input[offsetIndex + 5]))
         {
-            var ticks = value.Ticks;
-            string formatString =
-                value.Offset.Ticks == 0 ?
-                    // UTC+0 branch: hard-code 'Z'
-                    (ticks % TimeSpan.TicksPerSecond == 0 ? "yyyy-MM-dd'T'HH:mm:ss'Z'" :
-                    ticks % TimeSpan.TicksPerMillisecond == 0 ? "yyyy-MM-dd'T'HH:mm:ss.fff'Z'" :
-                    ticks % TicksPerMicrosecond == 0 ? "yyyy-MM-dd'T'HH:mm:ss.ffffff'Z'" :
-                    "yyyy-MM-dd'T'HH:mm:ss.fffffff'Z'") :
-                    // Non-UTC branch: use zzz to format the offset
-                    (ticks % TimeSpan.TicksPerSecond == 0 ? "yyyy-MM-dd'T'HH:mm:sszzz" :
-                    ticks % TimeSpan.TicksPerMillisecond == 0 ? "yyyy-MM-dd'T'HH:mm:ss.fffzzz" :
-                    ticks % TicksPerMicrosecond == 0 ? "yyyy-MM-dd'T'HH:mm:ss.ffffffzzz" :
-                    "yyyy-MM-dd'T'HH:mm:ss.fffffffzzz");
-            return value.ToString(formatString, CultureInfo.InvariantCulture);
+            offset = default;
+            return false;
         }
+
+        // Parse the digits as simply as possible.
+        int hours = ParseDigit(input[offsetIndex + 1]) * 10 + ParseDigit(input[offsetIndex + 2]);
+        int minutes = ParseDigit(input[offsetIndex + 4]) * 10 + ParseDigit(input[offsetIndex + 5]);
+        int totalMinutes = hours * 60 + minutes;
+        if (minutes >= 60 || totalMinutes > MaxOffsetMinutes)
+        {
+            offset = default;
+            return false;
+        }
+
+        // Handle the sign
+        if (input[offsetIndex] == '-')
+        {
+            totalMinutes = -totalMinutes;
+        }
+
+        offset = TimeSpan.FromMinutes(totalMinutes);
+        return true;
+
+        static int ParseDigit(char c) => c - '0';
+    }
+
+    private static bool IsAsciiDigit(char c) => c >= '0' && c <= '9';
+
+    /// <summary>
+    /// Parses a string as an RFC-3339-formatted date/time and UTC offset.
+    /// </summary>
+    /// <param name="input"></param>
+    /// <returns></returns>
+    public static DateTimeOffset Parse(string input) =>
+        TryParse(input, out var result) ? result : throw new FormatException("Invalid timestamp");
+
+    /// <summary>
+    /// Converts a <see cref="DateTimeOffset"/> value to a string using RFC-3339 format.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The sub-second precision in the result is determined by the first of the following conditions
+    /// to be met:
+    /// If the value is a whole number of seconds, the result contains no fractional-second
+    /// indicator at all.
+    /// If the sub-second value is a whole number of milliseconds, the result will contain three
+    /// digits of sub-second precision.
+    /// If the sub-second value is a whole number of microseconds, the result will contain six
+    /// digits of sub-second precision.
+    /// Otherwise, the result will contain 7 digits of sub-second precision. (This is the maximum
+    /// precision of <see cref="DateTimeOffset"/>.)
+    /// </para>
+    /// <para>
+    /// If the UTC offset is zero, this is represented as a suffix of 'Z';
+    /// otherwise, the offset is represented in the "+HH:mm" or "-HH:mm" format.
+    /// </para>
+    /// </remarks>
+    /// <param name="value">The value to convert to an RFC-3339 format string.</param>
+    /// <returns>The formatted string.</returns>
+    public static string Format(DateTimeOffset value)
+    {
+        var ticks = value.Ticks;
+        string formatString =
+            value.Offset.Ticks == 0 ?
+                // UTC+0 branch: hard-code 'Z'
+                (ticks % TimeSpan.TicksPerSecond == 0 ? "yyyy-MM-dd'T'HH:mm:ss'Z'" :
+                ticks % TimeSpan.TicksPerMillisecond == 0 ? "yyyy-MM-dd'T'HH:mm:ss.fff'Z'" :
+                ticks % TicksPerMicrosecond == 0 ? "yyyy-MM-dd'T'HH:mm:ss.ffffff'Z'" :
+                "yyyy-MM-dd'T'HH:mm:ss.fffffff'Z'") :
+                // Non-UTC branch: use zzz to format the offset
+                (ticks % TimeSpan.TicksPerSecond == 0 ? "yyyy-MM-dd'T'HH:mm:sszzz" :
+                ticks % TimeSpan.TicksPerMillisecond == 0 ? "yyyy-MM-dd'T'HH:mm:ss.fffzzz" :
+                ticks % TicksPerMicrosecond == 0 ? "yyyy-MM-dd'T'HH:mm:ss.ffffffzzz" :
+                "yyyy-MM-dd'T'HH:mm:ss.fffffffzzz");
+        return value.ToString(formatString, CultureInfo.InvariantCulture);
     }
 }

--- a/test/CloudNative.CloudEvents.IntegrationTests/AspNetCore/CloudEventBindingTests.cs
+++ b/test/CloudNative.CloudEvents.IntegrationTests/AspNetCore/CloudEventBindingTests.cs
@@ -10,46 +10,45 @@ using System.Net;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace CloudNative.CloudEvents.IntegrationTests.AspNetCore
+namespace CloudNative.CloudEvents.IntegrationTests.AspNetCore;
+
+public class CloudEventBindingTests : IClassFixture<WebApplicationFactory<Program>>
 {
-    public class CloudEventBindingTests : IClassFixture<WebApplicationFactory<Program>>
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public CloudEventBindingTests(WebApplicationFactory<Program> factory)
     {
-        private readonly WebApplicationFactory<Program> _factory;
+        _factory = factory;
+    }
 
-        public CloudEventBindingTests(WebApplicationFactory<Program> factory)
+    [Theory]
+    [InlineData(ContentMode.Structured)]
+    [InlineData(ContentMode.Binary)]
+    public async Task Binding_WithValidCloudEvent_NoContent_DeserializesUsingPipeline(ContentMode contentMode)
+    {
+        // Arrange
+        var expectedExtensionKey = "comexampleextension1";
+        var expectedExtensionValue = Guid.NewGuid().ToString();
+        var cloudEvent = new CloudEvent
         {
-            _factory = factory;
-        }
+            Type = "test-type-æøå",
+            Source = new Uri("urn:integration-tests"),
+            Id = Guid.NewGuid().ToString(),
+            DataContentType = "application/json",
+            Data = new { key1 = "value1" },
+            [expectedExtensionKey] = expectedExtensionValue
+        };
 
-        [Theory]
-        [InlineData(ContentMode.Structured)]
-        [InlineData(ContentMode.Binary)]
-        public async Task Binding_WithValidCloudEvent_NoContent_DeserializesUsingPipeline(ContentMode contentMode)
-        {
-            // Arrange
-            var expectedExtensionKey = "comexampleextension1";
-            var expectedExtensionValue = Guid.NewGuid().ToString();
-            var cloudEvent = new CloudEvent
-            {
-                Type = "test-type-æøå",
-                Source = new Uri("urn:integration-tests"),
-                Id = Guid.NewGuid().ToString(),
-                DataContentType = "application/json",
-                Data = new { key1 = "value1" },
-                [expectedExtensionKey] = expectedExtensionValue
-            };
+        var httpContent = cloudEvent.ToHttpContent(contentMode, new JsonEventFormatter());
 
-            var httpContent = cloudEvent.ToHttpContent(contentMode, new JsonEventFormatter());
+        // Act
+        var result = await _factory.CreateClient().PostAsync("/api/events/receive", httpContent);
 
-            // Act
-            var result = await _factory.CreateClient().PostAsync("/api/events/receive", httpContent);
-
-            // Assert
-            string resultContent = await result.Content.ReadAsStringAsync();
-            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
-            Assert.Contains(cloudEvent.Id, resultContent);
-            Assert.Contains(cloudEvent.Type, resultContent);
-            Assert.Contains($"\"{expectedExtensionKey}\":\"{expectedExtensionValue}\"", resultContent);
-        }
+        // Assert
+        string resultContent = await result.Content.ReadAsStringAsync();
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Contains(cloudEvent.Id, resultContent);
+        Assert.Contains(cloudEvent.Type, resultContent);
+        Assert.Contains($"\"{expectedExtensionKey}\":\"{expectedExtensionValue}\"", resultContent);
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/Amqp/AmqpTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Amqp/AmqpTest.cs
@@ -11,132 +11,131 @@ using System.Text;
 using Xunit;
 using static CloudNative.CloudEvents.UnitTests.TestHelpers;
 
-namespace CloudNative.CloudEvents.Amqp.UnitTests
+namespace CloudNative.CloudEvents.Amqp.UnitTests;
+
+public class AmqpTest
 {
-    public class AmqpTest
+    [Fact]
+    public void AmqpStructuredMessageTest()
     {
-        [Fact]
-        public void AmqpStructuredMessageTest()
+        // The AMQPNetLite library is factored such that we don't need to do a wire test here.
+        var cloudEvent = CreateSampleCloudEvent();
+        var message = cloudEvent.ToAmqpMessage(ContentMode.Structured, new JsonEventFormatter());
+        Assert.True(message.IsCloudEvent());
+        AssertDecodeThenEqual(cloudEvent, message);
+    }
+
+    [Fact]
+    public void AmqpBinaryMessageTest()
+    {
+        // The AMQPNetLite library is factored such that we don't need to do a wire test here.
+        var cloudEvent = CreateSampleCloudEvent();
+        var message = cloudEvent.ToAmqpMessage(ContentMode.Binary, new JsonEventFormatter());
+        Assert.True(message.IsCloudEvent());
+        var encodedAmqpMessage = message.Encode();
+
+        var message1 = Message.Decode(encodedAmqpMessage);
+        Assert.True(message1.IsCloudEvent());
+        var receivedCloudEvent = message1.ToCloudEvent(new JsonEventFormatter());
+
+        AssertCloudEventsEqual(cloudEvent, receivedCloudEvent);
+    }
+
+    [Fact]
+    public void BinaryMode_ContentTypeCanBeInferredByFormatter()
+    {
+        var cloudEvent = new CloudEvent
         {
-            // The AMQPNetLite library is factored such that we don't need to do a wire test here.
-            var cloudEvent = CreateSampleCloudEvent();
-            var message = cloudEvent.ToAmqpMessage(ContentMode.Structured, new JsonEventFormatter());
-            Assert.True(message.IsCloudEvent());
-            AssertDecodeThenEqual(cloudEvent, message);
-        }
+            Data = "plain text"
+        }.PopulateRequiredAttributes();
 
-        [Fact]
-        public void AmqpBinaryMessageTest()
-        {
-            // The AMQPNetLite library is factored such that we don't need to do a wire test here.
-            var cloudEvent = CreateSampleCloudEvent();
-            var message = cloudEvent.ToAmqpMessage(ContentMode.Binary, new JsonEventFormatter());
-            Assert.True(message.IsCloudEvent());
-            var encodedAmqpMessage = message.Encode();
+        var message = cloudEvent.ToAmqpMessage(ContentMode.Binary, new JsonEventFormatter());
+        Assert.Equal("application/json", message.Properties.ContentType);
+    }
 
-            var message1 = Message.Decode(encodedAmqpMessage);
-            Assert.True(message1.IsCloudEvent());
-            var receivedCloudEvent = message1.ToCloudEvent(new JsonEventFormatter());
-
-            AssertCloudEventsEqual(cloudEvent, receivedCloudEvent);
-        }
-
-        [Fact]
-        public void BinaryMode_ContentTypeCanBeInferredByFormatter()
-        {
-            var cloudEvent = new CloudEvent
-            {
-                Data = "plain text"
-            }.PopulateRequiredAttributes();
-
-            var message = cloudEvent.ToAmqpMessage(ContentMode.Binary, new JsonEventFormatter());
-            Assert.Equal("application/json", message.Properties.ContentType);
-        }
-
-        [Fact]
-        public void AmqpNormalizesTimestampsToUtc()
-        {
-            var cloudEvent = new CloudEvent
-            {
-                Type = "com.github.pull.create",
-                Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
-                Id = "A234-1234-1234",
-                // 2018-04-05T18:31:00+01:00 => 2018-04-05T17:31:00Z
-                Time = new DateTimeOffset(2018, 4, 5, 18, 31, 0, TimeSpan.FromHours(1))
-            };
-
-            var message = cloudEvent.ToAmqpMessage(ContentMode.Binary, new JsonEventFormatter());
-            var encodedAmqpMessage = message.Encode();
-
-            var message1 = Message.Decode(encodedAmqpMessage);
-            var receivedCloudEvent = message1.ToCloudEvent(new JsonEventFormatter());
-
-            AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time!.Value);
-        }
-
-        [Fact]
-        public void EncodeTextDataInBinaryMode_PopulatesDataProperty()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.DataContentType = "text/plain";
-            cloudEvent.Data = "some text";
-
-            var message = cloudEvent.ToAmqpMessage(ContentMode.Binary, new JsonEventFormatter());
-            var body = Assert.IsType<Data>(message.BodySection);
-            var text = Encoding.UTF8.GetString(body.Binary);
-            Assert.Equal("some text", text);
-        }
-
-        [Fact]
-        public void DefaultPrefix()
-        {
-            var cloudEvent = CreateSampleCloudEvent();
-
-            var message = cloudEvent.ToAmqpMessage(ContentMode.Binary, new JsonEventFormatter());
-            Assert.Equal(cloudEvent.Id, message.ApplicationProperties["cloudEvents:id"]);
-            AssertDecodeThenEqual(cloudEvent, message);
-        }
-
-        [Fact]
-        public void UnderscorePrefix()
-        {
-            var cloudEvent = CreateSampleCloudEvent();
-            var message = cloudEvent.ToAmqpMessageWithUnderscorePrefix(ContentMode.Binary, new JsonEventFormatter());
-            Assert.Equal(cloudEvent.Id, message.ApplicationProperties["cloudEvents_id"]);
-            AssertDecodeThenEqual(cloudEvent, message);
-        }
-
-        [Fact]
-        public void ColonPrefix()
-        {
-            var cloudEvent = CreateSampleCloudEvent();
-            var message = cloudEvent.ToAmqpMessageWithColonPrefix(ContentMode.Binary, new JsonEventFormatter());
-            Assert.Equal(cloudEvent.Id, message.ApplicationProperties["cloudEvents:id"]);
-            AssertDecodeThenEqual(cloudEvent, message);
-        }
-
-        private void AssertDecodeThenEqual(CloudEvent cloudEvent, Message message)
-        {
-            var encodedAmqpMessage = message.Encode();
-
-            var message1 = Message.Decode(encodedAmqpMessage);
-            var receivedCloudEvent = message1.ToCloudEvent(new JsonEventFormatter());
-            AssertCloudEventsEqual(cloudEvent, receivedCloudEvent);
-        }
-
-        /// <summary>
-        /// Returns a CloudEvent with XML data and an extension.
-        /// </summary>
-        private static CloudEvent CreateSampleCloudEvent() => new CloudEvent
+    [Fact]
+    public void AmqpNormalizesTimestampsToUtc()
+    {
+        var cloudEvent = new CloudEvent
         {
             Type = "com.github.pull.create",
-            Source = new Uri("https://github.com/cloudevents/spec/pull"),
-            Subject = "123",
+            Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
             Id = "A234-1234-1234",
-            Time = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero),
-            DataContentType = MediaTypeNames.Text.Xml,
-            Data = "<much wow=\"xml\"/>",
-            ["comexampleextension1"] = "value"
+            // 2018-04-05T18:31:00+01:00 => 2018-04-05T17:31:00Z
+            Time = new DateTimeOffset(2018, 4, 5, 18, 31, 0, TimeSpan.FromHours(1))
         };
+
+        var message = cloudEvent.ToAmqpMessage(ContentMode.Binary, new JsonEventFormatter());
+        var encodedAmqpMessage = message.Encode();
+
+        var message1 = Message.Decode(encodedAmqpMessage);
+        var receivedCloudEvent = message1.ToCloudEvent(new JsonEventFormatter());
+
+        AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time!.Value);
     }
+
+    [Fact]
+    public void EncodeTextDataInBinaryMode_PopulatesDataProperty()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.DataContentType = "text/plain";
+        cloudEvent.Data = "some text";
+
+        var message = cloudEvent.ToAmqpMessage(ContentMode.Binary, new JsonEventFormatter());
+        var body = Assert.IsType<Data>(message.BodySection);
+        var text = Encoding.UTF8.GetString(body.Binary);
+        Assert.Equal("some text", text);
+    }
+
+    [Fact]
+    public void DefaultPrefix()
+    {
+        var cloudEvent = CreateSampleCloudEvent();
+
+        var message = cloudEvent.ToAmqpMessage(ContentMode.Binary, new JsonEventFormatter());
+        Assert.Equal(cloudEvent.Id, message.ApplicationProperties["cloudEvents:id"]);
+        AssertDecodeThenEqual(cloudEvent, message);
+    }
+
+    [Fact]
+    public void UnderscorePrefix()
+    {
+        var cloudEvent = CreateSampleCloudEvent();
+        var message = cloudEvent.ToAmqpMessageWithUnderscorePrefix(ContentMode.Binary, new JsonEventFormatter());
+        Assert.Equal(cloudEvent.Id, message.ApplicationProperties["cloudEvents_id"]);
+        AssertDecodeThenEqual(cloudEvent, message);
+    }
+
+    [Fact]
+    public void ColonPrefix()
+    {
+        var cloudEvent = CreateSampleCloudEvent();
+        var message = cloudEvent.ToAmqpMessageWithColonPrefix(ContentMode.Binary, new JsonEventFormatter());
+        Assert.Equal(cloudEvent.Id, message.ApplicationProperties["cloudEvents:id"]);
+        AssertDecodeThenEqual(cloudEvent, message);
+    }
+
+    private void AssertDecodeThenEqual(CloudEvent cloudEvent, Message message)
+    {
+        var encodedAmqpMessage = message.Encode();
+
+        var message1 = Message.Decode(encodedAmqpMessage);
+        var receivedCloudEvent = message1.ToCloudEvent(new JsonEventFormatter());
+        AssertCloudEventsEqual(cloudEvent, receivedCloudEvent);
+    }
+
+    /// <summary>
+    /// Returns a CloudEvent with XML data and an extension.
+    /// </summary>
+    private static CloudEvent CreateSampleCloudEvent() => new CloudEvent
+    {
+        Type = "com.github.pull.create",
+        Source = new Uri("https://github.com/cloudevents/spec/pull"),
+        Subject = "123",
+        Id = "A234-1234-1234",
+        Time = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero),
+        DataContentType = MediaTypeNames.Text.Xml,
+        Data = "<much wow=\"xml\"/>",
+        ["comexampleextension1"] = "value"
+    };
 }

--- a/test/CloudNative.CloudEvents.UnitTests/AspNetCore/HttpRequestExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/AspNetCore/HttpRequestExtensionsTest.cs
@@ -12,11 +12,11 @@ using System.Threading.Tasks;
 using Xunit;
 using static CloudNative.CloudEvents.UnitTests.TestHelpers;
 
-namespace CloudNative.CloudEvents.AspNetCore.UnitTests
+namespace CloudNative.CloudEvents.AspNetCore.UnitTests;
+
+public class HttpRequestExtensionsTest
 {
-    public class HttpRequestExtensionsTest
-    {
-        public static TheoryData<string, string, IDictionary<string, string>?> SingleCloudEventMessages = new TheoryData<string, string, IDictionary<string, string>?>
+    public static TheoryData<string, string, IDictionary<string, string>?> SingleCloudEventMessages = new TheoryData<string, string, IDictionary<string, string>?>
         {
             {
                 "Binary",
@@ -36,7 +36,7 @@ namespace CloudNative.CloudEvents.AspNetCore.UnitTests
             }
         };
 
-        public static TheoryData<string, string, IDictionary<string, string>?> BatchMessages = new TheoryData<string, string, IDictionary<string, string>?>
+    public static TheoryData<string, string, IDictionary<string, string>?> BatchMessages = new TheoryData<string, string, IDictionary<string, string>?>
         {
             {
                 "Batch",
@@ -45,7 +45,7 @@ namespace CloudNative.CloudEvents.AspNetCore.UnitTests
             }
         };
 
-        public static TheoryData<string, string, IDictionary<string, string>?> NonCloudEventMessages = new TheoryData<string, string, IDictionary<string, string>?>
+    public static TheoryData<string, string, IDictionary<string, string>?> NonCloudEventMessages = new TheoryData<string, string, IDictionary<string, string>?>
         {
             {
                 "Plain text",
@@ -54,99 +54,98 @@ namespace CloudNative.CloudEvents.AspNetCore.UnitTests
             }
         };
 
-        [Theory]
-        [MemberData(nameof(SingleCloudEventMessages))]
-        public void IsCloudEvent_True(string description, string contentType, IDictionary<string, string>? headers)
-        {
-            // Really only present for display purposes.
-            Assert.NotNull(description);
+    [Theory]
+    [MemberData(nameof(SingleCloudEventMessages))]
+    public void IsCloudEvent_True(string description, string contentType, IDictionary<string, string>? headers)
+    {
+        // Really only present for display purposes.
+        Assert.NotNull(description);
 
-            var request = CreateRequest(new byte[0], new ContentType(contentType));
-            CopyHeaders(headers, request);
-            Assert.True(request.IsCloudEvent());
+        var request = CreateRequest(new byte[0], new ContentType(contentType));
+        CopyHeaders(headers, request);
+        Assert.True(request.IsCloudEvent());
+    }
+
+    [Theory]
+    [MemberData(nameof(BatchMessages))]
+    [MemberData(nameof(NonCloudEventMessages))]
+    public void IsCloudEvent_False(string description, string contentType, IDictionary<string, string>? headers)
+    {
+        // Really only present for display purposes.
+        Assert.NotNull(description);
+
+        var request = CreateRequest(new byte[0], new ContentType(contentType));
+        CopyHeaders(headers, request);
+        Assert.False(request.IsCloudEvent());
+    }
+
+    [Theory]
+    [MemberData(nameof(BatchMessages))]
+    public void IsCloudEventBatch_True(string description, string contentType, IDictionary<string, string>? headers)
+    {
+        // Really only present for display purposes.
+        Assert.NotNull(description);
+
+        var request = CreateRequest(new byte[0], new ContentType(contentType));
+        CopyHeaders(headers, request);
+        Assert.True(request.IsCloudEventBatch());
+    }
+
+    [Theory]
+    [MemberData(nameof(SingleCloudEventMessages))]
+    [MemberData(nameof(NonCloudEventMessages))]
+    public void IsCloudEventBatch_False(string description, string contentType, IDictionary<string, string>? headers)
+    {
+        // Really only present for display purposes.
+        Assert.NotNull(description);
+
+        var request = CreateRequest(new byte[0], new ContentType(contentType));
+        CopyHeaders(headers, request);
+        Assert.False(request.IsCloudEventBatch());
+    }
+
+    // TODO: Non-batch conversion tests
+
+    [Fact]
+    public async Task ToCloudEventBatchAsync_Valid()
+    {
+        var batch = CreateSampleBatch();
+
+        var formatter = new JsonEventFormatter();
+        var contentBytes = formatter.EncodeBatchModeMessage(batch, out var contentType);
+
+        AssertBatchesEqual(batch, await CreateRequest(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionArray));
+        AssertBatchesEqual(batch, await CreateRequest(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionSequence));
+    }
+
+    [Fact]
+    public async Task ToCloudEventBatchAsync_Invalid()
+    {
+        // Most likely accident: calling ToCloudEventBatchAsync with a single event in structured mode.
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        var formatter = new JsonEventFormatter();
+        var contentBytes = formatter.EncodeStructuredModeMessage(cloudEvent, out var contentType);
+        await Assert.ThrowsAsync<ArgumentException>(() => CreateRequest(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionArray));
+        await Assert.ThrowsAsync<ArgumentException>(() => CreateRequest(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionSequence));
+    }
+
+    private static HttpRequest CreateRequest(ReadOnlyMemory<byte> content, ContentType contentType)
+    {
+        var request = new DefaultHttpContext().Request;
+        request.ContentType = contentType.ToString();
+        request.Body = BinaryDataUtilities.AsStream(content);
+        return request;
+    }
+
+    private static void CopyHeaders(IDictionary<string, string>? source, HttpRequest target)
+    {
+        if (source is null)
+        {
+            return;
         }
-
-        [Theory]
-        [MemberData(nameof(BatchMessages))]
-        [MemberData(nameof(NonCloudEventMessages))]
-        public void IsCloudEvent_False(string description, string contentType, IDictionary<string, string>? headers)
+        foreach (var header in source)
         {
-            // Really only present for display purposes.
-            Assert.NotNull(description);
-
-            var request = CreateRequest(new byte[0], new ContentType(contentType));
-            CopyHeaders(headers, request);
-            Assert.False(request.IsCloudEvent());
-        }
-
-        [Theory]
-        [MemberData(nameof(BatchMessages))]
-        public void IsCloudEventBatch_True(string description, string contentType, IDictionary<string, string>? headers)
-        {
-            // Really only present for display purposes.
-            Assert.NotNull(description);
-
-            var request = CreateRequest(new byte[0], new ContentType(contentType));
-            CopyHeaders(headers, request);
-            Assert.True(request.IsCloudEventBatch());
-        }
-
-        [Theory]
-        [MemberData(nameof(SingleCloudEventMessages))]
-        [MemberData(nameof(NonCloudEventMessages))]
-        public void IsCloudEventBatch_False(string description, string contentType, IDictionary<string, string>? headers)
-        {
-            // Really only present for display purposes.
-            Assert.NotNull(description);
-
-            var request = CreateRequest(new byte[0], new ContentType(contentType));
-            CopyHeaders(headers, request);
-            Assert.False(request.IsCloudEventBatch());
-        }
-
-        // TODO: Non-batch conversion tests
-
-        [Fact]
-        public async Task ToCloudEventBatchAsync_Valid()
-        {
-            var batch = CreateSampleBatch();
-
-            var formatter = new JsonEventFormatter();
-            var contentBytes = formatter.EncodeBatchModeMessage(batch, out var contentType);
-
-            AssertBatchesEqual(batch, await CreateRequest(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionArray));
-            AssertBatchesEqual(batch, await CreateRequest(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionSequence));
-        }
-
-        [Fact]
-        public async Task ToCloudEventBatchAsync_Invalid()
-        {
-            // Most likely accident: calling ToCloudEventBatchAsync with a single event in structured mode.
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            var formatter = new JsonEventFormatter();
-            var contentBytes = formatter.EncodeStructuredModeMessage(cloudEvent, out var contentType);
-            await Assert.ThrowsAsync<ArgumentException>(() => CreateRequest(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionArray));
-            await Assert.ThrowsAsync<ArgumentException>(() => CreateRequest(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionSequence));
-        }
-
-        private static HttpRequest CreateRequest(ReadOnlyMemory<byte> content, ContentType contentType)
-        {
-            var request = new DefaultHttpContext().Request;
-            request.ContentType = contentType.ToString();
-            request.Body = BinaryDataUtilities.AsStream(content);
-            return request;
-        }
-
-        private static void CopyHeaders(IDictionary<string, string>? source, HttpRequest target)
-        {
-            if (source is null)
-            {
-                return;
-            }
-            foreach (var header in source)
-            {
-                target.Headers.Append(header.Key, header.Value);
-            }
+            target.Headers.Append(header.Key, header.Value);
         }
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/AspNetCore/HttpResponseExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/AspNetCore/HttpResponseExtensionsTest.cs
@@ -13,123 +13,122 @@ using System.Threading.Tasks;
 using Xunit;
 using static CloudNative.CloudEvents.UnitTests.TestHelpers;
 
-namespace CloudNative.CloudEvents.AspNetCore.UnitTests
+namespace CloudNative.CloudEvents.AspNetCore.UnitTests;
+
+public class HttpResponseExtensionsTest
 {
-    public class HttpResponseExtensionsTest
+    [Fact]
+    public async Task CopyToHttpResponseAsync_BinaryMode()
     {
-        [Fact]
-        public async Task CopyToHttpResponseAsync_BinaryMode()
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent
-            {
-                Data = "plain text",
-                DataContentType = "text/plain"
-            }.PopulateRequiredAttributes();
-            var formatter = new JsonEventFormatter();
-            var response = CreateResponse();
-            await cloudEvent.CopyToHttpResponseAsync(response, ContentMode.Binary, formatter);
+            Data = "plain text",
+            DataContentType = "text/plain"
+        }.PopulateRequiredAttributes();
+        var formatter = new JsonEventFormatter();
+        var response = CreateResponse();
+        await cloudEvent.CopyToHttpResponseAsync(response, ContentMode.Binary, formatter);
 
-            var content = GetContent(response);
-            Assert.Equal("text/plain", response.ContentType);
-            Assert.Equal("plain text", Encoding.UTF8.GetString(content.Span));
-            Assert.Equal("1.0", response.Headers["ce-specversion"]);
-            Assert.Equal(cloudEvent.Type, response.Headers["ce-type"]);
-            Assert.Equal(cloudEvent.Id, response.Headers["ce-id"]);
-            Assert.Equal(CloudEventAttributeType.UriReference.Format(cloudEvent.Source!), response.Headers["ce-source"]);
-            // There's no data content type header; the content type itself is used for that.
-            Assert.False(response.Headers.ContainsKey("ce-datacontenttype"));
-        }
+        var content = GetContent(response);
+        Assert.Equal("text/plain", response.ContentType);
+        Assert.Equal("plain text", Encoding.UTF8.GetString(content.Span));
+        Assert.Equal("1.0", response.Headers["ce-specversion"]);
+        Assert.Equal(cloudEvent.Type, response.Headers["ce-type"]);
+        Assert.Equal(cloudEvent.Id, response.Headers["ce-id"]);
+        Assert.Equal(CloudEventAttributeType.UriReference.Format(cloudEvent.Source!), response.Headers["ce-source"]);
+        // There's no data content type header; the content type itself is used for that.
+        Assert.False(response.Headers.ContainsKey("ce-datacontenttype"));
+    }
 
-        [Fact]
-        public async Task CopyToHttpResponseAsync_BinaryDataButNoDataContentType()
+    [Fact]
+    public async Task CopyToHttpResponseAsync_BinaryDataButNoDataContentType()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent
-            {
-                Data = new byte[10],
-            }.PopulateRequiredAttributes();
-            var formatter = new JsonEventFormatter();
-            var response = CreateResponse();
-            // The formatter doesn't infer the data content type for binary data.
-            await Assert.ThrowsAsync<ArgumentException>(() => cloudEvent.CopyToHttpResponseAsync(response, ContentMode.Binary, formatter));
-        }
+            Data = new byte[10],
+        }.PopulateRequiredAttributes();
+        var formatter = new JsonEventFormatter();
+        var response = CreateResponse();
+        // The formatter doesn't infer the data content type for binary data.
+        await Assert.ThrowsAsync<ArgumentException>(() => cloudEvent.CopyToHttpResponseAsync(response, ContentMode.Binary, formatter));
+    }
 
-        [Fact]
-        public async Task CopyToHttpResponseAsync_NonBinaryDataButNoDataContentType_ContentTypeIsInferred()
+    [Fact]
+    public async Task CopyToHttpResponseAsync_NonBinaryDataButNoDataContentType_ContentTypeIsInferred()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent
-            {
-                Data = "plain text",
-            }.PopulateRequiredAttributes();
-            var formatter = new JsonEventFormatter();
-            var response = CreateResponse();
-            await cloudEvent.CopyToHttpResponseAsync(response, ContentMode.Binary, formatter);
-            var content = GetContent(response);
-            // The formatter infers that it should encode the string as a JSON value (so it includes the double quotes)
-            Assert.Equal("application/json", response.ContentType);
-            Assert.Equal("\"plain text\"", Encoding.UTF8.GetString(content.Span));
-        }
+            Data = "plain text",
+        }.PopulateRequiredAttributes();
+        var formatter = new JsonEventFormatter();
+        var response = CreateResponse();
+        await cloudEvent.CopyToHttpResponseAsync(response, ContentMode.Binary, formatter);
+        var content = GetContent(response);
+        // The formatter infers that it should encode the string as a JSON value (so it includes the double quotes)
+        Assert.Equal("application/json", response.ContentType);
+        Assert.Equal("\"plain text\"", Encoding.UTF8.GetString(content.Span));
+    }
 
-        [Fact]
-        public async Task CopyToHttpResponseAsync_BadContentMode()
+    [Fact]
+    public async Task CopyToHttpResponseAsync_BadContentMode()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        var formatter = new JsonEventFormatter();
+        var response = CreateResponse();
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => cloudEvent.CopyToHttpResponseAsync(response, (ContentMode) 100, formatter));
+    }
+
+    [Fact]
+    public async Task CopyToHttpResponseAsync_StructuredMode()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            var formatter = new JsonEventFormatter();
-            var response = CreateResponse();
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => cloudEvent.CopyToHttpResponseAsync(response, (ContentMode) 100, formatter));
-        }
+            Data = "plain text",
+            DataContentType = "text/plain"
+        }.PopulateRequiredAttributes();
+        var formatter = new JsonEventFormatter();
+        var response = CreateResponse();
+        await cloudEvent.CopyToHttpResponseAsync(response, ContentMode.Structured, formatter);
+        var content = GetContent(response);
+        Assert.Equal(MimeUtilities.MediaType + "+json; charset=utf-8", response.ContentType);
+        Assert.NotNull(response.ContentType);
 
-        [Fact]
-        public async Task CopyToHttpResponseAsync_StructuredMode()
-        {
-            var cloudEvent = new CloudEvent
-            {
-                Data = "plain text",
-                DataContentType = "text/plain"
-            }.PopulateRequiredAttributes();
-            var formatter = new JsonEventFormatter();
-            var response = CreateResponse();
-            await cloudEvent.CopyToHttpResponseAsync(response, ContentMode.Structured, formatter);
-            var content = GetContent(response);
-            Assert.Equal(MimeUtilities.MediaType + "+json; charset=utf-8", response.ContentType);
-            Assert.NotNull(response.ContentType);
+        var parsed = new JsonEventFormatter().DecodeStructuredModeMessage(content, new ContentType(response.ContentType), extensionAttributes: null);
+        AssertCloudEventsEqual(cloudEvent, parsed);
 
-            var parsed = new JsonEventFormatter().DecodeStructuredModeMessage(content, new ContentType(response.ContentType), extensionAttributes: null);
-            AssertCloudEventsEqual(cloudEvent, parsed);
+        // We populate headers even though we don't strictly need to; let's validate that.
+        Assert.Equal("1.0", response.Headers["ce-specversion"]);
+        Assert.Equal(cloudEvent.Type, response.Headers["ce-type"]);
+        Assert.Equal(cloudEvent.Id, response.Headers["ce-id"]);
+        Assert.Equal(CloudEventAttributeType.UriReference.Format(cloudEvent.Source!), response.Headers["ce-source"]);
+        // We don't populate the data content type header
+        Assert.False(response.Headers.ContainsKey("ce-datacontenttype"));
+    }
 
-            // We populate headers even though we don't strictly need to; let's validate that.
-            Assert.Equal("1.0", response.Headers["ce-specversion"]);
-            Assert.Equal(cloudEvent.Type, response.Headers["ce-type"]);
-            Assert.Equal(cloudEvent.Id, response.Headers["ce-id"]);
-            Assert.Equal(CloudEventAttributeType.UriReference.Format(cloudEvent.Source!), response.Headers["ce-source"]);
-            // We don't populate the data content type header
-            Assert.False(response.Headers.ContainsKey("ce-datacontenttype"));
-        }
+    [Fact]
+    public async Task CopyToHttpResponseAsync_Batch()
+    {
+        var batch = CreateSampleBatch();
+        var response = CreateResponse();
+        await batch.CopyToHttpResponseAsync(response, new JsonEventFormatter());
 
-        [Fact]
-        public async Task CopyToHttpResponseAsync_Batch()
-        {
-            var batch = CreateSampleBatch();
-            var response = CreateResponse();
-            await batch.CopyToHttpResponseAsync(response, new JsonEventFormatter());
+        var content = GetContent(response);
+        Assert.Equal(MimeUtilities.BatchMediaType + "+json; charset=utf-8", response.ContentType);
+        Assert.NotNull(response.ContentType);
+        var parsedBatch = new JsonEventFormatter().DecodeBatchModeMessage(content, new ContentType(response.ContentType), extensionAttributes: null);
+        AssertBatchesEqual(batch, parsedBatch);
+    }
 
-            var content = GetContent(response);
-            Assert.Equal(MimeUtilities.BatchMediaType + "+json; charset=utf-8", response.ContentType);
-            Assert.NotNull(response.ContentType);
-            var parsedBatch = new JsonEventFormatter().DecodeBatchModeMessage(content, new ContentType(response.ContentType), extensionAttributes: null);
-            AssertBatchesEqual(batch, parsedBatch);
-        }
+    private static HttpResponse CreateResponse()
+    {
+        var response = new DefaultHttpContext().Response;
+        response.Body = new MemoryStream();
+        return response;
+    }
 
-        private static HttpResponse CreateResponse()
-        {
-            var response = new DefaultHttpContext().Response;
-            response.Body = new MemoryStream();
-            return response;
-        }
-
-        private static ReadOnlyMemory<byte> GetContent(HttpResponse response)
-        {
-            response.Body.Position = 0;
-            return BinaryDataUtilities.ToReadOnlyMemory(response.Body);
-        }
+    private static ReadOnlyMemory<byte> GetContent(HttpResponse response)
+    {
+        response.Body.Position = 0;
+        return BinaryDataUtilities.ToReadOnlyMemory(response.Body);
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/Avro/AvroEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Avro/AvroEventFormatterTest.cs
@@ -10,11 +10,11 @@ using Xunit;
 using static CloudNative.CloudEvents.UnitTests.CloudEventFormatterExtensions;
 using static CloudNative.CloudEvents.UnitTests.TestHelpers;
 
-namespace CloudNative.CloudEvents.Avro.UnitTests
+namespace CloudNative.CloudEvents.Avro.UnitTests;
+
+public class AvroEventFormatterTest
 {
-    public class AvroEventFormatterTest
-    {
-        private static readonly string jsonv10 = @"
+    private static readonly string jsonv10 = @"
             {
                 'specversion' : '1.0',
                 'type' : 'com.github.pull.create',
@@ -26,101 +26,100 @@ namespace CloudNative.CloudEvents.Avro.UnitTests
                 'data' : '<much wow=\'xml\'/>'
             }".Replace('\'', '"');
 
-        [Fact]
-        public void ReserializeTest()
-        {
-            var jsonFormatter = new JsonEventFormatter();
-            var avroFormatter = new AvroEventFormatter();
-            var cloudEvent = jsonFormatter.DecodeStructuredModeText(jsonv10);
-            var avroData = avroFormatter.EncodeStructuredModeMessage(cloudEvent, out var contentType);
-            var cloudEvent2 = avroFormatter.DecodeStructuredModeMessage(avroData, contentType, extensionAttributes: null);
+    [Fact]
+    public void ReserializeTest()
+    {
+        var jsonFormatter = new JsonEventFormatter();
+        var avroFormatter = new AvroEventFormatter();
+        var cloudEvent = jsonFormatter.DecodeStructuredModeText(jsonv10);
+        var avroData = avroFormatter.EncodeStructuredModeMessage(cloudEvent, out var contentType);
+        var cloudEvent2 = avroFormatter.DecodeStructuredModeMessage(avroData, contentType, extensionAttributes: null);
 
-            Assert.Equal(cloudEvent2.SpecVersion, cloudEvent.SpecVersion);
-            Assert.Equal(cloudEvent2.Type, cloudEvent.Type);
-            Assert.Equal(cloudEvent2.Source, cloudEvent.Source);
-            Assert.Equal(cloudEvent2.Id, cloudEvent.Id);
-            AssertTimestampsEqual(cloudEvent2.Time!.Value, cloudEvent.Time!.Value);
-            Assert.Equal(cloudEvent2.DataContentType, cloudEvent.DataContentType);
-            Assert.Equal(cloudEvent2.Data, cloudEvent.Data);
-        }
+        Assert.Equal(cloudEvent2.SpecVersion, cloudEvent.SpecVersion);
+        Assert.Equal(cloudEvent2.Type, cloudEvent.Type);
+        Assert.Equal(cloudEvent2.Source, cloudEvent.Source);
+        Assert.Equal(cloudEvent2.Id, cloudEvent.Id);
+        AssertTimestampsEqual(cloudEvent2.Time!.Value, cloudEvent.Time!.Value);
+        Assert.Equal(cloudEvent2.DataContentType, cloudEvent.DataContentType);
+        Assert.Equal(cloudEvent2.Data, cloudEvent.Data);
+    }
 
-        [Fact]
-        public void StructuredParseSuccess()
-        {
-            var jsonFormatter = new JsonEventFormatter();
-            var avroFormatter = new AvroEventFormatter();
-            var cloudEventJ = jsonFormatter.DecodeStructuredModeText(jsonv10);
-            var avroData = avroFormatter.EncodeStructuredModeMessage(cloudEventJ, out var contentType);
-            var cloudEvent = avroFormatter.DecodeStructuredModeMessage(avroData, contentType, extensionAttributes: null);
+    [Fact]
+    public void StructuredParseSuccess()
+    {
+        var jsonFormatter = new JsonEventFormatter();
+        var avroFormatter = new AvroEventFormatter();
+        var cloudEventJ = jsonFormatter.DecodeStructuredModeText(jsonv10);
+        var avroData = avroFormatter.EncodeStructuredModeMessage(cloudEventJ, out var contentType);
+        var cloudEvent = avroFormatter.DecodeStructuredModeMessage(avroData, contentType, extensionAttributes: null);
 
-            Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
-            Assert.Equal("com.github.pull.create", cloudEvent.Type);
-            Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
-            Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time!.Value);
-            Assert.Equal(MediaTypeNames.Text.Xml, cloudEvent.DataContentType);
-            Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
+        Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
+        Assert.Equal("com.github.pull.create", cloudEvent.Type);
+        Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
+        Assert.Equal("A234-1234-1234", cloudEvent.Id);
+        AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time!.Value);
+        Assert.Equal(MediaTypeNames.Text.Xml, cloudEvent.DataContentType);
+        Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
 
-            Assert.Equal("value", (string?) cloudEvent["comexampleextension1"]);
-        }
+        Assert.Equal("value", (string?) cloudEvent["comexampleextension1"]);
+    }
 
-        [Fact]
-        public void StructuredParseWithExtensionsSuccess()
-        {
-            var jsonFormatter = new JsonEventFormatter();
-            var avroFormatter = new AvroEventFormatter();
-            var extensionAttribute = CloudEventAttribute.CreateExtension("comexampleextension1", CloudEventAttributeType.String);
-            var cloudEventJ = jsonFormatter.DecodeStructuredModeText(jsonv10, new[] { extensionAttribute });
-            var avroData = avroFormatter.EncodeStructuredModeMessage(cloudEventJ, out var contentType);
-            var cloudEvent = avroFormatter.DecodeStructuredModeMessage(avroData, contentType, new[] { extensionAttribute });
+    [Fact]
+    public void StructuredParseWithExtensionsSuccess()
+    {
+        var jsonFormatter = new JsonEventFormatter();
+        var avroFormatter = new AvroEventFormatter();
+        var extensionAttribute = CloudEventAttribute.CreateExtension("comexampleextension1", CloudEventAttributeType.String);
+        var cloudEventJ = jsonFormatter.DecodeStructuredModeText(jsonv10, new[] { extensionAttribute });
+        var avroData = avroFormatter.EncodeStructuredModeMessage(cloudEventJ, out var contentType);
+        var cloudEvent = avroFormatter.DecodeStructuredModeMessage(avroData, contentType, new[] { extensionAttribute });
 
-            Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
-            Assert.Equal("com.github.pull.create", cloudEvent.Type);
-            Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
-            Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time!.Value);
-            Assert.Equal(MediaTypeNames.Text.Xml, cloudEvent.DataContentType);
-            Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
+        Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
+        Assert.Equal("com.github.pull.create", cloudEvent.Type);
+        Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
+        Assert.Equal("A234-1234-1234", cloudEvent.Id);
+        AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time!.Value);
+        Assert.Equal(MediaTypeNames.Text.Xml, cloudEvent.DataContentType);
+        Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
 
-            Assert.Equal("value", cloudEvent[extensionAttribute]);
-        }
+        Assert.Equal("value", cloudEvent[extensionAttribute]);
+    }
 
-        [Fact]
-        public void StructuredParseSerializationWithCustomSerializer()
-        {
-            var serializer = new FakeGenericRecordSerializer();
-            var jsonFormatter = new JsonEventFormatter();
-            var avroFormatter = new AvroEventFormatter(serializer);
+    [Fact]
+    public void StructuredParseSerializationWithCustomSerializer()
+    {
+        var serializer = new FakeGenericRecordSerializer();
+        var jsonFormatter = new JsonEventFormatter();
+        var avroFormatter = new AvroEventFormatter(serializer);
 
-            var expectedSerializedData = new byte[] { 0x1, 0x2, 0x3, };
-            serializer.SetSerializeResponse(expectedSerializedData);
+        var expectedSerializedData = new byte[] { 0x1, 0x2, 0x3, };
+        serializer.SetSerializeResponse(expectedSerializedData);
 
-            var inputCloudEvent = jsonFormatter.DecodeStructuredModeText(jsonv10);
-            var avroData = avroFormatter
-                .EncodeStructuredModeMessage(inputCloudEvent, out var _)
-                .ToArray();
+        var inputCloudEvent = jsonFormatter.DecodeStructuredModeText(jsonv10);
+        var avroData = avroFormatter
+            .EncodeStructuredModeMessage(inputCloudEvent, out var _)
+            .ToArray();
 
-            Assert.Equal(1, serializer.SerializeCalls);
-            Assert.Equal(expectedSerializedData, avroData);
-        }
+        Assert.Equal(1, serializer.SerializeCalls);
+        Assert.Equal(expectedSerializedData, avroData);
+    }
 
-        [Fact]
-        public void StructuredParseDeserializationWithCustomSerializer()
-        {
-            var serializer = new FakeGenericRecordSerializer();
-            var avroFormatter = new AvroEventFormatter(serializer);
-            var expectedCloudEventId = "4321";
-            var expectedCloudEventType = "MyBrilliantEvent";
-            var expectedCloudEventSource = "https://cloudevents.io.test/test-event";
-            serializer.SetDeserializeResponseAttributes(
-                expectedCloudEventId, expectedCloudEventType, expectedCloudEventSource);
+    [Fact]
+    public void StructuredParseDeserializationWithCustomSerializer()
+    {
+        var serializer = new FakeGenericRecordSerializer();
+        var avroFormatter = new AvroEventFormatter(serializer);
+        var expectedCloudEventId = "4321";
+        var expectedCloudEventType = "MyBrilliantEvent";
+        var expectedCloudEventSource = "https://cloudevents.io.test/test-event";
+        serializer.SetDeserializeResponseAttributes(
+            expectedCloudEventId, expectedCloudEventType, expectedCloudEventSource);
 
-            var actualCloudEvent = avroFormatter.DecodeStructuredModeMessage(Array.Empty<byte>(), null, null);
+        var actualCloudEvent = avroFormatter.DecodeStructuredModeMessage(Array.Empty<byte>(), null, null);
 
-            Assert.Equal(1, serializer.DeserializeCalls);
-            Assert.Equal(expectedCloudEventId, actualCloudEvent.Id);
-            Assert.Equal(expectedCloudEventType, actualCloudEvent.Type);
-            Assert.Equal(expectedCloudEventSource, actualCloudEvent.Source!.ToString());
-        }
+        Assert.Equal(1, serializer.DeserializeCalls);
+        Assert.Equal(expectedCloudEventId, actualCloudEvent.Id);
+        Assert.Equal(expectedCloudEventType, actualCloudEvent.Type);
+        Assert.Equal(expectedCloudEventSource, actualCloudEvent.Source!.ToString());
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventAttributeTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventAttributeTest.cs
@@ -5,157 +5,156 @@
 using System;
 using Xunit;
 
-namespace CloudNative.CloudEvents.UnitTests
+namespace CloudNative.CloudEvents.UnitTests;
+
+public class CloudEventAttributeTest
 {
-    public class CloudEventAttributeTest
+    [Theory]
+    [InlineData("")]
+    [InlineData("UPPER")]
+    [InlineData("punct-uation")]
+    [InlineData("under_scope")]
+    public void CreateExtension_InvalidName(string name)
     {
-        [Theory]
-        [InlineData("")]
-        [InlineData("UPPER")]
-        [InlineData("punct-uation")]
-        [InlineData("under_scope")]
-        public void CreateExtension_InvalidName(string name)
+        var exception = Assert.Throws<ArgumentException>(() => CloudEventAttribute.CreateExtension(name, CloudEventAttributeType.String));
+        if (!string.IsNullOrEmpty(name))
         {
-            var exception = Assert.Throws<ArgumentException>(() => CloudEventAttribute.CreateExtension(name, CloudEventAttributeType.String));
-            if (!string.IsNullOrEmpty(name))
-            {
-                Assert.Contains($"'{name}'", exception.Message);
-            }
+            Assert.Contains($"'{name}'", exception.Message);
         }
+    }
 
-        [Theory]
-        [InlineData("simple")]
-        [InlineData("longnamethatwouldnotberecommendedbutisstillvalidsoweshouldnotthrow")]
-        public void CreateExtension_ValidName(string name)
+    [Theory]
+    [InlineData("simple")]
+    [InlineData("longnamethatwouldnotberecommendedbutisstillvalidsoweshouldnotthrow")]
+    public void CreateExtension_ValidName(string name)
+    {
+        var attr = CloudEventAttribute.CreateExtension(name, CloudEventAttributeType.Uri);
+        Assert.Equal(name, attr.Name);
+    }
+
+    [Fact]
+    public void Properties_ExtensionAttribute()
+    {
+        var attr = CloudEventAttribute.CreateExtension("test", CloudEventAttributeType.Uri);
+        Assert.Equal("test", attr.Name);
+        Assert.Equal("test", attr.ToString());
+        Assert.Equal(CloudEventAttributeType.Uri, attr.Type);
+        Assert.False(attr.IsRequired);
+        Assert.True(attr.IsExtension);
+    }
+
+    [Fact]
+    public void Properties_RequiredAttribute()
+    {
+        var attr = CloudEventsSpecVersion.V1_0.IdAttribute;
+        Assert.Equal("id", attr.Name);
+        Assert.Equal("id", attr.ToString());
+        Assert.Equal(CloudEventAttributeType.String, attr.Type);
+        Assert.True(attr.IsRequired);
+        Assert.False(attr.IsExtension);
+    }
+
+    [Fact]
+    public void Properties_OptionalAttribute()
+    {
+        var attr = CloudEventsSpecVersion.V1_0.TimeAttribute;
+        Assert.Equal("time", attr.Name);
+        Assert.Equal("time", attr.ToString());
+        Assert.Equal(CloudEventAttributeType.Timestamp, attr.Type);
+        Assert.False(attr.IsRequired);
+        Assert.False(attr.IsExtension);
+    }
+
+    [Fact]
+    public void CreateExtension_NullName() =>
+        Assert.Throws<ArgumentNullException>(() => CloudEventAttribute.CreateExtension(null!, CloudEventAttributeType.String));
+
+    [Fact]
+    public void CreateExtension_NullType() =>
+        Assert.Throws<ArgumentNullException>(() => CloudEventAttribute.CreateExtension("name", null!));
+
+    [Fact]
+    public void CreateExtension_SpecVersionName() =>
+        Assert.Throws<ArgumentException>(() =>
+            CloudEventAttribute.CreateExtension(CloudEventsSpecVersion.SpecVersionAttributeName, CloudEventAttributeType.String));
+
+    [Fact]
+    public void CreateExtension_DataName() =>
+        Assert.Throws<ArgumentException>(() =>
+            CloudEventAttribute.CreateExtension("data", CloudEventAttributeType.String));
+
+    [Fact]
+    public void Validate_NoValidator_Valid()
+    {
+        var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer, validator: null);
+        attr.Validate(10);
+    }
+
+    [Fact]
+    public void Validate_NoValidator_InvalidType()
+    {
+        var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer, validator: null);
+        Assert.Throws<ArgumentException>(() => attr.Validate(10L));
+    }
+
+    [Fact]
+    public void Validate_WithValidator_Valid()
+    {
+        var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer, ValidateNonNegative);
+        attr.Validate(10);
+
+    }
+
+    [Fact]
+    public void Validate_WithValidator_InvalidType()
+    {
+        var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer, ValidateNonNegative);
+        Assert.Throws<ArgumentException>(() => attr.Validate(10L));
+    }
+
+    [Fact]
+    public void Validate_WithValidator_InvalidValue()
+    {
+        var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer, ValidateNonNegative);
+        var exception = Assert.Throws<ArgumentException>(() => attr.Validate(-5));
+        Assert.Contains("Custom validation message", exception.Message);
+        Assert.IsType<Exception>(exception.InnerException);
+        Assert.Equal("Custom validation message", exception.InnerException!.Message);
+    }
+
+    [Fact]
+    public void Parse_Valid()
+    {
+        var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer, ValidateNonNegative);
+        Assert.Equal(10, attr.Parse("10"));
+    }
+
+    [Fact]
+    public void Parse_Invalid()
+    {
+        var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer, ValidateNonNegative);
+        Assert.Throws<ArgumentException>(() => attr.Parse("-5"));
+    }
+
+    [Fact]
+    public void Format_Valid()
+    {
+        var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer, ValidateNonNegative);
+        Assert.Equal("10", attr.Format(10));
+    }
+
+    [Fact]
+    public void Format_Invalid()
+    {
+        var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer, ValidateNonNegative);
+        Assert.Throws<ArgumentException>(() => attr.Format(-5));
+    }
+
+    private void ValidateNonNegative(object value)
+    {
+        if ((int) value < 0)
         {
-            var attr = CloudEventAttribute.CreateExtension(name, CloudEventAttributeType.Uri);
-            Assert.Equal(name, attr.Name);
-        }
-
-        [Fact]
-        public void Properties_ExtensionAttribute()
-        {
-            var attr = CloudEventAttribute.CreateExtension("test", CloudEventAttributeType.Uri);
-            Assert.Equal("test", attr.Name);
-            Assert.Equal("test", attr.ToString());
-            Assert.Equal(CloudEventAttributeType.Uri, attr.Type);
-            Assert.False(attr.IsRequired);
-            Assert.True(attr.IsExtension);
-        }
-
-        [Fact]
-        public void Properties_RequiredAttribute()
-        {
-            var attr = CloudEventsSpecVersion.V1_0.IdAttribute;
-            Assert.Equal("id", attr.Name);
-            Assert.Equal("id", attr.ToString());
-            Assert.Equal(CloudEventAttributeType.String, attr.Type);
-            Assert.True(attr.IsRequired);
-            Assert.False(attr.IsExtension);
-        }
-
-        [Fact]
-        public void Properties_OptionalAttribute()
-        {
-            var attr = CloudEventsSpecVersion.V1_0.TimeAttribute;
-            Assert.Equal("time", attr.Name);
-            Assert.Equal("time", attr.ToString());
-            Assert.Equal(CloudEventAttributeType.Timestamp, attr.Type);
-            Assert.False(attr.IsRequired);
-            Assert.False(attr.IsExtension);
-        }
-
-        [Fact]
-        public void CreateExtension_NullName() =>
-            Assert.Throws<ArgumentNullException>(() => CloudEventAttribute.CreateExtension(null!, CloudEventAttributeType.String));
-
-        [Fact]
-        public void CreateExtension_NullType() =>
-            Assert.Throws<ArgumentNullException>(() => CloudEventAttribute.CreateExtension("name", null!));
-
-        [Fact]
-        public void CreateExtension_SpecVersionName() =>
-            Assert.Throws<ArgumentException>(() =>
-                CloudEventAttribute.CreateExtension(CloudEventsSpecVersion.SpecVersionAttributeName, CloudEventAttributeType.String));
-
-        [Fact]
-        public void CreateExtension_DataName() =>
-            Assert.Throws<ArgumentException>(() =>
-                CloudEventAttribute.CreateExtension("data", CloudEventAttributeType.String));
-
-        [Fact]
-        public void Validate_NoValidator_Valid()
-        {
-            var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer, validator: null);
-            attr.Validate(10);
-        }
-
-        [Fact]
-        public void Validate_NoValidator_InvalidType()
-        {
-            var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer, validator: null);
-            Assert.Throws<ArgumentException>(() => attr.Validate(10L));
-        }
-
-        [Fact]
-        public void Validate_WithValidator_Valid()
-        {
-            var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer, ValidateNonNegative);
-            attr.Validate(10);
-
-        }
-
-        [Fact]
-        public void Validate_WithValidator_InvalidType()
-        {
-            var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer, ValidateNonNegative);
-            Assert.Throws<ArgumentException>(() => attr.Validate(10L));
-        }
-
-        [Fact]
-        public void Validate_WithValidator_InvalidValue()
-        {
-            var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer, ValidateNonNegative);
-            var exception = Assert.Throws<ArgumentException>(() => attr.Validate(-5));
-            Assert.Contains("Custom validation message", exception.Message);
-            Assert.IsType<Exception>(exception.InnerException);
-            Assert.Equal("Custom validation message", exception.InnerException!.Message);
-        }
-
-        [Fact]
-        public void Parse_Valid()
-        {
-            var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer, ValidateNonNegative);
-            Assert.Equal(10, attr.Parse("10"));
-        }
-
-        [Fact]
-        public void Parse_Invalid()
-        {
-            var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer, ValidateNonNegative);
-            Assert.Throws<ArgumentException>(() => attr.Parse("-5"));
-        }
-
-        [Fact]
-        public void Format_Valid()
-        {
-            var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer, ValidateNonNegative);
-            Assert.Equal("10", attr.Format(10));
-        }
-
-        [Fact]
-        public void Format_Invalid()
-        {
-            var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer, ValidateNonNegative);
-            Assert.Throws<ArgumentException>(() => attr.Format(-5));
-        }
-
-        private void ValidateNonNegative(object value)
-        {
-            if ((int) value < 0)
-            {
-                throw new Exception("Custom validation message");
-            }
+            throw new Exception("Custom validation message");
         }
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventAttributeTypeTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventAttributeTypeTest.cs
@@ -8,11 +8,11 @@ using System.Reflection;
 using System.Text;
 using Xunit;
 
-namespace CloudNative.CloudEvents.UnitTests
+namespace CloudNative.CloudEvents.UnitTests;
+
+public class CloudEventAttributeTypeTest
 {
-    public class CloudEventAttributeTypeTest
-    {
-        public static readonly TheoryData<CloudEventAttributeType> AllTypes = new TheoryData<CloudEventAttributeType>
+    public static readonly TheoryData<CloudEventAttributeType> AllTypes = new TheoryData<CloudEventAttributeType>
         {
             CloudEventAttributeType.Binary,
             CloudEventAttributeType.Boolean,
@@ -23,278 +23,277 @@ namespace CloudNative.CloudEvents.UnitTests
             CloudEventAttributeType.UriReference
         };
 
+    [Fact]
+    public void Names()
+    {
+        Assert.Equal("Binary", CloudEventAttributeType.Binary.Name);
+        Assert.Equal("Boolean", CloudEventAttributeType.Boolean.Name);
+        Assert.Equal("Integer", CloudEventAttributeType.Integer.Name);
+        Assert.Equal("String", CloudEventAttributeType.String.Name);
+        Assert.Equal("Timestamp", CloudEventAttributeType.Timestamp.Name);
+        Assert.Equal("URI", CloudEventAttributeType.Uri.Name);
+        Assert.Equal("URI-Reference", CloudEventAttributeType.UriReference.Name);
+    }
+
+    [Fact]
+    public void OrdinalTypeNameMatchesPropertyName()
+    {
+        var properties = typeof(CloudEventAttributeType)
+            .GetProperties(BindingFlags.Public | BindingFlags.Static)
+            .Where(prop => prop.PropertyType == typeof(CloudEventAttributeType));
+        foreach (var property in properties)
+        {
+            var type = (CloudEventAttributeType) property.GetValue(null)!;
+            Assert.Equal(property.Name, type!.Ordinal.ToString());
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AllTypes))]
+    public void ParseNull(CloudEventAttributeType type) =>
+        Assert.Throws<ArgumentNullException>(() => type.Parse(null!));
+
+    [Theory]
+    [MemberData(nameof(AllTypes))]
+    public void FormatNull(CloudEventAttributeType type) =>
+        Assert.Throws<ArgumentNullException>(() => type.Format(null!));
+
+    // None of our types can be constructed with a StringBuilder.
+    [Theory]
+    [MemberData(nameof(AllTypes))]
+    public void FormatIncorrectType(CloudEventAttributeType type) =>
+        Assert.Throws<ArgumentException>(() => type.Format(new StringBuilder()));
+
+    [Theory]
+    [MemberData(nameof(AllTypes))]
+    public void ValidateIncorrectType(CloudEventAttributeType type) =>
+        Assert.Throws<ArgumentException>(() => type.Validate(new StringBuilder()));
+
+    public class BinaryTypeTest
+    {
+        [Theory]
+        [InlineData("")]
+        // Examples from https://en.wikipedia.org/wiki/Base64
+        [InlineData("TWFu", (byte) 77, (byte) 97, (byte) 110)]
+        [InlineData("TWE=", (byte) 77, (byte) 97)]
+        [InlineData("TQ==", (byte) 77)]
+        public void ParseAndFormat_Valid(string text, params byte[] bytes)
+        {
+            var parsedBytes = CloudEventAttributeType.Binary.Parse(text);
+            // Convert both to hex to provide simpler comparisons.
+            Assert.Equal(Convert.ToString(bytes), Convert.ToString(parsedBytes));
+
+            var formattedBytes = CloudEventAttributeType.Binary.Format(bytes);
+            Assert.Equal(text, formattedBytes);
+        }
+
+        [Theory]
+        [InlineData("x")]
+        [InlineData("TWFU=")]
+        [InlineData("==TQ")]
+        public void Parse_Invalid(string text)
+        {
+            Assert.Throws<FormatException>(() => CloudEventAttributeType.Binary.Parse(text));
+        }
+    }
+
+    public class BooleanTypeTest
+    {
+        [Theory]
+        [InlineData("false", false)]
+        [InlineData("true", true)]
+        public void ParseAndFormat_Valid(string text, bool value)
+        {
+            var parsedValue = (bool) CloudEventAttributeType.Boolean.Parse(text);
+            // Convert both to hex to provide simpler comparisons.
+            Assert.Equal(value, parsedValue);
+
+            var formattedValue = CloudEventAttributeType.Boolean.Format(value);
+            Assert.Equal(text, formattedValue);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("TRUE")]
+        [InlineData("FALSE")]
+        [InlineData("maybe")]
+        public void Parse_Invalid(string text)
+        {
+            Assert.Throws<ArgumentException>(() => CloudEventAttributeType.Boolean.Parse(text));
+        }
+    }
+
+    public class IntegerTypeTest
+    {
+        [Theory]
+        [InlineData("-2147483648", -2147483648)]
+        [InlineData("-1", -1)]
+        [InlineData("0", 0)]
+        [InlineData("1", 1)]
+        [InlineData("2147483647", 2147483647)]
+        public void ParseAndFormat_Valid(string text, int value)
+        {
+            var parsedValue = (int) CloudEventAttributeType.Integer.Parse(text);
+            // Convert both to hex to provide simpler comparisons.
+            Assert.Equal(value, parsedValue);
+
+            var formattedValue = CloudEventAttributeType.Integer.Format(value);
+            Assert.Equal(text, formattedValue);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("2147483648")] // Above int.MaxValue
+        [InlineData("-2147483649")] // Below int.MinValue
+        [InlineData("not an integer")]
+        [InlineData("1,000")]
+        [InlineData("1.5")]
+        [InlineData(" 10")] // Leading space
+        [InlineData("+10")] // Plus sign
+        [InlineData("10 ")] // Trailing space
+        public void Parse_Invalid(string text)
+        {
+            // Sometimes OverflowException, sometimes FormatException.
+            Assert.ThrowsAny<Exception>(() => CloudEventAttributeType.Integer.Parse(text));
+        }
+    }
+
+    public class StringTypeTest
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData("test")]
+        [InlineData("TEST")]
+        [InlineData("\U0001F600")]
+        [InlineData("x\U0001F600y")]
+        [InlineData("x\U0001F600y\U0001F600z")]
+        public void ParseAndFormat_Valid(string text)
+        {
+            var parseResult = (string) CloudEventAttributeType.String.Parse(text);
+            Assert.Equal(parseResult, text);
+            var formatResult = CloudEventAttributeType.String.Format(text);
+            Assert.Equal(text, formatResult);
+            CloudEventAttributeType.String.Validate(text);
+        }
+
+        [Theory]
+        [InlineData("\n")] // Control character (first range)
+        [InlineData("\u007f")] // Control character (second range)
+        [InlineData("\ufdd0")] // Non-character (first range)
+        [InlineData("\ufffe")] // Non-character (second range)
+        [InlineData("\U0001FFFE")] // Non-character (surrogate range)
+        [InlineData("\U0010FFFE")] // Non-character (surrogate range)
+        public void InvalidCharacters(string text)
+        {
+            Assert.Throws<ArgumentException>(() => CloudEventAttributeType.String.Validate(text));
+        }
+
+        // Note: these are specified separately as .NET string attributes are stored as UTF-8
+        // internally, which means you can't express invalid strings in attributes (and get them
+        // out again).
+        [Theory]
+        [InlineData(0xd800, 0x20)] // High surrogate followed by non-surrogate
+        [InlineData(0xdc00, 0x20)] // Low surrogate at start of string
+        [InlineData(0x20, 0xdc00)] // Non-surrogate followed by low surrogate
+        [InlineData(0xd800, 0xd800)] // High surrogate followed by high surrogate
+        [InlineData(0x20, 0xd800)] // High surrogate at end of string
+        public void InvalidSurrogates(int first, int second)
+        {
+            string text = $"{(char) first}{(char) second}";
+            Assert.Throws<ArgumentException>(() => CloudEventAttributeType.String.Validate(text));
+        }
+    }
+
+    public class TimestampTest
+    {
+        // Note: this is not particularly exhaustive, as we have a more comprehensive set of tests
+        // in TimestampsTest.
+
+        [Theory]
+        [InlineData("2021-01-18T14:52:01Z")]
+        [InlineData("2000-02-29T01:23:45.678+01:30")]
+        [InlineData("2000-02-29T01:23:45-01:30")]
+        public void ParseAndFormat_Valid(string text)
+        {
+            var parsed = CloudEventAttributeType.Timestamp.Parse(text);
+            var formatted = CloudEventAttributeType.Timestamp.Format(parsed);
+            Assert.Equal(text, formatted);
+        }
+
+        [Theory]
+        [InlineData("2021-01-18T14:52:01")] // No UTC offset indicator
+        [InlineData("2021-01-18T14:52:01.1234567XYZ")] // Garbage after 7 significant digits of sub-second
+        [InlineData("20garbage2T14:52:01Z01")] // Text after UTC offset indicator
+        [InlineData("2021-01-18T14:52:01X")] // Garbage UTC offset indicator
+        public void Parse_Invalid(string text)
+        {
+            Assert.Throws<FormatException>(() => CloudEventAttributeType.Timestamp.Parse(text));
+        }
+    }
+
+    public class UriTest
+    {
+        [Theory]
+        [InlineData("https://cloudevents.io/")]
+        [InlineData("https://cloudevents.io/path?query=value")]
+        [InlineData("ftp://cloudevents.io/path")]
+        [InlineData("ftp://cloudevents.io/path#fragment")]
+        // It's unclear why System.Uri thinks this doesn't need escaping, but apparently
+        // it doesn't (so we now just return the original string in all cases)
+        [InlineData("http://host/\u00a3")]
+        // These would not round-trip if we just called ToString.
+        [InlineData("https://cloudevents.io")]
+        [InlineData("https://cloudevents.io?query=value")]
+        public void ParseAndFormat_Roundtrip(string text)
+        {
+            var parsed = CloudEventAttributeType.Uri.Parse(text);
+            CloudEventAttributeType.Uri.Validate(parsed);
+            Assert.Equal(new Uri(text), parsed);
+            var formatted = CloudEventAttributeType.Uri.Format(parsed);
+            Assert.Equal(text, formatted);
+        }
+
+        [Theory]
+        [InlineData("//cloudevents.io?query=value")]
+        [InlineData("/path-absolute")]
+        [InlineData("")]
+        public void Parse_Invalid(string text)
+        {
+            Assert.Throws<UriFormatException>(() => CloudEventAttributeType.Uri.Parse(text));
+        }
+
         [Fact]
-        public void Names()
+        public void Validate_Invalid()
         {
-            Assert.Equal("Binary", CloudEventAttributeType.Binary.Name);
-            Assert.Equal("Boolean", CloudEventAttributeType.Boolean.Name);
-            Assert.Equal("Integer", CloudEventAttributeType.Integer.Name);
-            Assert.Equal("String", CloudEventAttributeType.String.Name);
-            Assert.Equal("Timestamp", CloudEventAttributeType.Timestamp.Name);
-            Assert.Equal("URI", CloudEventAttributeType.Uri.Name);
-            Assert.Equal("URI-Reference", CloudEventAttributeType.UriReference.Name);
+            var uri = new Uri("//relative", UriKind.Relative);
+            Assert.Throws<ArgumentException>(() => CloudEventAttributeType.Uri.Validate(uri));
         }
+    }
 
-        [Fact]
-        public void OrdinalTypeNameMatchesPropertyName()
-        {
-            var properties = typeof(CloudEventAttributeType)
-                .GetProperties(BindingFlags.Public | BindingFlags.Static)
-                .Where(prop => prop.PropertyType == typeof(CloudEventAttributeType));
-            foreach (var property in properties)
-            {
-                var type = (CloudEventAttributeType) property.GetValue(null)!;
-                Assert.Equal(property.Name, type!.Ordinal.ToString());
-            }
-        }
-
+    public class UriReferenceTest
+    {
         [Theory]
-        [MemberData(nameof(AllTypes))]
-        public void ParseNull(CloudEventAttributeType type) =>
-            Assert.Throws<ArgumentNullException>(() => type.Parse(null!));
-
-        [Theory]
-        [MemberData(nameof(AllTypes))]
-        public void FormatNull(CloudEventAttributeType type) =>
-            Assert.Throws<ArgumentNullException>(() => type.Format(null!));
-
-        // None of our types can be constructed with a StringBuilder.
-        [Theory]
-        [MemberData(nameof(AllTypes))]
-        public void FormatIncorrectType(CloudEventAttributeType type) =>
-            Assert.Throws<ArgumentException>(() => type.Format(new StringBuilder()));
-
-        [Theory]
-        [MemberData(nameof(AllTypes))]
-        public void ValidateIncorrectType(CloudEventAttributeType type) =>
-            Assert.Throws<ArgumentException>(() => type.Validate(new StringBuilder()));
-
-        public class BinaryTypeTest
+        [InlineData("https://cloudevents.io/?query=value")]
+        [InlineData("ftp://cloudevents.io/path")]
+        [InlineData("")] // Empty strings are valid URI references
+        [InlineData("//authority/path")]
+        [InlineData("/path-absolute")]
+        [InlineData("path-noscheme")]
+        [InlineData("#fragment")]
+        // These three really shouldn't round-trip. They're not valid URIs as they are,
+        // but it's hard to prevent that without also rejecting "#fragment", due to Uri's
+        // behavior. I'd expect the Uri constructor to automatically escape the leading
+        // character, but apparently it doesn't.
+        [InlineData(":colon-start")]
+        [InlineData("[open-bracket-start")]
+        [InlineData("]close-bracket-start")]
+        public void ParseFormatValidate_Valid(string text)
         {
-            [Theory]
-            [InlineData("")]
-            // Examples from https://en.wikipedia.org/wiki/Base64
-            [InlineData("TWFu", (byte) 77, (byte) 97, (byte) 110)]
-            [InlineData("TWE=", (byte) 77, (byte) 97)]
-            [InlineData("TQ==", (byte) 77)]
-            public void ParseAndFormat_Valid(string text, params byte[] bytes)
-            {
-                var parsedBytes = CloudEventAttributeType.Binary.Parse(text);
-                // Convert both to hex to provide simpler comparisons.
-                Assert.Equal(Convert.ToString(bytes), Convert.ToString(parsedBytes));
-
-                var formattedBytes = CloudEventAttributeType.Binary.Format(bytes);
-                Assert.Equal(text, formattedBytes);
-            }
-
-            [Theory]
-            [InlineData("x")]
-            [InlineData("TWFU=")]
-            [InlineData("==TQ")]
-            public void Parse_Invalid(string text)
-            {
-                Assert.Throws<FormatException>(() => CloudEventAttributeType.Binary.Parse(text));
-            }
-        }
-
-        public class BooleanTypeTest
-        {
-            [Theory]
-            [InlineData("false", false)]
-            [InlineData("true", true)]
-            public void ParseAndFormat_Valid(string text, bool value)
-            {
-                var parsedValue = (bool) CloudEventAttributeType.Boolean.Parse(text);
-                // Convert both to hex to provide simpler comparisons.
-                Assert.Equal(value, parsedValue);
-
-                var formattedValue = CloudEventAttributeType.Boolean.Format(value);
-                Assert.Equal(text, formattedValue);
-            }
-
-            [Theory]
-            [InlineData("")]
-            [InlineData("TRUE")]
-            [InlineData("FALSE")]
-            [InlineData("maybe")]
-            public void Parse_Invalid(string text)
-            {
-                Assert.Throws<ArgumentException>(() => CloudEventAttributeType.Boolean.Parse(text));
-            }
-        }
-
-        public class IntegerTypeTest
-        {
-            [Theory]
-            [InlineData("-2147483648", -2147483648)]
-            [InlineData("-1", -1)]
-            [InlineData("0", 0)]
-            [InlineData("1", 1)]
-            [InlineData("2147483647", 2147483647)]
-            public void ParseAndFormat_Valid(string text, int value)
-            {
-                var parsedValue = (int) CloudEventAttributeType.Integer.Parse(text);
-                // Convert both to hex to provide simpler comparisons.
-                Assert.Equal(value, parsedValue);
-
-                var formattedValue = CloudEventAttributeType.Integer.Format(value);
-                Assert.Equal(text, formattedValue);
-            }
-
-            [Theory]
-            [InlineData("")]
-            [InlineData("2147483648")] // Above int.MaxValue
-            [InlineData("-2147483649")] // Below int.MinValue
-            [InlineData("not an integer")]
-            [InlineData("1,000")]
-            [InlineData("1.5")]
-            [InlineData(" 10")] // Leading space
-            [InlineData("+10")] // Plus sign
-            [InlineData("10 ")] // Trailing space
-            public void Parse_Invalid(string text)
-            {
-                // Sometimes OverflowException, sometimes FormatException.
-                Assert.ThrowsAny<Exception>(() => CloudEventAttributeType.Integer.Parse(text));
-            }
-        }
-
-        public class StringTypeTest
-        {
-            [Theory]
-            [InlineData("")]
-            [InlineData("test")]
-            [InlineData("TEST")]
-            [InlineData("\U0001F600")]
-            [InlineData("x\U0001F600y")]
-            [InlineData("x\U0001F600y\U0001F600z")]
-            public void ParseAndFormat_Valid(string text)
-            {
-                var parseResult = (string) CloudEventAttributeType.String.Parse(text);
-                Assert.Equal(parseResult, text);
-                var formatResult = CloudEventAttributeType.String.Format(text);
-                Assert.Equal(text, formatResult);
-                CloudEventAttributeType.String.Validate(text);
-            }
-
-            [Theory]
-            [InlineData("\n")] // Control character (first range)
-            [InlineData("\u007f")] // Control character (second range)
-            [InlineData("\ufdd0")] // Non-character (first range)
-            [InlineData("\ufffe")] // Non-character (second range)
-            [InlineData("\U0001FFFE")] // Non-character (surrogate range)
-            [InlineData("\U0010FFFE")] // Non-character (surrogate range)
-            public void InvalidCharacters(string text)
-            {
-                Assert.Throws<ArgumentException>(() => CloudEventAttributeType.String.Validate(text));
-            }
-
-            // Note: these are specified separately as .NET string attributes are stored as UTF-8
-            // internally, which means you can't express invalid strings in attributes (and get them
-            // out again).
-            [Theory]
-            [InlineData(0xd800, 0x20)] // High surrogate followed by non-surrogate
-            [InlineData(0xdc00, 0x20)] // Low surrogate at start of string
-            [InlineData(0x20, 0xdc00)] // Non-surrogate followed by low surrogate
-            [InlineData(0xd800, 0xd800)] // High surrogate followed by high surrogate
-            [InlineData(0x20, 0xd800)] // High surrogate at end of string
-            public void InvalidSurrogates(int first, int second)
-            {
-                string text = $"{(char) first}{(char) second}";
-                Assert.Throws<ArgumentException>(() => CloudEventAttributeType.String.Validate(text));
-            }
-        }
-
-        public class TimestampTest
-        {
-            // Note: this is not particularly exhaustive, as we have a more comprehensive set of tests
-            // in TimestampsTest.
-
-            [Theory]
-            [InlineData("2021-01-18T14:52:01Z")]
-            [InlineData("2000-02-29T01:23:45.678+01:30")]
-            [InlineData("2000-02-29T01:23:45-01:30")]
-            public void ParseAndFormat_Valid(string text)
-            {
-                var parsed = CloudEventAttributeType.Timestamp.Parse(text);
-                var formatted = CloudEventAttributeType.Timestamp.Format(parsed);
-                Assert.Equal(text, formatted);
-            }
-
-            [Theory]
-            [InlineData("2021-01-18T14:52:01")] // No UTC offset indicator
-            [InlineData("2021-01-18T14:52:01.1234567XYZ")] // Garbage after 7 significant digits of sub-second
-            [InlineData("20garbage2T14:52:01Z01")] // Text after UTC offset indicator
-            [InlineData("2021-01-18T14:52:01X")] // Garbage UTC offset indicator
-            public void Parse_Invalid(string text)
-            {
-                Assert.Throws<FormatException>(() => CloudEventAttributeType.Timestamp.Parse(text));
-            }
-        }
-
-        public class UriTest
-        {
-            [Theory]
-            [InlineData("https://cloudevents.io/")]
-            [InlineData("https://cloudevents.io/path?query=value")]
-            [InlineData("ftp://cloudevents.io/path")]
-            [InlineData("ftp://cloudevents.io/path#fragment")]
-            // It's unclear why System.Uri thinks this doesn't need escaping, but apparently
-            // it doesn't (so we now just return the original string in all cases)
-            [InlineData("http://host/\u00a3")]
-            // These would not round-trip if we just called ToString.
-            [InlineData("https://cloudevents.io")]
-            [InlineData("https://cloudevents.io?query=value")]
-            public void ParseAndFormat_Roundtrip(string text)
-            {
-                var parsed = CloudEventAttributeType.Uri.Parse(text);
-                CloudEventAttributeType.Uri.Validate(parsed);
-                Assert.Equal(new Uri(text), parsed);
-                var formatted = CloudEventAttributeType.Uri.Format(parsed);
-                Assert.Equal(text, formatted);
-            }
-
-            [Theory]
-            [InlineData("//cloudevents.io?query=value")]
-            [InlineData("/path-absolute")]
-            [InlineData("")]
-            public void Parse_Invalid(string text)
-            {
-                Assert.Throws<UriFormatException>(() => CloudEventAttributeType.Uri.Parse(text));
-            }
-
-            [Fact]
-            public void Validate_Invalid()
-            {
-                var uri = new Uri("//relative", UriKind.Relative);
-                Assert.Throws<ArgumentException>(() => CloudEventAttributeType.Uri.Validate(uri));
-            }
-        }
-
-        public class UriReferenceTest
-        {
-            [Theory]
-            [InlineData("https://cloudevents.io/?query=value")]
-            [InlineData("ftp://cloudevents.io/path")]
-            [InlineData("")] // Empty strings are valid URI references
-            [InlineData("//authority/path")]
-            [InlineData("/path-absolute")]
-            [InlineData("path-noscheme")]
-            [InlineData("#fragment")]
-            // These three really shouldn't round-trip. They're not valid URIs as they are,
-            // but it's hard to prevent that without also rejecting "#fragment", due to Uri's
-            // behavior. I'd expect the Uri constructor to automatically escape the leading
-            // character, but apparently it doesn't.
-            [InlineData(":colon-start")]
-            [InlineData("[open-bracket-start")]
-            [InlineData("]close-bracket-start")]
-            public void ParseFormatValidate_Valid(string text)
-            {
-                var parsed = CloudEventAttributeType.UriReference.Parse(text);
-                CloudEventAttributeType.UriReference.Validate(parsed);
-                Assert.Equal(new Uri(text, UriKind.RelativeOrAbsolute), parsed);
-                var formatted = CloudEventAttributeType.UriReference.Format(parsed);
-                Assert.Equal(text, formatted);
-            }
+            var parsed = CloudEventAttributeType.UriReference.Parse(text);
+            CloudEventAttributeType.UriReference.Validate(parsed);
+            Assert.Equal(new Uri(text, UriKind.RelativeOrAbsolute), parsed);
+            var formatted = CloudEventAttributeType.UriReference.Format(parsed);
+            Assert.Equal(text, formatted);
         }
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventFormatterAttributeTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventFormatterAttributeTest.cs
@@ -7,72 +7,71 @@ using System.Collections.Generic;
 using System.Net.Mime;
 using Xunit;
 
-namespace CloudNative.CloudEvents.UnitTests
+namespace CloudNative.CloudEvents.UnitTests;
+
+public class CloudEventFormatterAttributeTest
 {
-    public class CloudEventFormatterAttributeTest
+    [Fact]
+    public void CreateFormatter_NoAttribute() =>
+        Assert.Null(CloudEventFormatterAttribute.CreateFormatter(typeof(NoAttribute)));
+
+    [Fact]
+    public void CreateFormatter_Valid() =>
+        Assert.IsType<SampleCloudEventFormatter>(CloudEventFormatterAttribute.CreateFormatter(typeof(ValidAttribute)));
+
+    [Theory]
+    [InlineData(typeof(NonInstantiableAttribute))]
+    [InlineData(typeof(NonEventFormatterAttribute))]
+    [InlineData(typeof(NullFormatterAttribute))]
+    public void CreateFormatter_Invalid(Type targetType) =>
+        Assert.Throws<ArgumentException>(() => CloudEventFormatterAttribute.CreateFormatter(targetType));
+
+    public class NoAttribute
     {
-        [Fact]
-        public void CreateFormatter_NoAttribute() =>
-            Assert.Null(CloudEventFormatterAttribute.CreateFormatter(typeof(NoAttribute)));
+    }
 
-        [Fact]
-        public void CreateFormatter_Valid() =>
-            Assert.IsType<SampleCloudEventFormatter>(CloudEventFormatterAttribute.CreateFormatter(typeof(ValidAttribute)));
+    [CloudEventFormatter(typeof(AbstractCloudEventFormatter))]
+    public class NonInstantiableAttribute
+    {
+    }
 
-        [Theory]
-        [InlineData(typeof(NonInstantiableAttribute))]
-        [InlineData(typeof(NonEventFormatterAttribute))]
-        [InlineData(typeof(NullFormatterAttribute))]
-        public void CreateFormatter_Invalid(Type targetType) =>
-            Assert.Throws<ArgumentException>(() => CloudEventFormatterAttribute.CreateFormatter(targetType));
+    [CloudEventFormatter(null!)]
+    public class NullFormatterAttribute
+    {
+    }
 
-        public class NoAttribute
-        {
-        }
+    [CloudEventFormatter(typeof(object))]
+    public class NonEventFormatterAttribute
+    {
+    }
 
-        [CloudEventFormatter(typeof(AbstractCloudEventFormatter))]
-        public class NonInstantiableAttribute
-        {
-        }
+    [CloudEventFormatter(typeof(SampleCloudEventFormatter))]
+    public class ValidAttribute
+    {
+    }
 
-        [CloudEventFormatter(null!)]
-        public class NullFormatterAttribute
-        {
-        }
+    public abstract class AbstractCloudEventFormatter : CloudEventFormatter
+    {
+    }
 
-        [CloudEventFormatter(typeof(object))]
-        public class NonEventFormatterAttribute
-        {
-        }
+    public class SampleCloudEventFormatter : CloudEventFormatter
+    {
+        public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
+            throw new NotImplementedException();
 
-        [CloudEventFormatter(typeof(SampleCloudEventFormatter))]
-        public class ValidAttribute
-        {
-        }
+        public override void DecodeBinaryModeEventData(ReadOnlyMemory<byte> body, CloudEvent cloudEvent) =>
+            throw new NotImplementedException();
 
-        public abstract class AbstractCloudEventFormatter : CloudEventFormatter
-        {
-        }
+        public override CloudEvent DecodeStructuredModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
+            throw new NotImplementedException();
 
-        public class SampleCloudEventFormatter : CloudEventFormatter
-        {
-            public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
-                throw new NotImplementedException();
+        public override ReadOnlyMemory<byte> EncodeBatchModeMessage(IEnumerable<CloudEvent> cloudEvents, out ContentType contentType) =>
+            throw new NotImplementedException();
 
-            public override void DecodeBinaryModeEventData(ReadOnlyMemory<byte> body, CloudEvent cloudEvent) =>
-                throw new NotImplementedException();
+        public override ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent) =>
+            throw new NotImplementedException();
 
-            public override CloudEvent DecodeStructuredModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
-                throw new NotImplementedException();
-
-            public override ReadOnlyMemory<byte> EncodeBatchModeMessage(IEnumerable<CloudEvent> cloudEvents, out ContentType contentType) =>
-                throw new NotImplementedException();
-
-            public override ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent) =>
-                throw new NotImplementedException();
-
-            public override ReadOnlyMemory<byte> EncodeStructuredModeMessage(CloudEvent cloudEvent, out ContentType contentType) =>
-                throw new NotImplementedException();
-        }
+        public override ReadOnlyMemory<byte> EncodeStructuredModeMessage(CloudEvent cloudEvent, out ContentType contentType) =>
+            throw new NotImplementedException();
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventFormatterExtensions.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventFormatterExtensions.cs
@@ -5,19 +5,18 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace CloudNative.CloudEvents.UnitTests
-{
-    /// <summary>
-    /// Extension methods for CloudEventFormatters to simplify testing.
-    /// Often in tests we have structured mode data as strings, and usually the content type isn't important,
-    /// so it's useful to be able to just decode that string directly.
-    /// </summary>
-    internal static class CloudEventFormatterExtensions
-    {
-        internal static CloudEvent DecodeStructuredModeText(this CloudEventFormatter eventFormatter, string text) =>
-            eventFormatter.DecodeStructuredModeMessage(Encoding.UTF8.GetBytes(text), contentType: null, extensionAttributes: null);
+namespace CloudNative.CloudEvents.UnitTests;
 
-        internal static CloudEvent DecodeStructuredModeText(this CloudEventFormatter eventFormatter, string text, IEnumerable<CloudEventAttribute> extensionAttributes) =>
-            eventFormatter.DecodeStructuredModeMessage(Encoding.UTF8.GetBytes(text), contentType: null, extensionAttributes);
-    }
+/// <summary>
+/// Extension methods for CloudEventFormatters to simplify testing.
+/// Often in tests we have structured mode data as strings, and usually the content type isn't important,
+/// so it's useful to be able to just decode that string directly.
+/// </summary>
+internal static class CloudEventFormatterExtensions
+{
+    internal static CloudEvent DecodeStructuredModeText(this CloudEventFormatter eventFormatter, string text) =>
+        eventFormatter.DecodeStructuredModeMessage(Encoding.UTF8.GetBytes(text), contentType: null, extensionAttributes: null);
+
+    internal static CloudEvent DecodeStructuredModeText(this CloudEventFormatter eventFormatter, string text, IEnumerable<CloudEventAttribute> extensionAttributes) =>
+        eventFormatter.DecodeStructuredModeMessage(Encoding.UTF8.GetBytes(text), contentType: null, extensionAttributes);
 }

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventFormatterTest.cs
@@ -7,78 +7,77 @@ using System.Collections.Generic;
 using System.Net.Mime;
 using Xunit;
 
-namespace CloudNative.CloudEvents.UnitTests
+namespace CloudNative.CloudEvents.UnitTests;
+
+public class CloudEventFormatterTest
 {
-    public class CloudEventFormatterTest
+    [Fact]
+    public void GetOrInferDataContentType_NullCloudEvent()
     {
-        [Fact]
-        public void GetOrInferDataContentType_NullCloudEvent()
-        {
-            var formatter = new ContentTypeInferringFormatter();
-            Assert.Throws<ArgumentNullException>(() => formatter.GetOrInferDataContentType(null!));
-        }
+        var formatter = new ContentTypeInferringFormatter();
+        Assert.Throws<ArgumentNullException>(() => formatter.GetOrInferDataContentType(null!));
+    }
 
-        [Fact]
-        public void GetOrInferDataContentType_NoDataOrDataContentType()
-        {
-            var formatter = new ContentTypeInferringFormatter();
-            var cloudEvent = new CloudEvent();
-            Assert.Null(formatter.GetOrInferDataContentType(cloudEvent));
-        }
+    [Fact]
+    public void GetOrInferDataContentType_NoDataOrDataContentType()
+    {
+        var formatter = new ContentTypeInferringFormatter();
+        var cloudEvent = new CloudEvent();
+        Assert.Null(formatter.GetOrInferDataContentType(cloudEvent));
+    }
 
-        [Fact]
-        public void GetOrInferDataContentType_HasDataContentType()
-        {
-            var formatter = new ContentTypeInferringFormatter();
-            var cloudEvent = new CloudEvent { DataContentType = "test/pass" };
-            Assert.Equal(cloudEvent.DataContentType, formatter.GetOrInferDataContentType(cloudEvent));
-        }
+    [Fact]
+    public void GetOrInferDataContentType_HasDataContentType()
+    {
+        var formatter = new ContentTypeInferringFormatter();
+        var cloudEvent = new CloudEvent { DataContentType = "test/pass" };
+        Assert.Equal(cloudEvent.DataContentType, formatter.GetOrInferDataContentType(cloudEvent));
+    }
 
-        [Fact]
-        public void GetOrInferDataContentType_HasDataButNoContentType_OverriddenInferDataContentType()
-        {
-            var formatter = new ContentTypeInferringFormatter();
-            var cloudEvent = new CloudEvent { Data = "some-data" };
-            Assert.Equal("test/some-data", formatter.GetOrInferDataContentType(cloudEvent));
-        }
+    [Fact]
+    public void GetOrInferDataContentType_HasDataButNoContentType_OverriddenInferDataContentType()
+    {
+        var formatter = new ContentTypeInferringFormatter();
+        var cloudEvent = new CloudEvent { Data = "some-data" };
+        Assert.Equal("test/some-data", formatter.GetOrInferDataContentType(cloudEvent));
+    }
 
-        [Fact]
-        public void GetOrInferDataContentType_DataButNoContentType_DefaultInferDataContentType()
-        {
-            var formatter = new ThrowingEventFormatter();
-            var cloudEvent = new CloudEvent { Data = "some-data" };
-            Assert.Null(formatter.GetOrInferDataContentType(cloudEvent));
-        }
+    [Fact]
+    public void GetOrInferDataContentType_DataButNoContentType_DefaultInferDataContentType()
+    {
+        var formatter = new ThrowingEventFormatter();
+        var cloudEvent = new CloudEvent { Data = "some-data" };
+        Assert.Null(formatter.GetOrInferDataContentType(cloudEvent));
+    }
 
-        private class ContentTypeInferringFormatter : ThrowingEventFormatter
-        {
-            protected override string? InferDataContentType(object data) => $"test/{data}";
-        }
+    private class ContentTypeInferringFormatter : ThrowingEventFormatter
+    {
+        protected override string? InferDataContentType(object data) => $"test/{data}";
+    }
 
-        /// <summary>
-        /// Event formatter that overrides every abstract method to throw NotImplementedException.
-        /// This can be derived from (and further overridden) to easily test concrete methods
-        /// in CloudEventFormatter itself.
-        /// </summary>
-        private class ThrowingEventFormatter : CloudEventFormatter
-        {
-            public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
-                throw new NotImplementedException();
+    /// <summary>
+    /// Event formatter that overrides every abstract method to throw NotImplementedException.
+    /// This can be derived from (and further overridden) to easily test concrete methods
+    /// in CloudEventFormatter itself.
+    /// </summary>
+    private class ThrowingEventFormatter : CloudEventFormatter
+    {
+        public override IReadOnlyList<CloudEvent> DecodeBatchModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
+            throw new NotImplementedException();
 
-            public override void DecodeBinaryModeEventData(ReadOnlyMemory<byte> body, CloudEvent cloudEvent) =>
-                throw new NotImplementedException();
+        public override void DecodeBinaryModeEventData(ReadOnlyMemory<byte> body, CloudEvent cloudEvent) =>
+            throw new NotImplementedException();
 
-            public override CloudEvent DecodeStructuredModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
-                throw new NotImplementedException();
+        public override CloudEvent DecodeStructuredModeMessage(ReadOnlyMemory<byte> body, ContentType? contentType, IEnumerable<CloudEventAttribute>? extensionAttributes) =>
+            throw new NotImplementedException();
 
-            public override ReadOnlyMemory<byte> EncodeBatchModeMessage(IEnumerable<CloudEvent> cloudEvents, out ContentType contentType) =>
-                throw new NotImplementedException();
+        public override ReadOnlyMemory<byte> EncodeBatchModeMessage(IEnumerable<CloudEvent> cloudEvents, out ContentType contentType) =>
+            throw new NotImplementedException();
 
-            public override ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent) =>
-                throw new NotImplementedException();
+        public override ReadOnlyMemory<byte> EncodeBinaryModeEventData(CloudEvent cloudEvent) =>
+            throw new NotImplementedException();
 
-            public override ReadOnlyMemory<byte> EncodeStructuredModeMessage(CloudEvent cloudEvent, out ContentType contentType) =>
-                throw new NotImplementedException();
-        }
+        public override ReadOnlyMemory<byte> EncodeStructuredModeMessage(CloudEvent cloudEvent, out ContentType contentType) =>
+            throw new NotImplementedException();
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventTest.cs
@@ -9,213 +9,213 @@ using System.Net.Mime;
 using Xunit;
 using static CloudNative.CloudEvents.UnitTests.TestHelpers;
 
-namespace CloudNative.CloudEvents.UnitTests
+namespace CloudNative.CloudEvents.UnitTests;
+
+public class CloudEventTest
 {
-    public class CloudEventTest
+    private static readonly DateTimeOffset sampleTimestamp = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void CreateSimpleEvent()
     {
-        private static readonly DateTimeOffset sampleTimestamp = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero);
-
-        [Fact]
-        public void CreateSimpleEvent()
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent
-            {
-                Type = "com.github.pull.create",
-                Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
-                Id = "A234-1234-1234",
-                Time = sampleTimestamp,
-                DataContentType = MediaTypeNames.Text.Xml,
-                Data = "<much wow=\"xml\"/>",
-                ["comexampleextension1"] = "value"
-            };
+            Type = "com.github.pull.create",
+            Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
+            Id = "A234-1234-1234",
+            Time = sampleTimestamp,
+            DataContentType = MediaTypeNames.Text.Xml,
+            Data = "<much wow=\"xml\"/>",
+            ["comexampleextension1"] = "value"
+        };
 
-            Assert.Equal(CloudEventsSpecVersion.Default, cloudEvent.SpecVersion);
-            Assert.Equal("com.github.pull.create", cloudEvent.Type);
-            Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
-            Assert.Equal("A234-1234-1234", cloudEvent.Id);
-            AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
-            Assert.Equal(MediaTypeNames.Text.Xml, cloudEvent.DataContentType);
-            Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
+        Assert.Equal(CloudEventsSpecVersion.Default, cloudEvent.SpecVersion);
+        Assert.Equal("com.github.pull.create", cloudEvent.Type);
+        Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), cloudEvent.Source);
+        Assert.Equal("A234-1234-1234", cloudEvent.Id);
+        AssertTimestampsEqual("2018-04-05T17:31:00Z", cloudEvent.Time.Value);
+        Assert.Equal(MediaTypeNames.Text.Xml, cloudEvent.DataContentType);
+        Assert.Equal("<much wow=\"xml\"/>", cloudEvent.Data);
 
-            Assert.Equal("value", (string?) cloudEvent["comexampleextension1"]);
-        }
+        Assert.Equal("value", (string?) cloudEvent["comexampleextension1"]);
+    }
 
-        [Fact]
-        public void CreateEventWithExtension()
+    [Fact]
+    public void CreateEventWithExtension()
+    {
+        var extension = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer);
+
+        var cloudEvent = new CloudEvent(new[] { extension })
         {
-            var extension = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer);
+            Type = "com.github.pull.create",
+            Id = "A234-1234-1234",
+            Time = sampleTimestamp,
+            [extension] = 10
+        };
 
-            var cloudEvent = new CloudEvent(new[] { extension })
-            {
-                Type = "com.github.pull.create",
-                Id = "A234-1234-1234",
-                Time = sampleTimestamp,
-                [extension] = 10
-            };
+        Assert.Equal(10, cloudEvent[extension]);
+        Assert.Equal(10, cloudEvent["ext"]);
 
-            Assert.Equal(10, cloudEvent[extension]);
-            Assert.Equal(10, cloudEvent["ext"]);
+        Assert.Throws<ArgumentException>(() => cloudEvent.SetAttributeFromString("ext", "not an integer"));
+        cloudEvent.SetAttributeFromString("ext", "20");
+        Assert.Equal(20, cloudEvent[extension]);
+    }
 
-            Assert.Throws<ArgumentException>(() => cloudEvent.SetAttributeFromString("ext", "not an integer"));
-            cloudEvent.SetAttributeFromString("ext", "20");
-            Assert.Equal(20, cloudEvent[extension]);
-        }
+    [Fact]
+    public void Invalid_ContentType_Throws()
+    {
+        var cloudEvent = new CloudEvent();
+        var exception = Assert.Throws<ArgumentException>(() => cloudEvent.DataContentType = "text/html; charset:");
+        Assert.StartsWith(Strings.ErrorContentTypeIsNotRFC2046, exception.InnerException!.Message);
+    }
 
-        [Fact]
-        public void Invalid_ContentType_Throws()
+    [Fact]
+    public void SetAttributePropertiesToNull()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent();
-            var exception = Assert.Throws<ArgumentException>(() => cloudEvent.DataContentType = "text/html; charset:");
-            Assert.StartsWith(Strings.ErrorContentTypeIsNotRFC2046, exception.InnerException!.Message);
-        }
+            Data = "some data",
+            DataContentType = "text/plain",
+            DataSchema = new Uri("https://schema")
+        };
 
-        [Fact]
-        public void SetAttributePropertiesToNull()
+        cloudEvent.Type = null;
+        cloudEvent.Source = null;
+        cloudEvent.Subject = null;
+        cloudEvent.Id = null;
+        cloudEvent.Time = null;
+        cloudEvent.Data = null;
+        cloudEvent.DataContentType = null;
+        cloudEvent.DataSchema = null;
+
+        Assert.Null(cloudEvent.Type);
+        Assert.Null(cloudEvent.Source);
+        Assert.Null(cloudEvent.Subject);
+        Assert.Null(cloudEvent.Id);
+        Assert.Null(cloudEvent.Time);
+        Assert.Null(cloudEvent.Data);
+        Assert.Null(cloudEvent.DataContentType);
+        Assert.Null(cloudEvent.DataSchema);
+    }
+
+    [Fact]
+    public void Validate_Invalid()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent
-            {
-                Data = "some data",
-                DataContentType = "text/plain",
-                DataSchema = new Uri("https://schema")
-            };
+            Type = "type",
+            DataContentType = "text/plain",
+            Data = "text"
+        };
+        Assert.False(cloudEvent.IsValid);
+        var exception1 = Assert.Throws<InvalidOperationException>(() => cloudEvent.Validate());
+        Assert.Contains(CloudEventsSpecVersion.Default.IdAttribute.Name, exception1.Message);
+        Assert.Contains(CloudEventsSpecVersion.Default.SourceAttribute.Name, exception1.Message);
+        Assert.DoesNotContain(CloudEventsSpecVersion.Default.TypeAttribute.Name, exception1.Message);
 
-            cloudEvent.Type = null;
-            cloudEvent.Source = null;
-            cloudEvent.Subject = null;
-            cloudEvent.Id = null;
-            cloudEvent.Time = null;
-            cloudEvent.Data = null;
-            cloudEvent.DataContentType = null;
-            cloudEvent.DataSchema = null;
+        var exception2 = Assert.Throws<ArgumentException>(() => Validation.CheckCloudEventArgument(cloudEvent, "param"));
+        Assert.Equal("param", exception2.ParamName);
+        Assert.Contains(CloudEventsSpecVersion.Default.IdAttribute.Name, exception1.Message);
+        Assert.Contains(CloudEventsSpecVersion.Default.SourceAttribute.Name, exception1.Message);
+        Assert.DoesNotContain(CloudEventsSpecVersion.Default.TypeAttribute.Name, exception1.Message);
+    }
 
-            Assert.Null(cloudEvent.Type);
-            Assert.Null(cloudEvent.Source);
-            Assert.Null(cloudEvent.Subject);
-            Assert.Null(cloudEvent.Id);
-            Assert.Null(cloudEvent.Time);
-            Assert.Null(cloudEvent.Data);
-            Assert.Null(cloudEvent.DataContentType);
-            Assert.Null(cloudEvent.DataSchema);
-        }
-
-        [Fact]
-        public void Validate_Invalid()
+    [Fact]
+    public void Validate_Valid()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent
-            {
-                Type = "type",
-                DataContentType = "text/plain",
-                Data = "text"
-            };
-            Assert.False(cloudEvent.IsValid);
-            var exception1 = Assert.Throws<InvalidOperationException>(() => cloudEvent.Validate());
-            Assert.Contains(CloudEventsSpecVersion.Default.IdAttribute.Name, exception1.Message);
-            Assert.Contains(CloudEventsSpecVersion.Default.SourceAttribute.Name, exception1.Message);
-            Assert.DoesNotContain(CloudEventsSpecVersion.Default.TypeAttribute.Name, exception1.Message);
+            Type = "type",
+            Id = "id",
+            Source = new Uri("https://somewhere")
+        };
+        Assert.True(cloudEvent.IsValid);
+        Assert.Same(cloudEvent, cloudEvent.Validate());
+        Assert.Same(cloudEvent, Validation.CheckCloudEventArgument(cloudEvent, "param"));
+    }
 
-            var exception2 = Assert.Throws<ArgumentException>(() => Validation.CheckCloudEventArgument(cloudEvent, "param"));
-            Assert.Equal("param", exception2.ParamName);
-            Assert.Contains(CloudEventsSpecVersion.Default.IdAttribute.Name, exception1.Message);
-            Assert.Contains(CloudEventsSpecVersion.Default.SourceAttribute.Name, exception1.Message);
-            Assert.DoesNotContain(CloudEventsSpecVersion.Default.TypeAttribute.Name, exception1.Message);
-        }
+    [Fact]
+    public void Constructor_SpecVersion()
+    {
+        var cloudEvent = new CloudEvent(CloudEventsSpecVersion.V1_0);
+        Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
+    }
 
-        [Fact]
-        public void Validate_Valid()
+    [Fact]
+    public void Constructor_NullVersion() =>
+        Assert.Throws<ArgumentNullException>(() => new CloudEvent(specVersion: null!));
+
+    [Fact]
+    public void Constructor_SpecVersionAndExtensionAttributes()
+    {
+        var extension = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer);
+        var cloudEvent = new CloudEvent(CloudEventsSpecVersion.V1_0, new[] { extension });
+        // This fails if the extension isn't registered.
+        cloudEvent["ext"] = 10;
+        Assert.Equal(10, cloudEvent[extension]);
+    }
+
+    [Fact]
+    public void Constructor_ExtensionAttributes_Duplicate()
+    {
+        var ext1 = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer);
+        var ext2 = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer);
+        var extensions = new[] { ext1, ext2 };
+        Assert.Throws<ArgumentException>(() => new CloudEvent(extensions));
+    }
+
+    [Fact]
+    public void Constructor_ExtensionAttributes_NullValue()
+    {
+        var extensions = new CloudEventAttribute[] { null! };
+        Assert.Throws<ArgumentException>(() => new CloudEvent(extensions));
+    }
+
+    [Fact]
+    public void Constructor_ExtensionAttributes_IncludesSpecVersionAttribute()
+    {
+        var extensions = new[] { CloudEventsSpecVersion.SpecVersionAttribute };
+        Assert.Throws<ArgumentException>(() => new CloudEvent(extensions));
+    }
+
+    [Fact]
+    public void Constructor_ExtensionAttributes_IncludesNonExtensionAttribute()
+    {
+        var extensions = new[] { CloudEventsSpecVersion.V1_0.DataContentTypeAttribute };
+        Assert.Throws<ArgumentException>(() => new CloudEvent(extensions));
+    }
+
+    [Fact]
+    public void ExtensionAttributesProperty()
+    {
+        var ext1 = CloudEventAttribute.CreateExtension("ext1", CloudEventAttributeType.Integer);
+        var ext2 = CloudEventAttribute.CreateExtension("ext2", CloudEventAttributeType.Integer);
+        var cloudEvent = new CloudEvent(new[] { ext1 });
+        cloudEvent[ext2] = 10;
+        var extensions = cloudEvent.ExtensionAttributes.OrderBy(attr => attr.Name).ToList();
+        Assert.Equal(new[] { ext1, ext2 }, extensions);
+    }
+
+    /// <summary>
+    /// This is effectively testing future proofing. If an extension attribute in 1.0 becomes an
+    /// optional attribute in 1.1 for example, then code that has been using it *as* an extension
+    /// attribute should still be able to work. The test has to use an attribute from 1.0 of course...
+    /// </summary>
+    [Fact]
+    public void Indexer_SetUsingExtensionAttributeWithSameType()
+    {
+        var extension = CloudEventAttribute.CreateExtension("subject", CloudEventAttributeType.String);
+        var cloudEvent = new CloudEvent();
+        cloudEvent.Subject = "normal subject";
+        cloudEvent[extension] = "extended subject";
+        Assert.Equal("extended subject", cloudEvent.Subject);
+    }
+
+    [Fact]
+    public void SetAttributeFromStringValue_Valid()
+    {
+        var extensions = new[]
         {
-            var cloudEvent = new CloudEvent
-            {
-                Type = "type",
-                Id = "id",
-                Source = new Uri("https://somewhere")
-            };
-            Assert.True(cloudEvent.IsValid);
-            Assert.Same(cloudEvent, cloudEvent.Validate());
-            Assert.Same(cloudEvent, Validation.CheckCloudEventArgument(cloudEvent, "param"));
-        }
-
-        [Fact]
-        public void Constructor_SpecVersion()
-        {
-            var cloudEvent = new CloudEvent(CloudEventsSpecVersion.V1_0);
-            Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
-        }
-
-        [Fact]
-        public void Constructor_NullVersion() =>
-            Assert.Throws<ArgumentNullException>(() => new CloudEvent(specVersion: null!));
-
-        [Fact]
-        public void Constructor_SpecVersionAndExtensionAttributes()
-        {
-            var extension = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer);
-            var cloudEvent = new CloudEvent(CloudEventsSpecVersion.V1_0, new[] { extension });
-            // This fails if the extension isn't registered.
-            cloudEvent["ext"] = 10;
-            Assert.Equal(10, cloudEvent[extension]);
-        }
-
-        [Fact]
-        public void Constructor_ExtensionAttributes_Duplicate()
-        {
-            var ext1 = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer);
-            var ext2 = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer);
-            var extensions = new[] { ext1, ext2 };
-            Assert.Throws<ArgumentException>(() => new CloudEvent(extensions));
-        }
-
-        [Fact]
-        public void Constructor_ExtensionAttributes_NullValue()
-        {
-            var extensions = new CloudEventAttribute[] { null! };
-            Assert.Throws<ArgumentException>(() => new CloudEvent(extensions));
-        }
-
-        [Fact]
-        public void Constructor_ExtensionAttributes_IncludesSpecVersionAttribute()
-        {
-            var extensions = new[] { CloudEventsSpecVersion.SpecVersionAttribute };
-            Assert.Throws<ArgumentException>(() => new CloudEvent(extensions));
-        }
-
-        [Fact]
-        public void Constructor_ExtensionAttributes_IncludesNonExtensionAttribute()
-        {
-            var extensions = new[] { CloudEventsSpecVersion.V1_0.DataContentTypeAttribute };
-            Assert.Throws<ArgumentException>(() => new CloudEvent(extensions));
-        }
-
-        [Fact]
-        public void ExtensionAttributesProperty()
-        {
-            var ext1 = CloudEventAttribute.CreateExtension("ext1", CloudEventAttributeType.Integer);
-            var ext2 = CloudEventAttribute.CreateExtension("ext2", CloudEventAttributeType.Integer);
-            var cloudEvent = new CloudEvent(new[] { ext1 });
-            cloudEvent[ext2] = 10;
-            var extensions = cloudEvent.ExtensionAttributes.OrderBy(attr => attr.Name).ToList();
-            Assert.Equal(new[] { ext1, ext2 }, extensions);
-        }
-
-        /// <summary>
-        /// This is effectively testing future proofing. If an extension attribute in 1.0 becomes an
-        /// optional attribute in 1.1 for example, then code that has been using it *as* an extension
-        /// attribute should still be able to work. The test has to use an attribute from 1.0 of course...
-        /// </summary>
-        [Fact]
-        public void Indexer_SetUsingExtensionAttributeWithSameType()
-        {
-            var extension = CloudEventAttribute.CreateExtension("subject", CloudEventAttributeType.String);
-            var cloudEvent = new CloudEvent();
-            cloudEvent.Subject = "normal subject";
-            cloudEvent[extension] = "extended subject";
-            Assert.Equal("extended subject", cloudEvent.Subject);
-        }
-
-        [Fact]
-        public void SetAttributeFromStringValue_Valid()
-        {
-            var extensions = new[]
-            {
                 CloudEventAttribute.CreateExtension("string", CloudEventAttributeType.String),
                 CloudEventAttribute.CreateExtension("integer", CloudEventAttributeType.Integer),
                 CloudEventAttribute.CreateExtension("binary", CloudEventAttributeType.Binary),
@@ -224,139 +224,138 @@ namespace CloudNative.CloudEvents.UnitTests
                 CloudEventAttribute.CreateExtension("uri", CloudEventAttributeType.Uri),
                 CloudEventAttribute.CreateExtension("urireference", CloudEventAttributeType.UriReference)
             };
-            var cloudEvent = new CloudEvent(extensions);
-            cloudEvent.SetAttributeFromString("string", "text");
-            cloudEvent.SetAttributeFromString("integer", "10");
-            cloudEvent.SetAttributeFromString("binary", "TQ==");
-            cloudEvent.SetAttributeFromString("boolean", "true");
-            cloudEvent.SetAttributeFromString("timestamp", "2021-02-09T11:58:12.242Z");
-            cloudEvent.SetAttributeFromString("uri", "https://cloudevents.io");
-            cloudEvent.SetAttributeFromString("urireference", "//auth");
+        var cloudEvent = new CloudEvent(extensions);
+        cloudEvent.SetAttributeFromString("string", "text");
+        cloudEvent.SetAttributeFromString("integer", "10");
+        cloudEvent.SetAttributeFromString("binary", "TQ==");
+        cloudEvent.SetAttributeFromString("boolean", "true");
+        cloudEvent.SetAttributeFromString("timestamp", "2021-02-09T11:58:12.242Z");
+        cloudEvent.SetAttributeFromString("uri", "https://cloudevents.io");
+        cloudEvent.SetAttributeFromString("urireference", "//auth");
 
-            Assert.Equal("text", cloudEvent["string"]);
-            Assert.Equal(10, cloudEvent["integer"]);
-            Assert.Equal(new byte[] { 77 }, cloudEvent["binary"]);
-            Assert.True((bool) cloudEvent["boolean"]!);
-            AssertTimestampsEqual("2021-02-09T11:58:12.242Z", (DateTimeOffset) cloudEvent["timestamp"]!);
-            Assert.Equal(new Uri("https://cloudevents.io"), cloudEvent["uri"]);
-            Assert.Equal(new Uri("//auth", UriKind.RelativeOrAbsolute), cloudEvent["urireference"]);
+        Assert.Equal("text", cloudEvent["string"]);
+        Assert.Equal(10, cloudEvent["integer"]);
+        Assert.Equal(new byte[] { 77 }, cloudEvent["binary"]);
+        Assert.True((bool) cloudEvent["boolean"]!);
+        AssertTimestampsEqual("2021-02-09T11:58:12.242Z", (DateTimeOffset) cloudEvent["timestamp"]!);
+        Assert.Equal(new Uri("https://cloudevents.io"), cloudEvent["uri"]);
+        Assert.Equal(new Uri("//auth", UriKind.RelativeOrAbsolute), cloudEvent["urireference"]);
+    }
+
+    [Fact]
+    public void SetAttributeFromStringValue_Validates()
+    {
+        var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer);
+        var cloudEvent = new CloudEvent(new[] { attr });
+        Assert.Throws<ArgumentException>(() => cloudEvent.SetAttributeFromString("ext", "garbage"));
+    }
+
+    [Fact]
+    public void SetAttributeFromStringValue_NewAttribute()
+    {
+        var cloudEvent = new CloudEvent();
+        cloudEvent.SetAttributeFromString("ext", "text");
+        Assert.Equal("text", cloudEvent["ext"]);
+        Assert.Equal(CloudEventAttributeType.String, cloudEvent.GetAttribute("ext")!.Type);
+    }
+
+    [Fact]
+    public void Indexer_NullKey_Throws()
+    {
+        var cloudEvent = new CloudEvent();
+        Assert.Throws<ArgumentNullException>(() => cloudEvent[(string) null!]);
+        Assert.Throws<ArgumentNullException>(() => cloudEvent[(CloudEventAttribute) null!]);
+        Assert.Throws<ArgumentNullException>(() => cloudEvent[(string) null!] = "text");
+        Assert.Throws<ArgumentNullException>(() => cloudEvent[(CloudEventAttribute) null!] = "text");
+    }
+
+    [Fact]
+    public void Indexer_NullValue_Removes()
+    {
+        var cloudEvent = new CloudEvent
+        {
+            Id = "id",
+            Type = "eventtype",
+            Time = DateTimeOffset.UtcNow
+        };
+        cloudEvent["id"] = null;
+        cloudEvent[CloudEventsSpecVersion.V1_0.TimeAttribute] = null;
+
+        // We only have a single attribute left.
+        var attributeAndValue = Assert.Single(cloudEvent.GetPopulatedAttributes());
+        Assert.Equal("type", attributeAndValue.Key.Name);
+        Assert.Equal("eventtype", attributeAndValue.Value);
+    }
+
+    /// <summary>
+    /// Tests for behavior we're not sure of yet. This documents what *does* happen (because the tests
+    /// pass) so we can more easily determine if it's what we *want* to happen.
+    /// </summary>
+    public class QuestionableBehavior
+    {
+        // We could infer the attribute type to be integer. 
+        [Fact]
+        public void SetNewAttributeWithNonString_Throws()
+        {
+            var cloudEvent = new CloudEvent();
+            Assert.Throws<ArgumentException>(() => cloudEvent["ext"] = 10);
         }
 
         [Fact]
-        public void SetAttributeFromStringValue_Validates()
+        public void FetchSpecVersionAttribute_Throws()
         {
+            var cloudEvent = new CloudEvent();
+            Assert.Throws<ArgumentException>(() => cloudEvent[CloudEventsSpecVersion.SpecVersionAttributeName]);
+            Assert.Throws<ArgumentException>(() => cloudEvent[CloudEventsSpecVersion.SpecVersionAttribute]);
+            Assert.Throws<ArgumentException>(() => cloudEvent[CloudEventsSpecVersion.SpecVersionAttributeName] = "1.0");
+            Assert.Throws<ArgumentException>(() => cloudEvent[CloudEventsSpecVersion.SpecVersionAttribute] = "1.0");
+        }
+
+        [Fact]
+        public void FetchIntegerExtensionSetImplicitlyWithString_Throws()
+        {
+            var cloudEvent = new CloudEvent();
+            cloudEvent["ext"] = "10";
+
             var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer);
-            var cloudEvent = new CloudEvent(new[] { attr });
-            Assert.Throws<ArgumentException>(() => cloudEvent.SetAttributeFromString("ext", "garbage"));
+            Assert.Throws<ArgumentException>(() => cloudEvent[attr]);
         }
 
         [Fact]
-        public void SetAttributeFromStringValue_NewAttribute()
+        public void SetIntegerExtensionSetImplicitlyWithString_Updates()
         {
             var cloudEvent = new CloudEvent();
-            cloudEvent.SetAttributeFromString("ext", "text");
-            Assert.Equal("text", cloudEvent["ext"]);
-            Assert.Equal(CloudEventAttributeType.String, cloudEvent.GetAttribute("ext")!.Type);
+            cloudEvent["ext"] = "10";
+            Assert.Equal(CloudEventAttributeType.String, cloudEvent.GetAttribute("ext")?.Type);
+
+            var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer);
+            // Setting the event with the attribute updates the extension registry...
+            cloudEvent[attr] = 10;
+            Assert.Equal(attr, cloudEvent.GetAttribute("ext"));
+            // So we can fetch the value by string or attribute.
+            Assert.Equal(10, cloudEvent[attr]);
+            Assert.Equal(10, cloudEvent["ext"]);
         }
 
         [Fact]
-        public void Indexer_NullKey_Throws()
+        public void ClearNewExtensionAttributeRetainsAttributeType()
         {
             var cloudEvent = new CloudEvent();
-            Assert.Throws<ArgumentNullException>(() => cloudEvent[(string) null!]);
-            Assert.Throws<ArgumentNullException>(() => cloudEvent[(CloudEventAttribute) null!]);
-            Assert.Throws<ArgumentNullException>(() => cloudEvent[(string) null!] = "text");
-            Assert.Throws<ArgumentNullException>(() => cloudEvent[(CloudEventAttribute) null!] = "text");
+            var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer);
+            cloudEvent[attr] = null; // Doesn't set any value, but remembers the extension...
+            cloudEvent["ext"] = 10; // Which means it can be set as the integer later.
+            Assert.Same(attr, cloudEvent.GetAttribute("ext"));
         }
 
+        // We may want to relax this - as otherwise specifying extensions without an explicit
+        // version is really brittle. (e.g. if "sampledrate" becomes an optional attribute in 1.1,
+        // and if our default version becomes 1.1, then previously-valid code will start to fail.)
         [Fact]
-        public void Indexer_NullValue_Removes()
+        public void Constructor_ExtensionAttributes_IncludesExistingAttributeName()
         {
-            var cloudEvent = new CloudEvent
-            {
-                Id = "id",
-                Type = "eventtype",
-                Time = DateTimeOffset.UtcNow
-            };
-            cloudEvent["id"] = null;
-            cloudEvent[CloudEventsSpecVersion.V1_0.TimeAttribute] = null;
-
-            // We only have a single attribute left.
-            var attributeAndValue = Assert.Single(cloudEvent.GetPopulatedAttributes());
-            Assert.Equal("type", attributeAndValue.Key.Name);
-            Assert.Equal("eventtype", attributeAndValue.Value);
-        }
-
-        /// <summary>
-        /// Tests for behavior we're not sure of yet. This documents what *does* happen (because the tests
-        /// pass) so we can more easily determine if it's what we *want* to happen.
-        /// </summary>
-        public class QuestionableBehavior
-        {
-            // We could infer the attribute type to be integer. 
-            [Fact]
-            public void SetNewAttributeWithNonString_Throws()
-            {
-                var cloudEvent = new CloudEvent();
-                Assert.Throws<ArgumentException>(() => cloudEvent["ext"] = 10);
-            }
-
-            [Fact]
-            public void FetchSpecVersionAttribute_Throws()
-            {
-                var cloudEvent = new CloudEvent();
-                Assert.Throws<ArgumentException>(() => cloudEvent[CloudEventsSpecVersion.SpecVersionAttributeName]);
-                Assert.Throws<ArgumentException>(() => cloudEvent[CloudEventsSpecVersion.SpecVersionAttribute]);
-                Assert.Throws<ArgumentException>(() => cloudEvent[CloudEventsSpecVersion.SpecVersionAttributeName] = "1.0");
-                Assert.Throws<ArgumentException>(() => cloudEvent[CloudEventsSpecVersion.SpecVersionAttribute] = "1.0");
-            }
-
-            [Fact]
-            public void FetchIntegerExtensionSetImplicitlyWithString_Throws()
-            {
-                var cloudEvent = new CloudEvent();
-                cloudEvent["ext"] = "10";
-
-                var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer);
-                Assert.Throws<ArgumentException>(() => cloudEvent[attr]);
-            }
-
-            [Fact]
-            public void SetIntegerExtensionSetImplicitlyWithString_Updates()
-            {
-                var cloudEvent = new CloudEvent();
-                cloudEvent["ext"] = "10";
-                Assert.Equal(CloudEventAttributeType.String, cloudEvent.GetAttribute("ext")?.Type);
-
-                var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer);
-                // Setting the event with the attribute updates the extension registry...
-                cloudEvent[attr] = 10;
-                Assert.Equal(attr, cloudEvent.GetAttribute("ext"));
-                // So we can fetch the value by string or attribute.
-                Assert.Equal(10, cloudEvent[attr]);
-                Assert.Equal(10, cloudEvent["ext"]);
-            }
-
-            [Fact]
-            public void ClearNewExtensionAttributeRetainsAttributeType()
-            {
-                var cloudEvent = new CloudEvent();
-                var attr = CloudEventAttribute.CreateExtension("ext", CloudEventAttributeType.Integer);
-                cloudEvent[attr] = null; // Doesn't set any value, but remembers the extension...
-                cloudEvent["ext"] = 10; // Which means it can be set as the integer later.
-                Assert.Same(attr, cloudEvent.GetAttribute("ext"));
-            }
-
-            // We may want to relax this - as otherwise specifying extensions without an explicit
-            // version is really brittle. (e.g. if "sampledrate" becomes an optional attribute in 1.1,
-            // and if our default version becomes 1.1, then previously-valid code will start to fail.)
-            [Fact]
-            public void Constructor_ExtensionAttributes_IncludesExistingAttributeName()
-            {
-                var ext = CloudEventAttribute.CreateExtension("type", CloudEventAttributeType.String);
-                var extensions = new[] { ext };
-                Assert.Throws<ArgumentException>(() => new CloudEvent(extensions));
-            }
+            var ext = CloudEventAttribute.CreateExtension("type", CloudEventAttributeType.String);
+            var extensions = new[] { ext };
+            Assert.Throws<ArgumentException>(() => new CloudEvent(extensions));
         }
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventsSpecVersionTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventsSpecVersionTest.cs
@@ -5,32 +5,31 @@
 using System;
 using Xunit;
 
-namespace CloudNative.CloudEvents.UnitTests
+namespace CloudNative.CloudEvents.UnitTests;
+
+public class CloudEventsSpecVersionTest
 {
-    public class CloudEventsSpecVersionTest
+    [Theory]
+    [InlineData(null)]
+    [InlineData("bogus")]
+    [InlineData("1")]
+    public void FromVersionId_Unknown(string? versionId) =>
+        Assert.Null(CloudEventsSpecVersion.FromVersionId(versionId));
+
+    [Theory]
+    [InlineData("1.0")]
+    public void FromVersionId_Known(string versionId)
     {
-        [Theory]
-        [InlineData(null)]
-        [InlineData("bogus")]
-        [InlineData("1")]
-        public void FromVersionId_Unknown(string? versionId) =>
-            Assert.Null(CloudEventsSpecVersion.FromVersionId(versionId));
+        var version = CloudEventsSpecVersion.FromVersionId(versionId);
+        Assert.NotNull(version);
+        Assert.Equal(versionId, version!.VersionId);
+    }
 
-        [Theory]
-        [InlineData("1.0")]
-        public void FromVersionId_Known(string versionId)
-        {
-            var version = CloudEventsSpecVersion.FromVersionId(versionId);
-            Assert.NotNull(version);
-            Assert.Equal(versionId, version!.VersionId);
-        }
-
-        [Fact]
-        public void V1Source_MustBeNonEmpty()
-        {
-            var attribute = CloudEventsSpecVersion.V1_0.SourceAttribute;
-            var uri = new Uri("", UriKind.RelativeOrAbsolute);
-            Assert.Throws<ArgumentException>(() => attribute.Validate(uri));
-        }
+    [Fact]
+    public void V1Source_MustBeNonEmpty()
+    {
+        var attribute = CloudEventsSpecVersion.V1_0.SourceAttribute;
+        var uri = new Uri("", UriKind.RelativeOrAbsolute);
+        Assert.Throws<ArgumentException>(() => attribute.Validate(uri));
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/Core/BinaryDataUtilitiesTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Core/BinaryDataUtilitiesTest.cs
@@ -6,28 +6,27 @@ using System;
 using System.Linq;
 using Xunit;
 
-namespace CloudNative.CloudEvents.Core.UnitTests
-{
-    public class BinaryDataUtilitiesTest
-    {
-        [Fact]
-        public void AsArray_ReturningOriginal()
-        {
-            byte[] original = { 1, 2, 3, 4, 5 };
-            var segment = new ArraySegment<byte>(original);
-            Assert.Same(original, BinaryDataUtilities.AsArray(segment));
-        }
+namespace CloudNative.CloudEvents.Core.UnitTests;
 
-        [Theory]
-        [InlineData(0)]
-        [InlineData(1)]
-        public void AsArray_FromPartialSegment(int offset)
-        {
-            byte[] original = { 1, 2, 3, 4, 5 };
-            var segment = new ArraySegment<byte>(original, offset, 4);
-            var actual = BinaryDataUtilities.AsArray(segment);
-            Assert.True(actual.SequenceEqual(segment));
-            Assert.NotSame(original, actual);
-        }
+public class BinaryDataUtilitiesTest
+{
+    [Fact]
+    public void AsArray_ReturningOriginal()
+    {
+        byte[] original = { 1, 2, 3, 4, 5 };
+        var segment = new ArraySegment<byte>(original);
+        Assert.Same(original, BinaryDataUtilities.AsArray(segment));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void AsArray_FromPartialSegment(int offset)
+    {
+        byte[] original = { 1, 2, 3, 4, 5 };
+        var segment = new ArraySegment<byte>(original, offset, 4);
+        var actual = BinaryDataUtilities.AsArray(segment);
+        Assert.True(actual.SequenceEqual(segment));
+        Assert.NotSame(original, actual);
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/Core/CloudEventAttributeTypesTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Core/CloudEventAttributeTypesTest.cs
@@ -5,8 +5,7 @@
 using System;
 using Xunit;
 
-namespace CloudNative.CloudEvents.Core.UnitTests
-{
+namespace CloudNative.CloudEvents.Core.UnitTests;
     public class CloudEventAttributeTypesTest
     {
         public static readonly TheoryData<CloudEventAttributeType> AllTypes = new TheoryData<CloudEventAttributeType>
@@ -29,4 +28,3 @@ namespace CloudNative.CloudEvents.Core.UnitTests
         public void GetOrdinal_NonNullInput(CloudEventAttributeType type) =>
             Assert.Equal(type.Ordinal, CloudEventAttributeTypes.GetOrdinal(type));
     }
-}

--- a/test/CloudNative.CloudEvents.UnitTests/Core/MimeUtilitiesTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Core/MimeUtilitiesTest.cs
@@ -8,100 +8,99 @@ using System.Net.Mime;
 using System.Text;
 using Xunit;
 
-namespace CloudNative.CloudEvents.Core.UnitTests
+namespace CloudNative.CloudEvents.Core.UnitTests;
+
+public class MimeUtilitiesTest
 {
-    public class MimeUtilitiesTest
+    [Theory]
+    [InlineData("application/json")]
+    [InlineData("application/json; charset=iso-8859-1")]
+    [InlineData("application/json; charset=iso-8859-1; name=some-name")]
+    [InlineData("application/json; charset=iso-8859-1; name=some-name; x=y; a=b")]
+    [InlineData("application/json; charset=iso-8859-1; name=some-name; boundary=xyzzy; x=y")]
+    public void ContentTypeConversions(string text)
     {
-        [Theory]
-        [InlineData("application/json")]
-        [InlineData("application/json; charset=iso-8859-1")]
-        [InlineData("application/json; charset=iso-8859-1; name=some-name")]
-        [InlineData("application/json; charset=iso-8859-1; name=some-name; x=y; a=b")]
-        [InlineData("application/json; charset=iso-8859-1; name=some-name; boundary=xyzzy; x=y")]
-        public void ContentTypeConversions(string text)
+        var originalContentType = new ContentType(text);
+        var header = MimeUtilities.ToMediaTypeHeaderValue(originalContentType);
+        AssertEqualParts(text, header!.ToString());
+        var convertedContentType = MimeUtilities.ToContentType(header);
+        AssertEqualParts(originalContentType.ToString(), convertedContentType!.ToString());
+
+        // Conversions can end up reordering the parameters. In reality we're only
+        // likely to end up with a media type and charset, but our tests use more parameters.
+        // This just makes them deterministic.
+        void AssertEqualParts(string expected, string actual)
         {
-            var originalContentType = new ContentType(text);
-            var header = MimeUtilities.ToMediaTypeHeaderValue(originalContentType);
-            AssertEqualParts(text, header!.ToString());
-            var convertedContentType = MimeUtilities.ToContentType(header);
-            AssertEqualParts(originalContentType.ToString(), convertedContentType!.ToString());
-
-            // Conversions can end up reordering the parameters. In reality we're only
-            // likely to end up with a media type and charset, but our tests use more parameters.
-            // This just makes them deterministic.
-            void AssertEqualParts(string expected, string actual)
-            {
-                expected = string.Join(";", expected.Split(";").OrderBy(x => x));
-                actual = string.Join(";", actual.Split(";").OrderBy(x => x));
-                Assert.Equal(expected, actual);
-            }
+            expected = string.Join(";", expected.Split(";").OrderBy(x => x));
+            actual = string.Join(";", actual.Split(";").OrderBy(x => x));
+            Assert.Equal(expected, actual);
         }
-
-        [Fact]
-        public void ContentTypeConversions_Null()
-        {
-            Assert.Null(MimeUtilities.ToMediaTypeHeaderValue(default(ContentType)));
-            Assert.Null(MimeUtilities.ToContentType(default(MediaTypeHeaderValue)));
-        }
-
-        [Theory]
-        [InlineData("iso-8859-1")]
-        [InlineData("utf-8")]
-        public void ContentTypeGetEncoding(string charSet)
-        {
-            var contentType = new ContentType($"text/plain; charset={charSet}");
-            Encoding encoding = MimeUtilities.GetEncoding(contentType);
-            Assert.Equal(charSet, encoding.WebName);
-        }
-
-        [Fact]
-        public void ContentTypeGetEncoding_NoContentType()
-        {
-            ContentType? contentType = null;
-            Encoding encoding = MimeUtilities.GetEncoding(contentType);
-            Assert.Equal(Encoding.UTF8, encoding);
-        }
-
-        [Fact]
-        public void ContentTypeGetEncoding_NoCharSet()
-        {
-            ContentType contentType = new ContentType("text/plain");
-            Encoding encoding = MimeUtilities.GetEncoding(contentType);
-            Assert.Equal(Encoding.UTF8, encoding);
-        }
-
-        [Theory]
-        [InlineData(null)]
-        [InlineData("text/plain")]
-        public void CreateContentTypeOrNull_WithContentType(string? text)
-        {
-            ContentType? ct = MimeUtilities.CreateContentTypeOrNull(text);
-            Assert.Equal(text, ct?.ToString());
-        }
-
-        [Theory]
-        [InlineData("text/plain", false)]
-        [InlineData(null, false)]
-        [InlineData("application/cloudevents", true)]
-        [InlineData("application/cloudevents+json", true)]
-        // It's not entirely clear that this *should* be true...
-        [InlineData("application/cloudeventstrailing", true)]
-        [InlineData("application/cloudevents-batch", false)]
-        [InlineData("application/cloudevents-batch+json", false)]
-        public void IsCloudEventsContentType(string? contentType, bool expectedResult) =>
-            Assert.Equal(expectedResult, MimeUtilities.IsCloudEventsContentType(contentType));
-
-        [Theory]
-        [InlineData("text/plain", false)]
-        [InlineData(null, false)]
-        [InlineData("application/cloudevents", false)]
-        [InlineData("application/cloudevents+json", false)]
-        [InlineData("application/cloudeventstrailing", false)]
-        [InlineData("application/cloudevents-batch", true)]
-        // It's not entirely clear that this *should* be true...
-        [InlineData("application/cloudevents-batchtrailing", true)]
-        [InlineData("application/cloudevents-batch+json", true)]
-        public void IsCloudEventsBatchContentType(string? contentType, bool expectedResult) =>
-            Assert.Equal(expectedResult, MimeUtilities.IsCloudEventsBatchContentType(contentType));
     }
+
+    [Fact]
+    public void ContentTypeConversions_Null()
+    {
+        Assert.Null(MimeUtilities.ToMediaTypeHeaderValue(default(ContentType)));
+        Assert.Null(MimeUtilities.ToContentType(default(MediaTypeHeaderValue)));
+    }
+
+    [Theory]
+    [InlineData("iso-8859-1")]
+    [InlineData("utf-8")]
+    public void ContentTypeGetEncoding(string charSet)
+    {
+        var contentType = new ContentType($"text/plain; charset={charSet}");
+        Encoding encoding = MimeUtilities.GetEncoding(contentType);
+        Assert.Equal(charSet, encoding.WebName);
+    }
+
+    [Fact]
+    public void ContentTypeGetEncoding_NoContentType()
+    {
+        ContentType? contentType = null;
+        Encoding encoding = MimeUtilities.GetEncoding(contentType);
+        Assert.Equal(Encoding.UTF8, encoding);
+    }
+
+    [Fact]
+    public void ContentTypeGetEncoding_NoCharSet()
+    {
+        ContentType contentType = new ContentType("text/plain");
+        Encoding encoding = MimeUtilities.GetEncoding(contentType);
+        Assert.Equal(Encoding.UTF8, encoding);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("text/plain")]
+    public void CreateContentTypeOrNull_WithContentType(string? text)
+    {
+        ContentType? ct = MimeUtilities.CreateContentTypeOrNull(text);
+        Assert.Equal(text, ct?.ToString());
+    }
+
+    [Theory]
+    [InlineData("text/plain", false)]
+    [InlineData(null, false)]
+    [InlineData("application/cloudevents", true)]
+    [InlineData("application/cloudevents+json", true)]
+    // It's not entirely clear that this *should* be true...
+    [InlineData("application/cloudeventstrailing", true)]
+    [InlineData("application/cloudevents-batch", false)]
+    [InlineData("application/cloudevents-batch+json", false)]
+    public void IsCloudEventsContentType(string? contentType, bool expectedResult) =>
+        Assert.Equal(expectedResult, MimeUtilities.IsCloudEventsContentType(contentType));
+
+    [Theory]
+    [InlineData("text/plain", false)]
+    [InlineData(null, false)]
+    [InlineData("application/cloudevents", false)]
+    [InlineData("application/cloudevents+json", false)]
+    [InlineData("application/cloudeventstrailing", false)]
+    [InlineData("application/cloudevents-batch", true)]
+    // It's not entirely clear that this *should* be true...
+    [InlineData("application/cloudevents-batchtrailing", true)]
+    [InlineData("application/cloudevents-batch+json", true)]
+    public void IsCloudEventsBatchContentType(string? contentType, bool expectedResult) =>
+        Assert.Equal(expectedResult, MimeUtilities.IsCloudEventsBatchContentType(contentType));
 }

--- a/test/CloudNative.CloudEvents.UnitTests/DocumentationSamples.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/DocumentationSamples.cs
@@ -16,161 +16,160 @@ using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace CloudNative.CloudEvents.UnitTests
+namespace CloudNative.CloudEvents.UnitTests;
+
+/// <summary>
+/// Tests for the code in the docs/ directory.
+/// The code itself is currently copy/pasted from this file, but at least we have some confidence
+/// that it's working code. In the future we can write tooling to extract the code automatically.
+/// </summary>
+public class DocumentationSamples
 {
-    /// <summary>
-    /// Tests for the code in the docs/ directory.
-    /// The code itself is currently copy/pasted from this file, but at least we have some confidence
-    /// that it's working code. In the future we can write tooling to extract the code automatically.
-    /// </summary>
-    public class DocumentationSamples
+    [Fact]
+    public async Task HttpRequestMessageRoundtrip()
     {
-        [Fact]
-        public async Task HttpRequestMessageRoundtrip()
+        var requestMessage = CreateHttpRequestMessage();
+        var request = await ConvertHttpRequestMessage(requestMessage);
+
+        var cloudEvent = await ParseHttpRequestAsync(request);
+        Assert.Equal("event-id", cloudEvent.Id);
+        Assert.Equal("This is CloudEvent data", cloudEvent.Data);
+    }
+
+    private static HttpRequestMessage CreateHttpRequestMessage()
+    {
+        // Sample: guide.md#PopulateHttpRequestMessage
+        CloudEvent cloudEvent = new CloudEvent
         {
-            var requestMessage = CreateHttpRequestMessage();
-            var request = await ConvertHttpRequestMessage(requestMessage);
+            Id = "event-id",
+            Type = "event-type",
+            Source = new Uri("https://cloudevents.io/"),
+            Time = DateTimeOffset.UtcNow,
+            DataContentType = "text/plain",
+            Data = "This is CloudEvent data"
+        };
 
-            var cloudEvent = await ParseHttpRequestAsync(request);
-            Assert.Equal("event-id", cloudEvent.Id);
-            Assert.Equal("This is CloudEvent data", cloudEvent.Data);
-        }
-
-        private static HttpRequestMessage CreateHttpRequestMessage()
+        CloudEventFormatter formatter = new JsonEventFormatter();
+        HttpRequestMessage request = new HttpRequestMessage
         {
-            // Sample: guide.md#PopulateHttpRequestMessage
-            CloudEvent cloudEvent = new CloudEvent
-            {
-                Id = "event-id",
-                Type = "event-type",
-                Source = new Uri("https://cloudevents.io/"),
-                Time = DateTimeOffset.UtcNow,
-                DataContentType = "text/plain",
-                Data = "This is CloudEvent data"
-            };
-
-            CloudEventFormatter formatter = new JsonEventFormatter();
-            HttpRequestMessage request = new HttpRequestMessage
-            {
-                Method = HttpMethod.Post,
-                Content = cloudEvent.ToHttpContent(ContentMode.Structured, formatter)
-            };
-            // End sample
-            return request;
-        }
-
-        private static async Task<CloudEvent> ParseHttpRequestAsync(HttpRequest request)
-        {
-            // Sample: guide.md#ParseHttpRequestMessage
-            CloudEventFormatter formatter = new JsonEventFormatter();
-            CloudEvent cloudEvent = await request.ToCloudEventAsync(formatter);
-            // End sample
-            return cloudEvent;
-        }
-
-        [Fact]
-        public async Task GameResultRoundtrip1()
-        {
-            var requestMessage = SerializeGameResult();
-            var request = await ConvertHttpRequestMessage(requestMessage);
-            var result = await DeserializeGameResult1(request);
-            Assert.Equal("player1", result.PlayerId);
-            Assert.Equal("game1", result.GameId);
-            Assert.Equal(200, result.Score);
-        }
-
-        [Fact]
-        public async Task GameResultRoundtrip2()
-        {
-            var requestMessage = SerializeGameResult();
-            var request = await ConvertHttpRequestMessage(requestMessage);
-            var result = await DeserializeGameResult2(request);
-            Assert.Equal("player1", result.PlayerId);
-            Assert.Equal("game1", result.GameId);
-            Assert.Equal(200, result.Score);
-        }
-
-        // Sample: guide.md#GameResult
-        public class GameResult
-        {
-            [JsonProperty("playerId")]
-            public string? PlayerId { get; set; }
-
-            [JsonProperty("gameId")]
-            public string? GameId { get; set; }
-
-            [JsonProperty("score")]
-            public int Score { get; set; }
-        }
+            Method = HttpMethod.Post,
+            Content = cloudEvent.ToHttpContent(ContentMode.Structured, formatter)
+        };
         // End sample
+        return request;
+    }
 
-        private static HttpRequestMessage SerializeGameResult()
+    private static async Task<CloudEvent> ParseHttpRequestAsync(HttpRequest request)
+    {
+        // Sample: guide.md#ParseHttpRequestMessage
+        CloudEventFormatter formatter = new JsonEventFormatter();
+        CloudEvent cloudEvent = await request.ToCloudEventAsync(formatter);
+        // End sample
+        return cloudEvent;
+    }
+
+    [Fact]
+    public async Task GameResultRoundtrip1()
+    {
+        var requestMessage = SerializeGameResult();
+        var request = await ConvertHttpRequestMessage(requestMessage);
+        var result = await DeserializeGameResult1(request);
+        Assert.Equal("player1", result.PlayerId);
+        Assert.Equal("game1", result.GameId);
+        Assert.Equal(200, result.Score);
+    }
+
+    [Fact]
+    public async Task GameResultRoundtrip2()
+    {
+        var requestMessage = SerializeGameResult();
+        var request = await ConvertHttpRequestMessage(requestMessage);
+        var result = await DeserializeGameResult2(request);
+        Assert.Equal("player1", result.PlayerId);
+        Assert.Equal("game1", result.GameId);
+        Assert.Equal(200, result.Score);
+    }
+
+    // Sample: guide.md#GameResult
+    public class GameResult
+    {
+        [JsonProperty("playerId")]
+        public string? PlayerId { get; set; }
+
+        [JsonProperty("gameId")]
+        public string? GameId { get; set; }
+
+        [JsonProperty("score")]
+        public int Score { get; set; }
+    }
+    // End sample
+
+    private static HttpRequestMessage SerializeGameResult()
+    {
+        // Sample: guide.md#SerializeGameResult
+        var result = new GameResult
         {
-            // Sample: guide.md#SerializeGameResult
-            var result = new GameResult
-            {
-                PlayerId = "player1",
-                GameId = "game1",
-                Score = 200
-            };
-            var cloudEvent = new CloudEvent
-            {
-                Id = "result-1",
-                Type = "game.played.v1",
-                Source = new Uri("/game", UriKind.Relative),
-                Time = DateTimeOffset.UtcNow,
-                DataContentType = "application/json",
-                Data = result
-            };
-            var formatter = new JsonEventFormatter();
-            var request = new HttpRequestMessage
-            {
-                Method = HttpMethod.Post,
-                Content = cloudEvent.ToHttpContent(ContentMode.Binary, formatter)
-            };
-            // End sample
-            return request;
+            PlayerId = "player1",
+            GameId = "game1",
+            Score = 200
+        };
+        var cloudEvent = new CloudEvent
+        {
+            Id = "result-1",
+            Type = "game.played.v1",
+            Source = new Uri("/game", UriKind.Relative),
+            Time = DateTimeOffset.UtcNow,
+            DataContentType = "application/json",
+            Data = result
+        };
+        var formatter = new JsonEventFormatter();
+        var request = new HttpRequestMessage
+        {
+            Method = HttpMethod.Post,
+            Content = cloudEvent.ToHttpContent(ContentMode.Binary, formatter)
+        };
+        // End sample
+        return request;
+    }
+
+    private static async Task<GameResult> DeserializeGameResult1(HttpRequest request)
+    {
+        // Sample: guide.md#DeserializeGameResult1
+        CloudEventFormatter formatter = new JsonEventFormatter();
+        CloudEvent cloudEvent = await request.ToCloudEventAsync(formatter);
+        JObject dataAsJObject = (JObject) cloudEvent.Data!;
+        GameResult result = dataAsJObject.ToObject<GameResult>()!;
+        // End sample
+        return result;
+    }
+
+    private static async Task<GameResult> DeserializeGameResult2(HttpRequest request)
+    {
+        // Sample: guide.md#DeserializeGameResult2
+        CloudEventFormatter formatter = new JsonEventFormatter<GameResult>();
+        CloudEvent cloudEvent = await request.ToCloudEventAsync(formatter);
+        GameResult result = (GameResult) cloudEvent.Data!;
+        // End sample
+        return result;
+    }
+
+    private static async Task<HttpRequest> ConvertHttpRequestMessage(HttpRequestMessage message)
+    {
+        var request = new DefaultHttpContext().Request;
+        foreach (var header in message.Headers)
+        {
+            request.Headers[header.Key] = header.Value.Single();
         }
-
-        private static async Task<GameResult> DeserializeGameResult1(HttpRequest request)
+        if (message.Content?.Headers is HttpContentHeaders contentHeaders)
         {
-            // Sample: guide.md#DeserializeGameResult1
-            CloudEventFormatter formatter = new JsonEventFormatter();
-            CloudEvent cloudEvent = await request.ToCloudEventAsync(formatter);
-            JObject dataAsJObject = (JObject) cloudEvent.Data!;
-            GameResult result = dataAsJObject.ToObject<GameResult>()!;
-            // End sample
-            return result;
-        }
-
-        private static async Task<GameResult> DeserializeGameResult2(HttpRequest request)
-        {
-            // Sample: guide.md#DeserializeGameResult2
-            CloudEventFormatter formatter = new JsonEventFormatter<GameResult>();
-            CloudEvent cloudEvent = await request.ToCloudEventAsync(formatter);
-            GameResult result = (GameResult) cloudEvent.Data!;
-            // End sample
-            return result;
-        }
-
-        private static async Task<HttpRequest> ConvertHttpRequestMessage(HttpRequestMessage message)
-        {
-            var request = new DefaultHttpContext().Request;
-            foreach (var header in message.Headers)
+            foreach (var header in contentHeaders)
             {
                 request.Headers[header.Key] = header.Value.Single();
             }
-            if (message.Content?.Headers is HttpContentHeaders contentHeaders)
-            {
-                foreach (var header in contentHeaders)
-                {
-                    request.Headers[header.Key] = header.Value.Single();
-                }
-            }
-
-            var contentBytes = await (message.Content?.ReadAsByteArrayAsync() ?? Task.FromResult(Array.Empty<byte>()));
-            request.Body = new MemoryStream(contentBytes);
-            return request;
         }
+
+        var contentBytes = await (message.Content?.ReadAsByteArrayAsync() ?? Task.FromResult(Array.Empty<byte>()));
+        request.Body = new MemoryStream(contentBytes);
+        return request;
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/Extensions/PartitioningTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Extensions/PartitioningTest.cs
@@ -6,11 +6,11 @@ using CloudNative.CloudEvents.NewtonsoftJson;
 using Xunit;
 using static CloudNative.CloudEvents.UnitTests.CloudEventFormatterExtensions;
 
-namespace CloudNative.CloudEvents.Extensions.UnitTests
+namespace CloudNative.CloudEvents.Extensions.UnitTests;
+
+public class PartitioningTest
 {
-    public class PartitioningTest
-    {
-        private static readonly string sampleJson = @"
+    private static readonly string sampleJson = @"
            {
                'specversion' : '1.0',
                'type' : 'com.github.pull.create',
@@ -20,53 +20,52 @@ namespace CloudNative.CloudEvents.Extensions.UnitTests
            }".Replace('\'', '"');
 
 
-        [Fact]
-        public void ParseJson()
+    [Fact]
+    public void ParseJson()
+    {
+        var jsonFormatter = new JsonEventFormatter();
+        var cloudEvent = jsonFormatter.DecodeStructuredModeText(sampleJson);
+        Assert.Equal("abc", cloudEvent["partitionkey"]);
+        Assert.Equal("abc", cloudEvent[Partitioning.PartitionKeyAttribute]);
+        Assert.Equal("abc", cloudEvent.GetPartitionKey());
+    }
+
+    [Fact]
+    public void Transcode()
+    {
+        var jsonFormatter = new JsonEventFormatter();
+        var cloudEvent1 = jsonFormatter.DecodeStructuredModeText(sampleJson);
+        var jsonData = jsonFormatter.EncodeStructuredModeMessage(cloudEvent1, out var contentType);
+        var cloudEvent = jsonFormatter.DecodeStructuredModeMessage(jsonData, contentType, null);
+
+        Assert.Equal("abc", cloudEvent["partitionkey"]);
+        Assert.Equal("abc", cloudEvent[Partitioning.PartitionKeyAttribute]);
+        Assert.Equal("abc", cloudEvent.GetPartitionKey());
+    }
+
+    [Fact]
+    public void SetPartitionKey()
+    {
+        var cloudEvent = new CloudEvent();
+        cloudEvent.SetPartitionKey("xyz");
+        Assert.Equal("xyz", cloudEvent["partitionkey"]);
+        Assert.Equal("xyz", cloudEvent[Partitioning.PartitionKeyAttribute]);
+
+        cloudEvent.SetPartitionKey(null);
+        Assert.Null(cloudEvent["partitionkey"]);
+        Assert.Null(cloudEvent[Partitioning.PartitionKeyAttribute]);
+    }
+
+    [Fact]
+    public void GetPartitionKey()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var jsonFormatter = new JsonEventFormatter();
-            var cloudEvent = jsonFormatter.DecodeStructuredModeText(sampleJson);
-            Assert.Equal("abc", cloudEvent["partitionkey"]);
-            Assert.Equal("abc", cloudEvent[Partitioning.PartitionKeyAttribute]);
-            Assert.Equal("abc", cloudEvent.GetPartitionKey());
-        }
+            ["partitionkey"] = "xyz"
+        };
+        Assert.Equal("xyz", cloudEvent.GetPartitionKey());
 
-        [Fact]
-        public void Transcode()
-        {
-            var jsonFormatter = new JsonEventFormatter();
-            var cloudEvent1 = jsonFormatter.DecodeStructuredModeText(sampleJson);
-            var jsonData = jsonFormatter.EncodeStructuredModeMessage(cloudEvent1, out var contentType);
-            var cloudEvent = jsonFormatter.DecodeStructuredModeMessage(jsonData, contentType, null);
-
-            Assert.Equal("abc", cloudEvent["partitionkey"]);
-            Assert.Equal("abc", cloudEvent[Partitioning.PartitionKeyAttribute]);
-            Assert.Equal("abc", cloudEvent.GetPartitionKey());
-        }
-
-        [Fact]
-        public void SetPartitionKey()
-        {
-            var cloudEvent = new CloudEvent();
-            cloudEvent.SetPartitionKey("xyz");
-            Assert.Equal("xyz", cloudEvent["partitionkey"]);
-            Assert.Equal("xyz", cloudEvent[Partitioning.PartitionKeyAttribute]);
-
-            cloudEvent.SetPartitionKey(null);
-            Assert.Null(cloudEvent["partitionkey"]);
-            Assert.Null(cloudEvent[Partitioning.PartitionKeyAttribute]);
-        }
-
-        [Fact]
-        public void GetPartitionKey()
-        {
-            var cloudEvent = new CloudEvent
-            {
-                ["partitionkey"] = "xyz"
-            };
-            Assert.Equal("xyz", cloudEvent.GetPartitionKey());
-
-            cloudEvent["partitionkey"] = null;
-            Assert.Null(cloudEvent.GetPartitionKey());
-        }
+        cloudEvent["partitionkey"] = null;
+        Assert.Null(cloudEvent.GetPartitionKey());
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/Extensions/SamplingTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Extensions/SamplingTest.cs
@@ -7,11 +7,11 @@ using System;
 using Xunit;
 using static CloudNative.CloudEvents.UnitTests.CloudEventFormatterExtensions;
 
-namespace CloudNative.CloudEvents.Extensions.UnitTests
+namespace CloudNative.CloudEvents.Extensions.UnitTests;
+
+public class SamplingTest
 {
-    public class SamplingTest
-    {
-        private static readonly string sampleJson = @"
+    private static readonly string sampleJson = @"
            {
                'specversion' : '1.0',
                'type' : 'com.github.pull.create',
@@ -20,62 +20,61 @@ namespace CloudNative.CloudEvents.Extensions.UnitTests
                'sampledrate' : 1,
            }".Replace('\'', '"');
 
-        [Fact]
-        public void SamplingParse()
-        {
-            var jsonFormatter = new JsonEventFormatter();
-            var cloudEvent = jsonFormatter.DecodeStructuredModeText(sampleJson, Sampling.AllAttributes);
+    [Fact]
+    public void SamplingParse()
+    {
+        var jsonFormatter = new JsonEventFormatter();
+        var cloudEvent = jsonFormatter.DecodeStructuredModeText(sampleJson, Sampling.AllAttributes);
 
-            Assert.Equal(1, cloudEvent["sampledrate"]);
-            Assert.Equal(1, cloudEvent.GetSampledRate());
-        }
+        Assert.Equal(1, cloudEvent["sampledrate"]);
+        Assert.Equal(1, cloudEvent.GetSampledRate());
+    }
 
-        [Fact]
-        public void SamplingJsonTranscode()
-        {
-            var jsonFormatter = new JsonEventFormatter();
-            var cloudEvent1 = jsonFormatter.DecodeStructuredModeText(sampleJson);
-            // Note that the value is just a string here, as we don't know the attribute type.
-            Assert.Equal("1", cloudEvent1["sampledrate"]);
+    [Fact]
+    public void SamplingJsonTranscode()
+    {
+        var jsonFormatter = new JsonEventFormatter();
+        var cloudEvent1 = jsonFormatter.DecodeStructuredModeText(sampleJson);
+        // Note that the value is just a string here, as we don't know the attribute type.
+        Assert.Equal("1", cloudEvent1["sampledrate"]);
 
-            var jsonData = jsonFormatter.EncodeStructuredModeMessage(cloudEvent1, out var contentType);
-            var cloudEvent = jsonFormatter.DecodeStructuredModeMessage(jsonData, contentType, Sampling.AllAttributes);
+        var jsonData = jsonFormatter.EncodeStructuredModeMessage(cloudEvent1, out var contentType);
+        var cloudEvent = jsonFormatter.DecodeStructuredModeMessage(jsonData, contentType, Sampling.AllAttributes);
 
-            // When parsing with the attributes in place, the value is propagated as an integer.
-            Assert.Equal(1, cloudEvent["sampledrate"]);
-            Assert.Equal(1, cloudEvent.GetSampledRate());
-        }
+        // When parsing with the attributes in place, the value is propagated as an integer.
+        Assert.Equal(1, cloudEvent["sampledrate"]);
+        Assert.Equal(1, cloudEvent.GetSampledRate());
+    }
 
-        [Fact]
-        public void SetAttributeValue_Invalid()
-        {
-            var cloudEvent = new CloudEvent(Sampling.AllAttributes);
-            Assert.Throws<ArgumentException>(() => cloudEvent["sampledrate"] = 0);
-        }
+    [Fact]
+    public void SetAttributeValue_Invalid()
+    {
+        var cloudEvent = new CloudEvent(Sampling.AllAttributes);
+        Assert.Throws<ArgumentException>(() => cloudEvent["sampledrate"] = 0);
+    }
 
-        [Fact]
-        public void SetSampledRate()
-        {
-            var cloudEvent = new CloudEvent();
-            cloudEvent.SetSampledRate(5);
-            Assert.Equal(5, cloudEvent["sampledrate"]);
+    [Fact]
+    public void SetSampledRate()
+    {
+        var cloudEvent = new CloudEvent();
+        cloudEvent.SetSampledRate(5);
+        Assert.Equal(5, cloudEvent["sampledrate"]);
 
-            cloudEvent.SetSampledRate(null);
-            Assert.Null(cloudEvent["sampledrate"]);
-        }
+        cloudEvent.SetSampledRate(null);
+        Assert.Null(cloudEvent["sampledrate"]);
+    }
 
-        [Fact]
-        public void SetSampleRate_Invalid()
-        {
-            var cloudEvent = new CloudEvent();
-            Assert.Throws<ArgumentException>(() => cloudEvent.SetSampledRate(0));
-        }
+    [Fact]
+    public void SetSampleRate_Invalid()
+    {
+        var cloudEvent = new CloudEvent();
+        Assert.Throws<ArgumentException>(() => cloudEvent.SetSampledRate(0));
+    }
 
-        [Fact]
-        public void GetSampledRate_NotSet()
-        {
-            var cloudEvent = new CloudEvent();
-            Assert.Null(cloudEvent.GetSampledRate());
-        }
+    [Fact]
+    public void GetSampledRate_NotSet()
+    {
+        var cloudEvent = new CloudEvent();
+        Assert.Null(cloudEvent.GetSampledRate());
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/Extensions/SequenceTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Extensions/SequenceTest.cs
@@ -7,11 +7,11 @@ using System;
 using Xunit;
 using static CloudNative.CloudEvents.UnitTests.CloudEventFormatterExtensions;
 
-namespace CloudNative.CloudEvents.Extensions.UnitTests
+namespace CloudNative.CloudEvents.Extensions.UnitTests;
+
+public class SequenceTest
 {
-    public class SequenceTest
-    {
-        private static readonly string sampleJson = @"
+    private static readonly string sampleJson = @"
            {
                'specversion' : '1.0',
                'type' : 'com.github.pull.create',
@@ -21,96 +21,95 @@ namespace CloudNative.CloudEvents.Extensions.UnitTests
                'sequence' : '25'
            }".Replace('\'', '"');
 
-        [Fact]
-        public void Parse()
+    [Fact]
+    public void Parse()
+    {
+        var jsonFormatter = new JsonEventFormatter();
+        var cloudEvent = jsonFormatter.DecodeStructuredModeText(sampleJson, Sequence.AllAttributes);
+
+        Assert.Equal("Integer", cloudEvent[Sequence.SequenceTypeAttribute]);
+        Assert.Equal("25", cloudEvent[Sequence.SequenceAttribute]);
+    }
+
+    [Fact]
+    public void Transcode()
+    {
+        var jsonFormatter = new JsonEventFormatter();
+        var cloudEvent1 = jsonFormatter.DecodeStructuredModeText(sampleJson);
+        var jsonData = jsonFormatter.EncodeStructuredModeMessage(cloudEvent1, out var contentType);
+        var cloudEvent = jsonFormatter.DecodeStructuredModeMessage(jsonData, contentType, Sequence.AllAttributes);
+
+        Assert.Equal("Integer", cloudEvent[Sequence.SequenceTypeAttribute]);
+        Assert.Equal("25", cloudEvent[Sequence.SequenceAttribute]);
+    }
+
+    [Fact]
+    public void GetSequenceExtensionMethods_Integer()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var jsonFormatter = new JsonEventFormatter();
-            var cloudEvent = jsonFormatter.DecodeStructuredModeText(sampleJson, Sequence.AllAttributes);
+            ["sequencetype"] = "Integer",
+            ["sequence"] = "25"
+        };
 
-            Assert.Equal("Integer", cloudEvent[Sequence.SequenceTypeAttribute]);
-            Assert.Equal("25", cloudEvent[Sequence.SequenceAttribute]);
-        }
+        Assert.Equal(25, cloudEvent.GetSequenceValue());
+        Assert.Equal("25", cloudEvent.GetSequenceString());
+        Assert.Equal("Integer", cloudEvent.GetSequenceType());
+    }
 
-        [Fact]
-        public void Transcode()
+    [Fact]
+    public void GetSequenceExtensionMethods_Null()
+    {
+        var cloudEvent = new CloudEvent();
+
+        Assert.Null(cloudEvent.GetSequenceValue());
+        Assert.Null(cloudEvent.GetSequenceString());
+        Assert.Null(cloudEvent.GetSequenceType());
+    }
+
+    [Fact]
+    public void GetSequenceExtensionMethods_UnknownType()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var jsonFormatter = new JsonEventFormatter();
-            var cloudEvent1 = jsonFormatter.DecodeStructuredModeText(sampleJson);
-            var jsonData = jsonFormatter.EncodeStructuredModeMessage(cloudEvent1, out var contentType);
-            var cloudEvent = jsonFormatter.DecodeStructuredModeMessage(jsonData, contentType, Sequence.AllAttributes);
+            ["sequencetype"] = "Mystery",
+            ["sequence"] = "xyz"
+        };
 
-            Assert.Equal("Integer", cloudEvent[Sequence.SequenceTypeAttribute]);
-            Assert.Equal("25", cloudEvent[Sequence.SequenceAttribute]);
-        }
+        Assert.Equal("Mystery", cloudEvent.GetSequenceType());
+        Assert.Equal("xyz", cloudEvent.GetSequenceString());
+        Assert.Throws<InvalidOperationException>(() => cloudEvent.GetSequenceValue());
+    }
 
-        [Fact]
-        public void GetSequenceExtensionMethods_Integer()
+    [Fact]
+    public void SetSequence_Null()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent
-            {
-                ["sequencetype"] = "Integer",
-                ["sequence"] = "25"
-            };
+            ["sequence"] = "xyz",
+            ["sequencetype"] = "new sequence type"
+        };
+        cloudEvent.SetSequence(null);
 
-            Assert.Equal(25, cloudEvent.GetSequenceValue());
-            Assert.Equal("25", cloudEvent.GetSequenceString());
-            Assert.Equal("Integer", cloudEvent.GetSequenceType());
-        }
-
-        [Fact]
-        public void GetSequenceExtensionMethods_Null()
-        {
-            var cloudEvent = new CloudEvent();
-
-            Assert.Null(cloudEvent.GetSequenceValue());
-            Assert.Null(cloudEvent.GetSequenceString());
-            Assert.Null(cloudEvent.GetSequenceType());
-        }
-
-        [Fact]
-        public void GetSequenceExtensionMethods_UnknownType()
-        {
-            var cloudEvent = new CloudEvent
-            {
-                ["sequencetype"] = "Mystery",
-                ["sequence"] = "xyz"
-            };
-
-            Assert.Equal("Mystery", cloudEvent.GetSequenceType());
-            Assert.Equal("xyz", cloudEvent.GetSequenceString());
-            Assert.Throws<InvalidOperationException>(() => cloudEvent.GetSequenceValue());
-        }
-
-        [Fact]
-        public void SetSequence_Null()
-        {
-            var cloudEvent = new CloudEvent
-            {
-                ["sequence"] = "xyz",
-                ["sequencetype"] = "new sequence type"
-            };
-            cloudEvent.SetSequence(null);
-
-            Assert.Null(cloudEvent["sequence"]);
-            Assert.Null(cloudEvent["sequencetype"]);
-        }
+        Assert.Null(cloudEvent["sequence"]);
+        Assert.Null(cloudEvent["sequencetype"]);
+    }
 
 
-        [Fact]
-        public void SetSequence_Integer()
-        {
-            var cloudEvent = new CloudEvent().SetSequence(15);
+    [Fact]
+    public void SetSequence_Integer()
+    {
+        var cloudEvent = new CloudEvent().SetSequence(15);
 
-            Assert.Equal("15", cloudEvent["sequence"]);
-            Assert.Equal("Integer", cloudEvent["sequencetype"]);
-        }
+        Assert.Equal("15", cloudEvent["sequence"]);
+        Assert.Equal("Integer", cloudEvent["sequencetype"]);
+    }
 
-        [Fact]
-        public void SetSequence_UnknownType()
-        {
-            var cloudEvent = new CloudEvent();
-            var uri = new Uri("https://oddsequencetype");
-            Assert.Throws<ArgumentException>(() => cloudEvent.SetSequence(uri));
-        }
+    [Fact]
+    public void SetSequence_UnknownType()
+    {
+        var cloudEvent = new CloudEvent();
+        var uri = new Uri("https://oddsequencetype");
+        Assert.Throws<ArgumentException>(() => cloudEvent.SetSequence(uri));
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/Http/HttpClientExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Http/HttpClientExtensionsTest.cs
@@ -18,11 +18,11 @@ using System.Threading.Tasks;
 using Xunit;
 using static CloudNative.CloudEvents.UnitTests.TestHelpers;
 
-namespace CloudNative.CloudEvents.Http.UnitTests
+namespace CloudNative.CloudEvents.Http.UnitTests;
+
+public class HttpClientExtensionsTest : HttpTestBase
 {
-    public class HttpClientExtensionsTest : HttpTestBase
-    {
-        public static TheoryData<string, HttpContent, IDictionary<string, string>?> SingleCloudEventMessages => new TheoryData<string, HttpContent, IDictionary<string, string>?>
+    public static TheoryData<string, HttpContent, IDictionary<string, string>?> SingleCloudEventMessages => new TheoryData<string, HttpContent, IDictionary<string, string>?>
         {
             {
                 "Binary",
@@ -56,7 +56,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
             }
         };
 
-        public static TheoryData<string, HttpContent, IDictionary<string, string>?> BatchMessages => new TheoryData<string, HttpContent, IDictionary<string, string>?>
+    public static TheoryData<string, HttpContent, IDictionary<string, string>?> BatchMessages => new TheoryData<string, HttpContent, IDictionary<string, string>?>
         {
             {
                 "Batch",
@@ -65,7 +65,7 @@ namespace CloudNative.CloudEvents.Http.UnitTests
             }
         };
 
-        public static TheoryData<string, HttpContent, IDictionary<string, string>?> NonCloudEventMessages => new TheoryData<string, HttpContent, IDictionary<string, string>?>
+    public static TheoryData<string, HttpContent, IDictionary<string, string>?> NonCloudEventMessages => new TheoryData<string, HttpContent, IDictionary<string, string>?>
         {
             {
                 "Plain text",
@@ -74,437 +74,436 @@ namespace CloudNative.CloudEvents.Http.UnitTests
             }
         };
 
-        [Theory]
-        [MemberData(nameof(SingleCloudEventMessages))]
-        public void IsCloudEvent_True(string description, HttpContent content, IDictionary<string, string>? headers)
+    [Theory]
+    [MemberData(nameof(SingleCloudEventMessages))]
+    public void IsCloudEvent_True(string description, HttpContent content, IDictionary<string, string>? headers)
+    {
+        // Really only present for display purposes.
+        Assert.NotNull(description);
+
+        var request = new HttpRequestMessage { Content = content };
+        CopyHeaders(headers, request.Headers);
+        Assert.True(request.IsCloudEvent());
+
+        var response = new HttpResponseMessage { Content = content };
+        CopyHeaders(headers, response.Headers);
+        Assert.True(request.IsCloudEvent());
+    }
+
+    [Theory]
+    [MemberData(nameof(BatchMessages))]
+    [MemberData(nameof(NonCloudEventMessages))]
+    public void IsCloudEvent_False(string description, HttpContent content, IDictionary<string, string>? headers)
+    {
+        // Really only present for display purposes.
+        Assert.NotNull(description);
+
+        var request = new HttpRequestMessage { Content = content };
+        CopyHeaders(headers, request.Headers);
+        Assert.False(request.IsCloudEvent());
+
+        var response = new HttpResponseMessage { Content = content };
+        CopyHeaders(headers, response.Headers);
+        Assert.False(request.IsCloudEvent());
+    }
+
+    [Theory]
+    [MemberData(nameof(BatchMessages))]
+    public void IsCloudEventBatch_True(string description, HttpContent content, IDictionary<string, string>? headers)
+    {
+        // Really only present for display purposes.
+        Assert.NotNull(description);
+
+        var request = new HttpRequestMessage { Content = content };
+        CopyHeaders(headers, request.Headers);
+        Assert.True(request.IsCloudEventBatch());
+
+        var response = new HttpResponseMessage { Content = content };
+        CopyHeaders(headers, response.Headers);
+        Assert.True(request.IsCloudEventBatch());
+    }
+
+    [Theory]
+    [MemberData(nameof(SingleCloudEventMessages))]
+    [MemberData(nameof(NonCloudEventMessages))]
+    public void IsCloudEventBatch_False(string description, HttpContent content, IDictionary<string, string>? headers)
+    {
+        // Really only present for display purposes.
+        Assert.NotNull(description);
+
+        var request = new HttpRequestMessage { Content = content };
+        CopyHeaders(headers, request.Headers);
+        Assert.False(request.IsCloudEventBatch());
+
+        var response = new HttpResponseMessage { Content = content };
+        CopyHeaders(headers, response.Headers);
+        Assert.False(request.IsCloudEventBatch());
+    }
+
+    [Fact]
+    public async Task ToCloudEventBatchAsync_Valid()
+    {
+        var batch = CreateSampleBatch();
+
+        var formatter = new JsonEventFormatter();
+        var contentBytes = formatter.EncodeBatchModeMessage(batch, out var contentType);
+
+        AssertBatchesEqual(batch, await CreateRequestMessage(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionArray));
+        AssertBatchesEqual(batch, await CreateRequestMessage(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionSequence));
+        AssertBatchesEqual(batch, await CreateResponseMessage(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionArray));
+        AssertBatchesEqual(batch, await CreateResponseMessage(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionSequence));
+    }
+
+    [Fact]
+    public async Task ToCloudEventBatchAsync_Invalid()
+    {
+        // Most likely accident: calling ToCloudEventBatchAsync with a single event in structured mode.
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        var formatter = new JsonEventFormatter();
+        var contentBytes = formatter.EncodeStructuredModeMessage(cloudEvent, out var contentType);
+        await Assert.ThrowsAsync<ArgumentException>(() => CreateRequestMessage(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionArray));
+        await Assert.ThrowsAsync<ArgumentException>(() => CreateRequestMessage(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionSequence));
+        await Assert.ThrowsAsync<ArgumentException>(() => CreateResponseMessage(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionArray));
+        await Assert.ThrowsAsync<ArgumentException>(() => CreateResponseMessage(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionSequence));
+    }
+
+    [Fact]
+    public async Task ToCloudEvent_Valid()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        var formatter = new JsonEventFormatter();
+        var contentBytes = formatter.EncodeStructuredModeMessage(cloudEvent, out var contentType);
+        var parsedRequest = await CreateRequestMessage(contentBytes, contentType).ToCloudEventAsync(formatter);
+        var parsedResponse = await CreateResponseMessage(contentBytes, contentType).ToCloudEventAsync(formatter);
+
+        AssertCloudEventsEqual(parsedRequest, cloudEvent);
+        AssertCloudEventsEqual(parsedResponse, cloudEvent);
+    }
+
+    [Fact]
+    public async Task ToCloudEvent_Invalid()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        var formatter = new JsonEventFormatter();
+        var contentBytes = formatter.EncodeStructuredModeMessage(cloudEvent, out var contentType);
+        // Remove the required 'id' attribute
+        var obj = JObject.Parse(BinaryDataUtilities.GetString(contentBytes, Encoding.UTF8));
+        obj.Remove("id");
+        contentBytes = Encoding.UTF8.GetBytes(obj.ToString());
+
+        await Assert.ThrowsAsync<ArgumentException>(() => CreateRequestMessage(contentBytes, contentType).ToCloudEventAsync(formatter));
+        await Assert.ThrowsAsync<ArgumentException>(() => CreateResponseMessage(contentBytes, contentType).ToCloudEventAsync(formatter));
+    }
+
+    [Fact]
+    public async Task HttpBinaryClientReceiveTest()
+    {
+        string ctx = Guid.NewGuid().ToString();
+        PendingRequests.TryAdd(ctx, async context =>
         {
-            // Really only present for display purposes.
-            Assert.NotNull(description);
-
-            var request = new HttpRequestMessage { Content = content };
-            CopyHeaders(headers, request.Headers);
-            Assert.True(request.IsCloudEvent());
-
-            var response = new HttpResponseMessage { Content = content };
-            CopyHeaders(headers, response.Headers);
-            Assert.True(request.IsCloudEvent());
-        }
-
-        [Theory]
-        [MemberData(nameof(BatchMessages))]
-        [MemberData(nameof(NonCloudEventMessages))]
-        public void IsCloudEvent_False(string description, HttpContent content, IDictionary<string, string>? headers)
-        {
-            // Really only present for display purposes.
-            Assert.NotNull(description);
-
-            var request = new HttpRequestMessage { Content = content };
-            CopyHeaders(headers, request.Headers);
-            Assert.False(request.IsCloudEvent());
-
-            var response = new HttpResponseMessage { Content = content };
-            CopyHeaders(headers, response.Headers);
-            Assert.False(request.IsCloudEvent());
-        }
-
-        [Theory]
-        [MemberData(nameof(BatchMessages))]
-        public void IsCloudEventBatch_True(string description, HttpContent content, IDictionary<string, string>? headers)
-        {
-            // Really only present for display purposes.
-            Assert.NotNull(description);
-
-            var request = new HttpRequestMessage { Content = content };
-            CopyHeaders(headers, request.Headers);
-            Assert.True(request.IsCloudEventBatch());
-
-            var response = new HttpResponseMessage { Content = content };
-            CopyHeaders(headers, response.Headers);
-            Assert.True(request.IsCloudEventBatch());
-        }
-
-        [Theory]
-        [MemberData(nameof(SingleCloudEventMessages))]
-        [MemberData(nameof(NonCloudEventMessages))]
-        public void IsCloudEventBatch_False(string description, HttpContent content, IDictionary<string, string>? headers)
-        {
-            // Really only present for display purposes.
-            Assert.NotNull(description);
-
-            var request = new HttpRequestMessage { Content = content };
-            CopyHeaders(headers, request.Headers);
-            Assert.False(request.IsCloudEventBatch());
-
-            var response = new HttpResponseMessage { Content = content };
-            CopyHeaders(headers, response.Headers);
-            Assert.False(request.IsCloudEventBatch());
-        }
-
-        [Fact]
-        public async Task ToCloudEventBatchAsync_Valid()
-        {
-            var batch = CreateSampleBatch();
-
-            var formatter = new JsonEventFormatter();
-            var contentBytes = formatter.EncodeBatchModeMessage(batch, out var contentType);
-
-            AssertBatchesEqual(batch, await CreateRequestMessage(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionArray));
-            AssertBatchesEqual(batch, await CreateRequestMessage(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionSequence));
-            AssertBatchesEqual(batch, await CreateResponseMessage(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionArray));
-            AssertBatchesEqual(batch, await CreateResponseMessage(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionSequence));
-        }
-
-        [Fact]
-        public async Task ToCloudEventBatchAsync_Invalid()
-        {
-            // Most likely accident: calling ToCloudEventBatchAsync with a single event in structured mode.
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            var formatter = new JsonEventFormatter();
-            var contentBytes = formatter.EncodeStructuredModeMessage(cloudEvent, out var contentType);
-            await Assert.ThrowsAsync<ArgumentException>(() => CreateRequestMessage(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionArray));
-            await Assert.ThrowsAsync<ArgumentException>(() => CreateRequestMessage(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionSequence));
-            await Assert.ThrowsAsync<ArgumentException>(() => CreateResponseMessage(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionArray));
-            await Assert.ThrowsAsync<ArgumentException>(() => CreateResponseMessage(contentBytes, contentType).ToCloudEventBatchAsync(formatter, EmptyExtensionSequence));
-        }
-
-        [Fact]
-        public async Task ToCloudEvent_Valid()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            var formatter = new JsonEventFormatter();
-            var contentBytes = formatter.EncodeStructuredModeMessage(cloudEvent, out var contentType);
-            var parsedRequest = await CreateRequestMessage(contentBytes, contentType).ToCloudEventAsync(formatter);
-            var parsedResponse = await CreateResponseMessage(contentBytes, contentType).ToCloudEventAsync(formatter);
-
-            AssertCloudEventsEqual(parsedRequest, cloudEvent);
-            AssertCloudEventsEqual(parsedResponse, cloudEvent);
-        }
-
-        [Fact]
-        public async Task ToCloudEvent_Invalid()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            var formatter = new JsonEventFormatter();
-            var contentBytes = formatter.EncodeStructuredModeMessage(cloudEvent, out var contentType);
-            // Remove the required 'id' attribute
-            var obj = JObject.Parse(BinaryDataUtilities.GetString(contentBytes, Encoding.UTF8));
-            obj.Remove("id");
-            contentBytes = Encoding.UTF8.GetBytes(obj.ToString());
-
-            await Assert.ThrowsAsync<ArgumentException>(() => CreateRequestMessage(contentBytes, contentType).ToCloudEventAsync(formatter));
-            await Assert.ThrowsAsync<ArgumentException>(() => CreateResponseMessage(contentBytes, contentType).ToCloudEventAsync(formatter));
-        }
-
-        [Fact]
-        public async Task HttpBinaryClientReceiveTest()
-        {
-            string ctx = Guid.NewGuid().ToString();
-            PendingRequests.TryAdd(ctx, async context =>
+            var cloudEvent = new CloudEvent()
             {
-                var cloudEvent = new CloudEvent()
-                {
-                    Type = "com.github.pull.create",
-                    Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
-                    Id = "A234-1234-1234",
-                    Time = SampleTimestamp,
-                    DataContentType = MediaTypeNames.Text.Xml,
-                    // TODO: This isn't JSON, so maybe we shouldn't be using a JSON formatter?
-                    // Further thought: separate out payload formatting from event formatting.
-                    Data = "<much wow=\"xml\"/>",
-                    ["comexampleextension1"] = "value",
-                    ["utf8examplevalue"] = "æøå"
-                };
+                Type = "com.github.pull.create",
+                Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
+                Id = "A234-1234-1234",
+                Time = SampleTimestamp,
+                DataContentType = MediaTypeNames.Text.Xml,
+                // TODO: This isn't JSON, so maybe we shouldn't be using a JSON formatter?
+                // Further thought: separate out payload formatting from event formatting.
+                Data = "<much wow=\"xml\"/>",
+                ["comexampleextension1"] = "value",
+                ["utf8examplevalue"] = "æøå"
+            };
 
-                await cloudEvent.CopyToHttpListenerResponseAsync(context.Response, ContentMode.Binary, new JsonEventFormatter());
-                context.Response.StatusCode = (int) HttpStatusCode.OK;
-            });
+            await cloudEvent.CopyToHttpListenerResponseAsync(context.Response, ContentMode.Binary, new JsonEventFormatter());
+            context.Response.StatusCode = (int) HttpStatusCode.OK;
+        });
 
-            var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Add(TestContextHeader, ctx);
-            var result = await httpClient.GetAsync(new Uri(ListenerAddress + "ep"));
+        var httpClient = new HttpClient();
+        httpClient.DefaultRequestHeaders.Add(TestContextHeader, ctx);
+        var result = await httpClient.GetAsync(new Uri(ListenerAddress + "ep"));
 
-            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+
+        // The non-ASCII attribute value should have been URL-encoded using UTF-8 for the header.
+        Assert.True(result.Headers.TryGetValues("ce-utf8examplevalue", out var utf8ExampleValues));
+        Assert.Equal("%C3%A6%C3%B8%C3%A5", utf8ExampleValues.Single());
+
+        var receivedCloudEvent = await result.ToCloudEventAsync(new JsonEventFormatter());
+
+        Assert.Equal(CloudEventsSpecVersion.V1_0, receivedCloudEvent.SpecVersion);
+        Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
+        Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
+        Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
+        AssertTimestampsEqual(SampleTimestamp, receivedCloudEvent.Time!.Value);
+        Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
+        Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
+
+        Assert.Equal("value", receivedCloudEvent["comexampleextension1"]);
+        Assert.Equal("æøå", receivedCloudEvent["utf8examplevalue"]);
+    }
+
+    [Fact]
+    public async Task HttpBinaryClientSendTest()
+    {
+        var cloudEvent = new CloudEvent
+        {
+            Type = "com.github.pull.create",
+            Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
+            Id = "A234-1234-1234",
+            Time = SampleTimestamp,
+            DataContentType = MediaTypeNames.Text.Xml,
+            Data = "<much wow=\"xml\"/>",
+            ["comexampleextension1"] = "value",
+            ["utf8examplevalue"] = "æøå"
+        };
+
+        string ctx = Guid.NewGuid().ToString();
+        var content = cloudEvent.ToHttpContent(ContentMode.Binary, new JsonEventFormatter());
+        content.Headers.Add(TestContextHeader, ctx);
+
+        PendingRequests.TryAdd(ctx, context =>
+        {
+            Assert.True(context.Request.IsCloudEvent());
+
+            var receivedCloudEvent = context.Request.ToCloudEvent(new JsonEventFormatter());
+
+            Assert.Equal(CloudEventsSpecVersion.V1_0, receivedCloudEvent.SpecVersion);
+            Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
+            Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
+            Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
+            AssertTimestampsEqual(SampleTimestamp, cloudEvent.Time.Value);
+            Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
 
             // The non-ASCII attribute value should have been URL-encoded using UTF-8 for the header.
-            Assert.True(result.Headers.TryGetValues("ce-utf8examplevalue", out var utf8ExampleValues));
+            Assert.True(content.Headers.TryGetValues("ce-utf8examplevalue", out var utf8ExampleValues));
             Assert.Equal("%C3%A6%C3%B8%C3%A5", utf8ExampleValues.Single());
-
-            var receivedCloudEvent = await result.ToCloudEventAsync(new JsonEventFormatter());
-
-            Assert.Equal(CloudEventsSpecVersion.V1_0, receivedCloudEvent.SpecVersion);
-            Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
-            Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
-            Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-            AssertTimestampsEqual(SampleTimestamp, receivedCloudEvent.Time!.Value);
-            Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
             Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
 
             Assert.Equal("value", receivedCloudEvent["comexampleextension1"]);
+            // The non-ASCII attribute value should have been correctly URL-decoded.
             Assert.Equal("æøå", receivedCloudEvent["utf8examplevalue"]);
-        }
+            context.Response.StatusCode = (int) HttpStatusCode.NoContent;
+            return Task.CompletedTask;
+        });
 
-        [Fact]
-        public async Task HttpBinaryClientSendTest()
+        var httpClient = new HttpClient();
+        var result = await httpClient.PostAsync(new Uri(ListenerAddress + "ep"), content);
+        if (result.StatusCode != HttpStatusCode.NoContent)
         {
-            var cloudEvent = new CloudEvent
-            {
-                Type = "com.github.pull.create",
-                Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
-                Id = "A234-1234-1234",
-                Time = SampleTimestamp,
-                DataContentType = MediaTypeNames.Text.Xml,
-                Data = "<much wow=\"xml\"/>",
-                ["comexampleextension1"] = "value",
-                ["utf8examplevalue"] = "æøå"
-            };
-
-            string ctx = Guid.NewGuid().ToString();
-            var content = cloudEvent.ToHttpContent(ContentMode.Binary, new JsonEventFormatter());
-            content.Headers.Add(TestContextHeader, ctx);
-
-            PendingRequests.TryAdd(ctx, context =>
-            {
-                Assert.True(context.Request.IsCloudEvent());
-
-                var receivedCloudEvent = context.Request.ToCloudEvent(new JsonEventFormatter());
-
-                Assert.Equal(CloudEventsSpecVersion.V1_0, receivedCloudEvent.SpecVersion);
-                Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
-                Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
-                Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-                AssertTimestampsEqual(SampleTimestamp, cloudEvent.Time.Value);
-                Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
-
-                // The non-ASCII attribute value should have been URL-encoded using UTF-8 for the header.
-                Assert.True(content.Headers.TryGetValues("ce-utf8examplevalue", out var utf8ExampleValues));
-                Assert.Equal("%C3%A6%C3%B8%C3%A5", utf8ExampleValues.Single());
-                Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
-
-                Assert.Equal("value", receivedCloudEvent["comexampleextension1"]);
-                // The non-ASCII attribute value should have been correctly URL-decoded.
-                Assert.Equal("æøå", receivedCloudEvent["utf8examplevalue"]);
-                context.Response.StatusCode = (int) HttpStatusCode.NoContent;
-                return Task.CompletedTask;
-            });
-
-            var httpClient = new HttpClient();
-            var result = await httpClient.PostAsync(new Uri(ListenerAddress + "ep"), content);
-            if (result.StatusCode != HttpStatusCode.NoContent)
-            {
-                throw new InvalidOperationException(await result.Content.ReadAsStringAsync());
-            }
+            throw new InvalidOperationException(await result.Content.ReadAsStringAsync());
         }
-
-        [Fact]
-        public async Task HttpStructuredClientReceiveTest()
-        {
-            string ctx = Guid.NewGuid().ToString();
-            PendingRequests.TryAdd(ctx, async context =>
-            {
-                var cloudEvent = new CloudEvent
-                {
-                    Type = "com.github.pull.create",
-                    Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
-                    Id = "A234-1234-1234",
-                    Time = SampleTimestamp,
-                    DataContentType = MediaTypeNames.Text.Xml,
-                    Data = "<much wow=\"xml\"/>",
-                    ["comexampleextension1"] = "value",
-                    ["utf8examplevalue"] = "æøå"
-                };
-
-                await cloudEvent.CopyToHttpListenerResponseAsync(context.Response, ContentMode.Structured, new JsonEventFormatter());
-                context.Response.StatusCode = (int) HttpStatusCode.OK;
-            });
-
-            var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Add(TestContextHeader, ctx);
-            var result = await httpClient.GetAsync(new Uri(ListenerAddress + "ep"));
-
-            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
-            Assert.True(result.IsCloudEvent());
-            var receivedCloudEvent = await result.ToCloudEventAsync(new JsonEventFormatter());
-
-            Assert.Equal(CloudEventsSpecVersion.V1_0, receivedCloudEvent.SpecVersion);
-            Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
-            Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
-            Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-            AssertTimestampsEqual(SampleTimestamp, receivedCloudEvent.Time!.Value);
-            Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
-            Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
-
-            Assert.Equal("value", receivedCloudEvent["comexampleextension1"]);
-            Assert.Equal("æøå", receivedCloudEvent["utf8examplevalue"]);
-        }
-
-        [Fact]
-        public async Task HttpStructuredClientSendTest()
-        {
-            var cloudEvent = new CloudEvent
-            {
-                Type = "com.github.pull.create",
-                Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
-                Id = "A234-1234-1234",
-                Time = SampleTimestamp,
-                DataContentType = MediaTypeNames.Text.Xml,
-                Data = "<much wow=\"xml\"/>",
-                ["comexampleextension1"] = "value",
-                ["utf8examplevalue"] = "æøå"
-            };
-
-            string ctx = Guid.NewGuid().ToString();
-            var content = cloudEvent.ToHttpContent(ContentMode.Structured, new JsonEventFormatter());
-            content.Headers.Add(TestContextHeader, ctx);
-
-            PendingRequests.TryAdd(ctx, context =>
-            {
-                // Structured events contain a copy of the CloudEvent attributes as HTTP headers.
-                var headers = context.Request.Headers;
-                Assert.Equal("1.0", headers["ce-specversion"]);
-                Assert.Equal("com.github.pull.create", headers["ce-type"]);
-                Assert.Equal("https://github.com/cloudevents/spec/pull/123", headers["ce-source"]);
-                Assert.Equal("A234-1234-1234", headers["ce-id"]);
-                Assert.Equal("2018-04-05T17:31:00Z", headers["ce-time"]);
-                // Note that datacontenttype is mapped in this case, but would not be included in binary mode.
-                Assert.Equal("text/xml", headers["ce-datacontenttype"]);
-                Assert.Equal("application/cloudevents+json; charset=utf-8", context.Request.ContentType);
-                Assert.Equal("value", headers["ce-comexampleextension1"]);
-                // The non-ASCII attribute value should have been URL-encoded using UTF-8 for the header.
-                Assert.Equal("%C3%A6%C3%B8%C3%A5", headers["ce-utf8examplevalue"]);
-
-                var receivedCloudEvent = context.Request.ToCloudEvent(new JsonEventFormatter());
-
-                Assert.Equal(CloudEventsSpecVersion.V1_0, receivedCloudEvent.SpecVersion);
-                Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
-                Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
-                Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-                AssertTimestampsEqual(SampleTimestamp, cloudEvent.Time.Value);
-                Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
-                Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
-
-                Assert.Equal("value", receivedCloudEvent["comexampleextension1"]);
-                Assert.Equal("æøå", receivedCloudEvent["utf8examplevalue"]);
-                context.Response.StatusCode = (int) HttpStatusCode.NoContent;
-                return Task.CompletedTask;
-            });
-
-            var httpClient = new HttpClient();
-            var result = (await httpClient.PostAsync(new Uri(ListenerAddress + "ep"), content));
-            if (result.StatusCode != HttpStatusCode.NoContent)
-            {
-                throw new InvalidOperationException(await result.Content.ReadAsStringAsync());
-            }
-        }
-
-        [Fact]
-        public void ContentType_FromCloudEvent_BinaryMode()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.DataContentType = "text/plain";
-            var content = cloudEvent.ToHttpContent(ContentMode.Binary, new JsonEventFormatter());
-            var expectedContentType = new MediaTypeHeaderValue("text/plain");
-            Assert.Equal(expectedContentType, content.Headers.ContentType);
-        }
-
-        // We need to work out whether we want a modified version of this test.
-        // It should be okay to not set a DataContentType if there's no data...
-        // but what if there's a data value which is an empty string, empty byte array or empty stream?
-        [Fact]
-        public void NoDataContentType_NoData()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            var content = cloudEvent.ToHttpContent(ContentMode.Binary, new JsonEventFormatter());
-            Assert.Null(content.Headers.ContentType);
-        }
-
-        [Fact]
-        public void NoDataContentType_ContentTypeInferredFromFormatter()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            // The JSON event format infers application/json for non-binary data
-            cloudEvent.Data = new { Name = "xyz" };
-            var content = cloudEvent.ToHttpContent(ContentMode.Binary, new JsonEventFormatter());
-            var expectedContentType = new MediaTypeHeaderValue("application/json");
-            Assert.Equal(expectedContentType, content.Headers.ContentType);
-        }
-
-        [Fact]
-        public void NoDataContentType_NoContentTypeInferredFromFormatter()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            // The JSON event format does not infer a data content type for binary data
-            cloudEvent.Data = new byte[10];
-            var exception = Assert.Throws<ArgumentException>(() => cloudEvent.ToHttpContent(ContentMode.Binary, new JsonEventFormatter()));
-            Assert.StartsWith(Strings.ErrorContentTypeUnspecified, exception.Message);
-        }
-
-        [Fact]
-        public async Task ToHttpContent_Batch()
-        {
-            var batch = CreateSampleBatch();
-
-            var formatter = new JsonEventFormatter();
-            var content = batch.ToHttpContent(formatter);
-
-            var bytes = await content.ReadAsByteArrayAsync();
-            var parsedBatch = formatter.DecodeBatchModeMessage(bytes, MimeUtilities.ToContentType(content.Headers.ContentType), extensionAttributes: null);
-            AssertBatchesEqual(batch, parsedBatch);
-        }
-
-        [Theory]
-        [InlineData(ContentMode.Binary)]
-        [InlineData(ContentMode.Structured)]
-        public async Task RoundtripRequest(ContentMode contentMode)
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            var formatter = new JsonEventFormatter();
-            var content = cloudEvent.ToHttpContent(contentMode, formatter);
-            var request = new HttpRequestMessage { Content = content };
-            var parsed = await request.ToCloudEventAsync(formatter);
-            AssertCloudEventsEqual(cloudEvent, parsed);
-        }
-
-        [Theory]
-        [InlineData(ContentMode.Binary)]
-        [InlineData(ContentMode.Structured)]
-        public async Task RoundtripResponse(ContentMode contentMode)
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            var formatter = new JsonEventFormatter();
-            var content = cloudEvent.ToHttpContent(contentMode, formatter);
-            var request = new HttpResponseMessage { Content = content };
-            var parsed = await request.ToCloudEventAsync(formatter);
-            AssertCloudEventsEqual(cloudEvent, parsed);
-        }
-
-        internal static void CopyHeaders(IDictionary<string, string>? source, HttpHeaders target)
-        {
-            if (source is null)
-            {
-                return;
-            }
-            foreach (var header in source)
-            {
-                target.Add(header.Key, header.Value);
-            }
-        }
-
-        internal static HttpRequestMessage CreateRequestMessage(ReadOnlyMemory<byte> content, ContentType contentType) =>
-            new HttpRequestMessage
-            {
-                Content = new ByteArrayContent(content.ToArray())
-                {
-                    Headers = { ContentType = MimeUtilities.ToMediaTypeHeaderValue(contentType) }
-                }
-            };
-
-        internal static HttpResponseMessage CreateResponseMessage(ReadOnlyMemory<byte> content, ContentType contentType) =>
-            new HttpResponseMessage
-            {
-                Content = new ByteArrayContent(content.ToArray())
-                {
-                    Headers = { ContentType = MimeUtilities.ToMediaTypeHeaderValue(contentType) }
-                }
-            };
     }
+
+    [Fact]
+    public async Task HttpStructuredClientReceiveTest()
+    {
+        string ctx = Guid.NewGuid().ToString();
+        PendingRequests.TryAdd(ctx, async context =>
+        {
+            var cloudEvent = new CloudEvent
+            {
+                Type = "com.github.pull.create",
+                Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
+                Id = "A234-1234-1234",
+                Time = SampleTimestamp,
+                DataContentType = MediaTypeNames.Text.Xml,
+                Data = "<much wow=\"xml\"/>",
+                ["comexampleextension1"] = "value",
+                ["utf8examplevalue"] = "æøå"
+            };
+
+            await cloudEvent.CopyToHttpListenerResponseAsync(context.Response, ContentMode.Structured, new JsonEventFormatter());
+            context.Response.StatusCode = (int) HttpStatusCode.OK;
+        });
+
+        var httpClient = new HttpClient();
+        httpClient.DefaultRequestHeaders.Add(TestContextHeader, ctx);
+        var result = await httpClient.GetAsync(new Uri(ListenerAddress + "ep"));
+
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.True(result.IsCloudEvent());
+        var receivedCloudEvent = await result.ToCloudEventAsync(new JsonEventFormatter());
+
+        Assert.Equal(CloudEventsSpecVersion.V1_0, receivedCloudEvent.SpecVersion);
+        Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
+        Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
+        Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
+        AssertTimestampsEqual(SampleTimestamp, receivedCloudEvent.Time!.Value);
+        Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
+        Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
+
+        Assert.Equal("value", receivedCloudEvent["comexampleextension1"]);
+        Assert.Equal("æøå", receivedCloudEvent["utf8examplevalue"]);
+    }
+
+    [Fact]
+    public async Task HttpStructuredClientSendTest()
+    {
+        var cloudEvent = new CloudEvent
+        {
+            Type = "com.github.pull.create",
+            Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
+            Id = "A234-1234-1234",
+            Time = SampleTimestamp,
+            DataContentType = MediaTypeNames.Text.Xml,
+            Data = "<much wow=\"xml\"/>",
+            ["comexampleextension1"] = "value",
+            ["utf8examplevalue"] = "æøå"
+        };
+
+        string ctx = Guid.NewGuid().ToString();
+        var content = cloudEvent.ToHttpContent(ContentMode.Structured, new JsonEventFormatter());
+        content.Headers.Add(TestContextHeader, ctx);
+
+        PendingRequests.TryAdd(ctx, context =>
+        {
+            // Structured events contain a copy of the CloudEvent attributes as HTTP headers.
+            var headers = context.Request.Headers;
+            Assert.Equal("1.0", headers["ce-specversion"]);
+            Assert.Equal("com.github.pull.create", headers["ce-type"]);
+            Assert.Equal("https://github.com/cloudevents/spec/pull/123", headers["ce-source"]);
+            Assert.Equal("A234-1234-1234", headers["ce-id"]);
+            Assert.Equal("2018-04-05T17:31:00Z", headers["ce-time"]);
+            // Note that datacontenttype is mapped in this case, but would not be included in binary mode.
+            Assert.Equal("text/xml", headers["ce-datacontenttype"]);
+            Assert.Equal("application/cloudevents+json; charset=utf-8", context.Request.ContentType);
+            Assert.Equal("value", headers["ce-comexampleextension1"]);
+            // The non-ASCII attribute value should have been URL-encoded using UTF-8 for the header.
+            Assert.Equal("%C3%A6%C3%B8%C3%A5", headers["ce-utf8examplevalue"]);
+
+            var receivedCloudEvent = context.Request.ToCloudEvent(new JsonEventFormatter());
+
+            Assert.Equal(CloudEventsSpecVersion.V1_0, receivedCloudEvent.SpecVersion);
+            Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
+            Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
+            Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
+            AssertTimestampsEqual(SampleTimestamp, cloudEvent.Time.Value);
+            Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
+            Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
+
+            Assert.Equal("value", receivedCloudEvent["comexampleextension1"]);
+            Assert.Equal("æøå", receivedCloudEvent["utf8examplevalue"]);
+            context.Response.StatusCode = (int) HttpStatusCode.NoContent;
+            return Task.CompletedTask;
+        });
+
+        var httpClient = new HttpClient();
+        var result = (await httpClient.PostAsync(new Uri(ListenerAddress + "ep"), content));
+        if (result.StatusCode != HttpStatusCode.NoContent)
+        {
+            throw new InvalidOperationException(await result.Content.ReadAsStringAsync());
+        }
+    }
+
+    [Fact]
+    public void ContentType_FromCloudEvent_BinaryMode()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.DataContentType = "text/plain";
+        var content = cloudEvent.ToHttpContent(ContentMode.Binary, new JsonEventFormatter());
+        var expectedContentType = new MediaTypeHeaderValue("text/plain");
+        Assert.Equal(expectedContentType, content.Headers.ContentType);
+    }
+
+    // We need to work out whether we want a modified version of this test.
+    // It should be okay to not set a DataContentType if there's no data...
+    // but what if there's a data value which is an empty string, empty byte array or empty stream?
+    [Fact]
+    public void NoDataContentType_NoData()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        var content = cloudEvent.ToHttpContent(ContentMode.Binary, new JsonEventFormatter());
+        Assert.Null(content.Headers.ContentType);
+    }
+
+    [Fact]
+    public void NoDataContentType_ContentTypeInferredFromFormatter()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        // The JSON event format infers application/json for non-binary data
+        cloudEvent.Data = new { Name = "xyz" };
+        var content = cloudEvent.ToHttpContent(ContentMode.Binary, new JsonEventFormatter());
+        var expectedContentType = new MediaTypeHeaderValue("application/json");
+        Assert.Equal(expectedContentType, content.Headers.ContentType);
+    }
+
+    [Fact]
+    public void NoDataContentType_NoContentTypeInferredFromFormatter()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        // The JSON event format does not infer a data content type for binary data
+        cloudEvent.Data = new byte[10];
+        var exception = Assert.Throws<ArgumentException>(() => cloudEvent.ToHttpContent(ContentMode.Binary, new JsonEventFormatter()));
+        Assert.StartsWith(Strings.ErrorContentTypeUnspecified, exception.Message);
+    }
+
+    [Fact]
+    public async Task ToHttpContent_Batch()
+    {
+        var batch = CreateSampleBatch();
+
+        var formatter = new JsonEventFormatter();
+        var content = batch.ToHttpContent(formatter);
+
+        var bytes = await content.ReadAsByteArrayAsync();
+        var parsedBatch = formatter.DecodeBatchModeMessage(bytes, MimeUtilities.ToContentType(content.Headers.ContentType), extensionAttributes: null);
+        AssertBatchesEqual(batch, parsedBatch);
+    }
+
+    [Theory]
+    [InlineData(ContentMode.Binary)]
+    [InlineData(ContentMode.Structured)]
+    public async Task RoundtripRequest(ContentMode contentMode)
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        var formatter = new JsonEventFormatter();
+        var content = cloudEvent.ToHttpContent(contentMode, formatter);
+        var request = new HttpRequestMessage { Content = content };
+        var parsed = await request.ToCloudEventAsync(formatter);
+        AssertCloudEventsEqual(cloudEvent, parsed);
+    }
+
+    [Theory]
+    [InlineData(ContentMode.Binary)]
+    [InlineData(ContentMode.Structured)]
+    public async Task RoundtripResponse(ContentMode contentMode)
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        var formatter = new JsonEventFormatter();
+        var content = cloudEvent.ToHttpContent(contentMode, formatter);
+        var request = new HttpResponseMessage { Content = content };
+        var parsed = await request.ToCloudEventAsync(formatter);
+        AssertCloudEventsEqual(cloudEvent, parsed);
+    }
+
+    internal static void CopyHeaders(IDictionary<string, string>? source, HttpHeaders target)
+    {
+        if (source is null)
+        {
+            return;
+        }
+        foreach (var header in source)
+        {
+            target.Add(header.Key, header.Value);
+        }
+    }
+
+    internal static HttpRequestMessage CreateRequestMessage(ReadOnlyMemory<byte> content, ContentType contentType) =>
+        new HttpRequestMessage
+        {
+            Content = new ByteArrayContent(content.ToArray())
+            {
+                Headers = { ContentType = MimeUtilities.ToMediaTypeHeaderValue(contentType) }
+            }
+        };
+
+    internal static HttpResponseMessage CreateResponseMessage(ReadOnlyMemory<byte> content, ContentType contentType) =>
+        new HttpResponseMessage
+        {
+            Content = new ByteArrayContent(content.ToArray())
+            {
+                Headers = { ContentType = MimeUtilities.ToMediaTypeHeaderValue(contentType) }
+            }
+        };
 }

--- a/test/CloudNative.CloudEvents.UnitTests/Http/HttpListenerExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Http/HttpListenerExtensionsTest.cs
@@ -15,329 +15,328 @@ using System.Threading.Tasks;
 using Xunit;
 using static CloudNative.CloudEvents.UnitTests.TestHelpers;
 
-namespace CloudNative.CloudEvents.Http.UnitTests
+namespace CloudNative.CloudEvents.Http.UnitTests;
+
+public class HttpListenerExtensionsTest : HttpTestBase
 {
-    public class HttpListenerExtensionsTest : HttpTestBase
+    [Theory]
+    [MemberData(nameof(HttpClientExtensionsTest.SingleCloudEventMessages), MemberType = typeof(HttpClientExtensionsTest))]
+    public async Task IsCloudEvent_True(string description, HttpContent content, IDictionary<string, string>? headers)
     {
-        [Theory]
-        [MemberData(nameof(HttpClientExtensionsTest.SingleCloudEventMessages), MemberType = typeof(HttpClientExtensionsTest))]
-        public async Task IsCloudEvent_True(string description, HttpContent content, IDictionary<string, string>? headers)
+        // Really only present for display purposes.
+        Assert.NotNull(description);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, ListenerAddress) { Content = content };
+        HttpClientExtensionsTest.CopyHeaders(headers, request.Headers);
+        var result = await SendRequestAsync(request, context => Task.FromResult(context.Request.IsCloudEvent()));
+        Assert.True(result);
+    }
+
+    [Theory]
+    [MemberData(nameof(HttpClientExtensionsTest.BatchMessages), MemberType = typeof(HttpClientExtensionsTest))]
+    [MemberData(nameof(HttpClientExtensionsTest.NonCloudEventMessages), MemberType = typeof(HttpClientExtensionsTest))]
+    public async Task IsCloudEvent_False(string description, HttpContent content, IDictionary<string, string>? headers)
+    {
+        // Really only present for display purposes.
+        Assert.NotNull(description);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, ListenerAddress) { Content = content };
+        HttpClientExtensionsTest.CopyHeaders(headers, request.Headers);
+        var result = await SendRequestAsync(request, context => Task.FromResult(context.Request.IsCloudEvent()));
+        Assert.False(result);
+    }
+
+    [Theory]
+    [MemberData(nameof(HttpClientExtensionsTest.BatchMessages), MemberType = typeof(HttpClientExtensionsTest))]
+    public async Task IsCloudEventBatch_True(string description, HttpContent content, IDictionary<string, string>? headers)
+    {
+        // Really only present for display purposes.
+        Assert.NotNull(description);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, ListenerAddress) { Content = content };
+        HttpClientExtensionsTest.CopyHeaders(headers, request.Headers);
+        var result = await SendRequestAsync(request, context => Task.FromResult(context.Request.IsCloudEventBatch()));
+        Assert.True(result);
+    }
+
+    [Theory]
+    [MemberData(nameof(HttpClientExtensionsTest.SingleCloudEventMessages), MemberType = typeof(HttpClientExtensionsTest))]
+    [MemberData(nameof(HttpClientExtensionsTest.NonCloudEventMessages), MemberType = typeof(HttpClientExtensionsTest))]
+    public async Task IsCloudEventBatch_False(string description, HttpContent content, IDictionary<string, string>? headers)
+    {
+        // Really only present for display purposes.
+        Assert.NotNull(description);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, ListenerAddress) { Content = content };
+        HttpClientExtensionsTest.CopyHeaders(headers, request.Headers);
+        var result = await SendRequestAsync(request, context => Task.FromResult(context.Request.IsCloudEventBatch()));
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ToCloudEvent_BinaryMode(bool async)
+    {
+        var request = new HttpRequestMessage
         {
-            // Really only present for display purposes.
-            Assert.NotNull(description);
-
-            var request = new HttpRequestMessage(HttpMethod.Get, ListenerAddress) { Content = content };
-            HttpClientExtensionsTest.CopyHeaders(headers, request.Headers);
-            var result = await SendRequestAsync(request, context => Task.FromResult(context.Request.IsCloudEvent()));
-            Assert.True(result);
-        }
-
-        [Theory]
-        [MemberData(nameof(HttpClientExtensionsTest.BatchMessages), MemberType = typeof(HttpClientExtensionsTest))]
-        [MemberData(nameof(HttpClientExtensionsTest.NonCloudEventMessages), MemberType = typeof(HttpClientExtensionsTest))]
-        public async Task IsCloudEvent_False(string description, HttpContent content, IDictionary<string, string>? headers)
-        {
-            // Really only present for display purposes.
-            Assert.NotNull(description);
-
-            var request = new HttpRequestMessage(HttpMethod.Get, ListenerAddress) { Content = content };
-            HttpClientExtensionsTest.CopyHeaders(headers, request.Headers);
-            var result = await SendRequestAsync(request, context => Task.FromResult(context.Request.IsCloudEvent()));
-            Assert.False(result);
-        }
-
-        [Theory]
-        [MemberData(nameof(HttpClientExtensionsTest.BatchMessages), MemberType = typeof(HttpClientExtensionsTest))]
-        public async Task IsCloudEventBatch_True(string description, HttpContent content, IDictionary<string, string>? headers)
-        {
-            // Really only present for display purposes.
-            Assert.NotNull(description);
-
-            var request = new HttpRequestMessage(HttpMethod.Get, ListenerAddress) { Content = content };
-            HttpClientExtensionsTest.CopyHeaders(headers, request.Headers);
-            var result = await SendRequestAsync(request, context => Task.FromResult(context.Request.IsCloudEventBatch()));
-            Assert.True(result);
-        }
-
-        [Theory]
-        [MemberData(nameof(HttpClientExtensionsTest.SingleCloudEventMessages), MemberType = typeof(HttpClientExtensionsTest))]
-        [MemberData(nameof(HttpClientExtensionsTest.NonCloudEventMessages), MemberType = typeof(HttpClientExtensionsTest))]
-        public async Task IsCloudEventBatch_False(string description, HttpContent content, IDictionary<string, string>? headers)
-        {
-            // Really only present for display purposes.
-            Assert.NotNull(description);
-
-            var request = new HttpRequestMessage(HttpMethod.Get, ListenerAddress) { Content = content };
-            HttpClientExtensionsTest.CopyHeaders(headers, request.Headers);
-            var result = await SendRequestAsync(request, context => Task.FromResult(context.Request.IsCloudEventBatch()));
-            Assert.False(result);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task ToCloudEvent_BinaryMode(bool async)
-        {
-            var request = new HttpRequestMessage
-            {
-                RequestUri = new Uri(ListenerAddress),
-                Headers =
+            RequestUri = new Uri(ListenerAddress),
+            Headers =
                 {
                     { "ce-specversion", "1.0" },
                     { "ce-type", "test-type" },
                     { "ce-id", "test-id" },
                     { "ce-source", TestHelpers.SampleUriReferenceText },
                 },
-                Content = new ByteArrayContent(Encoding.UTF8.GetBytes("test content"))
-                {
-                    Headers = { { "content-type", "text/plain" } }
-                }
-            };
-
-            var cloudEvent = await SendRequestAsync(request, async context =>
-                async
-                    ? await context.Request.ToCloudEventAsync(new JsonEventFormatter())
-                    : context.Request.ToCloudEvent(new JsonEventFormatter()));
-
-            Assert.NotNull(cloudEvent);
-            Assert.Equal("test-id", cloudEvent.Id);
-            Assert.Equal("test-type", cloudEvent.Type);
-            Assert.Equal(TestHelpers.SampleUriReference, cloudEvent.Source);
-            Assert.Equal("text/plain", cloudEvent.DataContentType);
-            Assert.Equal("test content", cloudEvent.Data);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task ToCloudEvent_StructuredMode(bool async)
-        {
-            var originalCloudEvent = new CloudEvent
+            Content = new ByteArrayContent(Encoding.UTF8.GetBytes("test content"))
             {
-                Data = "sample text",
-                DataContentType = "text/plain"
-            }.PopulateRequiredAttributes();
-
-            var bytes = new JsonEventFormatter().EncodeStructuredModeMessage(originalCloudEvent, out var contentType);
-            var request = new HttpRequestMessage
-            {
-                RequestUri = new Uri(ListenerAddress),
-                Content = new ByteArrayContent(bytes.ToArray())
-                {
-                    Headers = { { "content-type", contentType.ToString() } }
-                }
-            };
-
-            var parsedCloudEvent = await SendRequestAsync(request, async context =>
-                async
-                    ? await context.Request.ToCloudEventAsync(new JsonEventFormatter())
-                    : context.Request.ToCloudEvent(new JsonEventFormatter()));
-
-            Assert.NotNull(parsedCloudEvent);
-            Assert.Equal(originalCloudEvent.Id, parsedCloudEvent.Id);
-            Assert.Equal(originalCloudEvent.Type, parsedCloudEvent.Type);
-            Assert.Equal(originalCloudEvent.Source, parsedCloudEvent.Source);
-            Assert.Equal(originalCloudEvent.DataContentType, parsedCloudEvent.DataContentType);
-            Assert.Equal(originalCloudEvent.Data, parsedCloudEvent.Data);
-        }
-
-        [Fact]
-        public async Task ToCloudEventBatch_Valid()
-        {
-            var batch = CreateSampleBatch();
-
-            var formatter = new JsonEventFormatter();
-            var contentBytes = formatter.EncodeBatchModeMessage(batch, out var contentType);
-
-            AssertBatchesEqual(batch, await GetBatchAsync(context => context.Request.ToCloudEventBatchAsync(formatter, EmptyExtensionArray)));
-            AssertBatchesEqual(batch, await GetBatchAsync(context => context.Request.ToCloudEventBatchAsync(formatter, EmptyExtensionSequence)));
-            AssertBatchesEqual(batch, await GetBatchAsync(context => Task.FromResult(context.Request.ToCloudEventBatch(formatter, EmptyExtensionArray))));
-            AssertBatchesEqual(batch, await GetBatchAsync(context => Task.FromResult(context.Request.ToCloudEventBatch(formatter, EmptyExtensionSequence))));
-
-            Task<IReadOnlyList<CloudEvent>> GetBatchAsync(Func<HttpListenerContext, Task<IReadOnlyList<CloudEvent>>> handler)
-            {
-                var request = HttpClientExtensionsTest.CreateRequestMessage(contentBytes, contentType);
-                request.RequestUri = new Uri(ListenerAddress);
-                return SendRequestAsync(request, handler);
+                Headers = { { "content-type", "text/plain" } }
             }
-        }
+        };
 
-        [Fact]
-        public async Task ToCloudEventBatchAsync_Invalid()
+        var cloudEvent = await SendRequestAsync(request, async context =>
+            async
+                ? await context.Request.ToCloudEventAsync(new JsonEventFormatter())
+                : context.Request.ToCloudEvent(new JsonEventFormatter()));
+
+        Assert.NotNull(cloudEvent);
+        Assert.Equal("test-id", cloudEvent.Id);
+        Assert.Equal("test-type", cloudEvent.Type);
+        Assert.Equal(TestHelpers.SampleUriReference, cloudEvent.Source);
+        Assert.Equal("text/plain", cloudEvent.DataContentType);
+        Assert.Equal("test content", cloudEvent.Data);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ToCloudEvent_StructuredMode(bool async)
+    {
+        var originalCloudEvent = new CloudEvent
         {
-            // Most likely accident: calling ToCloudEventBatchAsync with a single event in structured mode.
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            var formatter = new JsonEventFormatter();
-            var contentBytes = formatter.EncodeStructuredModeMessage(cloudEvent, out var contentType);
+            Data = "sample text",
+            DataContentType = "text/plain"
+        }.PopulateRequiredAttributes();
 
-            await ExpectFailure(context => context.Request.ToCloudEventBatchAsync(formatter, EmptyExtensionArray));
-            await ExpectFailure(context => context.Request.ToCloudEventBatchAsync(formatter, EmptyExtensionSequence));
-            await ExpectFailure(context => Task.FromResult(context.Request.ToCloudEventBatch(formatter, EmptyExtensionArray)));
-            await ExpectFailure(context => Task.FromResult(context.Request.ToCloudEventBatch(formatter, EmptyExtensionSequence)));
-
-            async Task ExpectFailure(Func<HttpListenerContext, Task<IReadOnlyList<CloudEvent>>> handler)
+        var bytes = new JsonEventFormatter().EncodeStructuredModeMessage(originalCloudEvent, out var contentType);
+        var request = new HttpRequestMessage
+        {
+            RequestUri = new Uri(ListenerAddress),
+            Content = new ByteArrayContent(bytes.ToArray())
             {
-                var request = HttpClientExtensionsTest.CreateRequestMessage(contentBytes, contentType);
-                request.RequestUri = new Uri(ListenerAddress);
-                await SendRequestAsync(request, context => Assert.ThrowsAsync<ArgumentException>(() => handler(context)));
+                Headers = { { "content-type", contentType.ToString() } }
             }
-        }
+        };
 
-        [Fact]
-        public async Task CopyToHttpListenerResponseAsync_BinaryMode()
+        var parsedCloudEvent = await SendRequestAsync(request, async context =>
+            async
+                ? await context.Request.ToCloudEventAsync(new JsonEventFormatter())
+                : context.Request.ToCloudEvent(new JsonEventFormatter()));
+
+        Assert.NotNull(parsedCloudEvent);
+        Assert.Equal(originalCloudEvent.Id, parsedCloudEvent.Id);
+        Assert.Equal(originalCloudEvent.Type, parsedCloudEvent.Type);
+        Assert.Equal(originalCloudEvent.Source, parsedCloudEvent.Source);
+        Assert.Equal(originalCloudEvent.DataContentType, parsedCloudEvent.DataContentType);
+        Assert.Equal(originalCloudEvent.Data, parsedCloudEvent.Data);
+    }
+
+    [Fact]
+    public async Task ToCloudEventBatch_Valid()
+    {
+        var batch = CreateSampleBatch();
+
+        var formatter = new JsonEventFormatter();
+        var contentBytes = formatter.EncodeBatchModeMessage(batch, out var contentType);
+
+        AssertBatchesEqual(batch, await GetBatchAsync(context => context.Request.ToCloudEventBatchAsync(formatter, EmptyExtensionArray)));
+        AssertBatchesEqual(batch, await GetBatchAsync(context => context.Request.ToCloudEventBatchAsync(formatter, EmptyExtensionSequence)));
+        AssertBatchesEqual(batch, await GetBatchAsync(context => Task.FromResult(context.Request.ToCloudEventBatch(formatter, EmptyExtensionArray))));
+        AssertBatchesEqual(batch, await GetBatchAsync(context => Task.FromResult(context.Request.ToCloudEventBatch(formatter, EmptyExtensionSequence))));
+
+        Task<IReadOnlyList<CloudEvent>> GetBatchAsync(Func<HttpListenerContext, Task<IReadOnlyList<CloudEvent>>> handler)
         {
-            var cloudEvent = new CloudEvent
-            {
-                Data = "plain text",
-                DataContentType = "text/plain"
-            }.PopulateRequiredAttributes();
-            var formatter = new JsonEventFormatter();
-            var response = await GetResponseAsync(
-                async context => await cloudEvent.CopyToHttpListenerResponseAsync(context.Response, ContentMode.Binary, formatter));
-            response.EnsureSuccessStatusCode();
-            var content = response.Content;
-            Assert.Equal("text/plain", content.Headers.ContentType!.MediaType);
-            Assert.Equal("plain text", await content.ReadAsStringAsync());
-            Assert.Equal("1.0", response.Headers.GetValues("ce-specversion").Single());
-            Assert.Equal(cloudEvent.Type, response.Headers.GetValues("ce-type").Single());
-            Assert.Equal(cloudEvent.Id, response.Headers.GetValues("ce-id").Single());
-            Assert.Equal(CloudEventAttributeType.UriReference.Format(cloudEvent.Source!), response.Headers.GetValues("ce-source").Single());
-            // There's no data content type header; the content type itself is used for that.
-            Assert.False(response.Headers.Contains("ce-datacontenttype"));
+            var request = HttpClientExtensionsTest.CreateRequestMessage(contentBytes, contentType);
+            request.RequestUri = new Uri(ListenerAddress);
+            return SendRequestAsync(request, handler);
         }
+    }
 
-        [Fact]
-        public async Task CopyToListenerResponseAsync_BinaryDataButNoDataContentType()
+    [Fact]
+    public async Task ToCloudEventBatchAsync_Invalid()
+    {
+        // Most likely accident: calling ToCloudEventBatchAsync with a single event in structured mode.
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        var formatter = new JsonEventFormatter();
+        var contentBytes = formatter.EncodeStructuredModeMessage(cloudEvent, out var contentType);
+
+        await ExpectFailure(context => context.Request.ToCloudEventBatchAsync(formatter, EmptyExtensionArray));
+        await ExpectFailure(context => context.Request.ToCloudEventBatchAsync(formatter, EmptyExtensionSequence));
+        await ExpectFailure(context => Task.FromResult(context.Request.ToCloudEventBatch(formatter, EmptyExtensionArray)));
+        await ExpectFailure(context => Task.FromResult(context.Request.ToCloudEventBatch(formatter, EmptyExtensionSequence)));
+
+        async Task ExpectFailure(Func<HttpListenerContext, Task<IReadOnlyList<CloudEvent>>> handler)
         {
-            var cloudEvent = new CloudEvent
-            {
-                Data = new byte[10],
-            }.PopulateRequiredAttributes();
-            var formatter = new JsonEventFormatter();
-            await GetResponseAsync(
-                async context => await Assert.ThrowsAsync<ArgumentException>(() => cloudEvent.CopyToHttpListenerResponseAsync(context.Response, ContentMode.Binary, formatter)));
+            var request = HttpClientExtensionsTest.CreateRequestMessage(contentBytes, contentType);
+            request.RequestUri = new Uri(ListenerAddress);
+            await SendRequestAsync(request, context => Assert.ThrowsAsync<ArgumentException>(() => handler(context)));
         }
+    }
 
-        [Fact]
-        public async Task CopyToListenerResponseAsync_NonBinaryDataButNoDataContentType_ContentTypeIsInferred()
+    [Fact]
+    public async Task CopyToHttpListenerResponseAsync_BinaryMode()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent
-            {
-                Data = "plain text",
-            }.PopulateRequiredAttributes();
-            var formatter = new JsonEventFormatter();
-            var response = await GetResponseAsync(
-                async context => await cloudEvent.CopyToHttpListenerResponseAsync(context.Response, ContentMode.Binary, formatter));
-            var content = response.Content;
-            Assert.Equal("application/json", content.Headers.ContentType!.MediaType);
-            Assert.Equal("\"plain text\"", await content.ReadAsStringAsync());
-        }
+            Data = "plain text",
+            DataContentType = "text/plain"
+        }.PopulateRequiredAttributes();
+        var formatter = new JsonEventFormatter();
+        var response = await GetResponseAsync(
+            async context => await cloudEvent.CopyToHttpListenerResponseAsync(context.Response, ContentMode.Binary, formatter));
+        response.EnsureSuccessStatusCode();
+        var content = response.Content;
+        Assert.Equal("text/plain", content.Headers.ContentType!.MediaType);
+        Assert.Equal("plain text", await content.ReadAsStringAsync());
+        Assert.Equal("1.0", response.Headers.GetValues("ce-specversion").Single());
+        Assert.Equal(cloudEvent.Type, response.Headers.GetValues("ce-type").Single());
+        Assert.Equal(cloudEvent.Id, response.Headers.GetValues("ce-id").Single());
+        Assert.Equal(CloudEventAttributeType.UriReference.Format(cloudEvent.Source!), response.Headers.GetValues("ce-source").Single());
+        // There's no data content type header; the content type itself is used for that.
+        Assert.False(response.Headers.Contains("ce-datacontenttype"));
+    }
 
-        [Fact]
-        public async Task CopyToListenerResponseAsync_BadContentMode()
+    [Fact]
+    public async Task CopyToListenerResponseAsync_BinaryDataButNoDataContentType()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            var formatter = new JsonEventFormatter();
-            await GetResponseAsync(
-                async context => await Assert.ThrowsAsync<ArgumentException>(() => cloudEvent.CopyToHttpListenerResponseAsync(context.Response, (ContentMode) 100, formatter)));
-        }
+            Data = new byte[10],
+        }.PopulateRequiredAttributes();
+        var formatter = new JsonEventFormatter();
+        await GetResponseAsync(
+            async context => await Assert.ThrowsAsync<ArgumentException>(() => cloudEvent.CopyToHttpListenerResponseAsync(context.Response, ContentMode.Binary, formatter)));
+    }
 
-        [Fact]
-        public async Task CopyToHttpListenerResponseAsync_StructuredMode()
+    [Fact]
+    public async Task CopyToListenerResponseAsync_NonBinaryDataButNoDataContentType_ContentTypeIsInferred()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent
-            {
-                Data = "plain text",
-                DataContentType = "text/plain"
-            }.PopulateRequiredAttributes();
-            var formatter = new JsonEventFormatter();
-            var response = await GetResponseAsync(
-                async context => await cloudEvent.CopyToHttpListenerResponseAsync(context.Response, ContentMode.Structured, formatter));
-            response.EnsureSuccessStatusCode();
-            var content = response.Content;
-            Assert.Equal(MimeUtilities.MediaType + "+json", content.Headers.ContentType!.MediaType);
-            var bytes = await content.ReadAsByteArrayAsync();
+            Data = "plain text",
+        }.PopulateRequiredAttributes();
+        var formatter = new JsonEventFormatter();
+        var response = await GetResponseAsync(
+            async context => await cloudEvent.CopyToHttpListenerResponseAsync(context.Response, ContentMode.Binary, formatter));
+        var content = response.Content;
+        Assert.Equal("application/json", content.Headers.ContentType!.MediaType);
+        Assert.Equal("\"plain text\"", await content.ReadAsStringAsync());
+    }
 
-            var parsed = new JsonEventFormatter().DecodeStructuredModeMessage(bytes, MimeUtilities.ToContentType(content.Headers.ContentType), extensionAttributes: null);
-            AssertCloudEventsEqual(cloudEvent, parsed);
+    [Fact]
+    public async Task CopyToListenerResponseAsync_BadContentMode()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        var formatter = new JsonEventFormatter();
+        await GetResponseAsync(
+            async context => await Assert.ThrowsAsync<ArgumentException>(() => cloudEvent.CopyToHttpListenerResponseAsync(context.Response, (ContentMode) 100, formatter)));
+    }
 
-            // We populate headers even though we don't strictly need to; let's validate that.
-            Assert.Equal("1.0", response.Headers.GetValues("ce-specversion").Single());
-            Assert.Equal(cloudEvent.Type, response.Headers.GetValues("ce-type").Single());
-            Assert.Equal(cloudEvent.Id, response.Headers.GetValues("ce-id").Single());
-            Assert.Equal(CloudEventAttributeType.UriReference.Format(cloudEvent.Source!), response.Headers.GetValues("ce-source").Single());
-            // We don't populate the data content type header
-            Assert.False(response.Headers.Contains("ce-datacontenttype"));
-        }
-
-        [Fact]
-        public async Task CopyToHttpListenerResponseAsync_Batch()
+    [Fact]
+    public async Task CopyToHttpListenerResponseAsync_StructuredMode()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var batch = CreateSampleBatch();
+            Data = "plain text",
+            DataContentType = "text/plain"
+        }.PopulateRequiredAttributes();
+        var formatter = new JsonEventFormatter();
+        var response = await GetResponseAsync(
+            async context => await cloudEvent.CopyToHttpListenerResponseAsync(context.Response, ContentMode.Structured, formatter));
+        response.EnsureSuccessStatusCode();
+        var content = response.Content;
+        Assert.Equal(MimeUtilities.MediaType + "+json", content.Headers.ContentType!.MediaType);
+        var bytes = await content.ReadAsByteArrayAsync();
 
-            var response = await GetResponseAsync(async context =>
-            {
-                await batch.CopyToHttpListenerResponseAsync(context.Response, new JsonEventFormatter());
-                context.Response.StatusCode = 200;
-            });
+        var parsed = new JsonEventFormatter().DecodeStructuredModeMessage(bytes, MimeUtilities.ToContentType(content.Headers.ContentType), extensionAttributes: null);
+        AssertCloudEventsEqual(cloudEvent, parsed);
 
-            response.EnsureSuccessStatusCode();
-            var content = response.Content;
-            Assert.Equal(MimeUtilities.BatchMediaType + "+json", content.Headers.ContentType!.MediaType);
-            var bytes = await content.ReadAsByteArrayAsync();
-            var parsedBatch = new JsonEventFormatter().DecodeBatchModeMessage(bytes, MimeUtilities.ToContentType(content.Headers.ContentType), extensionAttributes: null);
-            AssertBatchesEqual(batch, parsedBatch);
-        }
+        // We populate headers even though we don't strictly need to; let's validate that.
+        Assert.Equal("1.0", response.Headers.GetValues("ce-specversion").Single());
+        Assert.Equal(cloudEvent.Type, response.Headers.GetValues("ce-type").Single());
+        Assert.Equal(cloudEvent.Id, response.Headers.GetValues("ce-id").Single());
+        Assert.Equal(CloudEventAttributeType.UriReference.Format(cloudEvent.Source!), response.Headers.GetValues("ce-source").Single());
+        // We don't populate the data content type header
+        Assert.False(response.Headers.Contains("ce-datacontenttype"));
+    }
 
-        /// <summary>
-        /// Executes the given request, expecting the given handler to be called.
-        /// An empty response is proided on success.
-        /// </summary>
-        private async Task<T> SendRequestAsync<T>(HttpRequestMessage request, Func<HttpListenerContext, Task<T>> handler)
+    [Fact]
+    public async Task CopyToHttpListenerResponseAsync_Batch()
+    {
+        var batch = CreateSampleBatch();
+
+        var response = await GetResponseAsync(async context =>
         {
-            var guid = Guid.NewGuid().ToString();
-            request.Headers.Add(TestContextHeader, guid);
+            await batch.CopyToHttpListenerResponseAsync(context.Response, new JsonEventFormatter());
+            context.Response.StatusCode = 200;
+        });
 
-            T result = default!;
-            bool executed = false;
+        response.EnsureSuccessStatusCode();
+        var content = response.Content;
+        Assert.Equal(MimeUtilities.BatchMediaType + "+json", content.Headers.ContentType!.MediaType);
+        var bytes = await content.ReadAsByteArrayAsync();
+        var parsedBatch = new JsonEventFormatter().DecodeBatchModeMessage(bytes, MimeUtilities.ToContentType(content.Headers.ContentType), extensionAttributes: null);
+        AssertBatchesEqual(batch, parsedBatch);
+    }
 
-            PendingRequests[guid] = async context =>
-            {
-                executed = true;
-                result = await handler(context);
-                context.Response.StatusCode = (int) HttpStatusCode.NoContent;
-            };
+    /// <summary>
+    /// Executes the given request, expecting the given handler to be called.
+    /// An empty response is proided on success.
+    /// </summary>
+    private async Task<T> SendRequestAsync<T>(HttpRequestMessage request, Func<HttpListenerContext, Task<T>> handler)
+    {
+        var guid = Guid.NewGuid().ToString();
+        request.Headers.Add(TestContextHeader, guid);
 
-            var httpClient = new HttpClient();
-            var response = await httpClient.SendAsync(request);
-            var content = await response.Content.ReadAsStringAsync();
-            Assert.True(response.IsSuccessStatusCode, content);
-            Assert.True(executed);
-            return result!;
-        }
+        T result = default!;
+        bool executed = false;
 
-        /// <summary>
-        /// Executes a simple GET request that will invoke the given handler, and returns the response (as an HttpResponseMessage).
-        /// The handler is responsible for writing the response.
-        /// </summary>
-        private async Task<HttpResponseMessage> GetResponseAsync(Func<HttpListenerContext, Task> handler)
+        PendingRequests[guid] = async context =>
         {
-            var guid = Guid.NewGuid().ToString();
-            var request = new HttpRequestMessage(HttpMethod.Get, ListenerAddress);
-            request.Headers.Add(TestContextHeader, guid);
+            executed = true;
+            result = await handler(context);
+            context.Response.StatusCode = (int) HttpStatusCode.NoContent;
+        };
 
-            bool executed = false;
+        var httpClient = new HttpClient();
+        var response = await httpClient.SendAsync(request);
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.True(response.IsSuccessStatusCode, content);
+        Assert.True(executed);
+        return result!;
+    }
 
-            PendingRequests[guid] = async context =>
-            {
-                executed = true;
-                await handler(context);
-            };
+    /// <summary>
+    /// Executes a simple GET request that will invoke the given handler, and returns the response (as an HttpResponseMessage).
+    /// The handler is responsible for writing the response.
+    /// </summary>
+    private async Task<HttpResponseMessage> GetResponseAsync(Func<HttpListenerContext, Task> handler)
+    {
+        var guid = Guid.NewGuid().ToString();
+        var request = new HttpRequestMessage(HttpMethod.Get, ListenerAddress);
+        request.Headers.Add(TestContextHeader, guid);
 
-            var httpClient = new HttpClient();
-            var response = await httpClient.SendAsync(request);
-            Assert.True(executed);
-            return response;
-        }
+        bool executed = false;
+
+        PendingRequests[guid] = async context =>
+        {
+            executed = true;
+            await handler(context);
+        };
+
+        var httpClient = new HttpClient();
+        var response = await httpClient.SendAsync(request);
+        Assert.True(executed);
+        return response;
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/Http/HttpTestBase.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Http/HttpTestBase.cs
@@ -9,106 +9,105 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace CloudNative.CloudEvents.Http.UnitTests
+namespace CloudNative.CloudEvents.Http.UnitTests;
+
+/// <summary>
+/// Base class for HTTP tests, which sets up an HttpListener.
+/// </summary>
+public abstract class HttpTestBase : IDisposable
 {
-    /// <summary>
-    /// Base class for HTTP tests, which sets up an HttpListener.
-    /// </summary>
-    public abstract class HttpTestBase : IDisposable
+    internal static readonly DateTimeOffset SampleTimestamp = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero);
+    internal string ListenerAddress { get; }
+    internal const string TestContextHeader = "testcontext";
+    private readonly HttpListener listener;
+    private readonly Task processingTask;
+    private volatile bool disposed;
+
+    internal ConcurrentDictionary<string, Func<HttpListenerContext, Task>> PendingRequests { get; } =
+        new ConcurrentDictionary<string, Func<HttpListenerContext, Task>>();
+
+    public HttpTestBase()
     {
-        internal static readonly DateTimeOffset SampleTimestamp = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero);
-        internal string ListenerAddress { get; }
-        internal const string TestContextHeader = "testcontext";
-        private readonly HttpListener listener;
-        private readonly Task processingTask;
-        private volatile bool disposed;
-
-        internal ConcurrentDictionary<string, Func<HttpListenerContext, Task>> PendingRequests { get; } =
-            new ConcurrentDictionary<string, Func<HttpListenerContext, Task>>();
-
-        public HttpTestBase()
+        var port = GetRandomUnusedPort();
+        ListenerAddress = $"http://localhost:{port}/";
+        listener = new HttpListener()
         {
-            var port = GetRandomUnusedPort();
-            ListenerAddress = $"http://localhost:{port}/";
-            listener = new HttpListener()
-            {
-                AuthenticationSchemes = AuthenticationSchemes.Anonymous,
-                Prefixes = { ListenerAddress }
-            };
-            listener.Start();
-            processingTask = ProcessRequestsAsync();
+            AuthenticationSchemes = AuthenticationSchemes.Anonymous,
+            Prefixes = { ListenerAddress }
+        };
+        listener.Start();
+        processingTask = ProcessRequestsAsync();
+    }
+
+    public void Dispose()
+    {
+        // Note: we don't protected against multiple disposal, but that's not
+        // expected to be a problem. (We're not disposing of this manually.)
+        disposed = true;
+        listener.Stop();
+        if (!processingTask.Wait(1000))
+        {
+            throw new InvalidOperationException("Processing task did not complete");
         }
+    }
 
-        public void Dispose()
+    private async Task ProcessRequestsAsync()
+    {
+        while (!disposed)
         {
-            // Note: we don't protected against multiple disposal, but that's not
-            // expected to be a problem. (We're not disposing of this manually.)
-            disposed = true;
-            listener.Stop();
-            if (!processingTask.Wait(1000))
-            {
-                throw new InvalidOperationException("Processing task did not complete");
-            }
-        }
-
-        private async Task ProcessRequestsAsync()
-        {
-            while (!disposed)
-            {
-                HttpListenerContext context;
-                try
-                {
-                    context = await listener.GetContextAsync().ConfigureAwait(false);
-                }
-                // The listener throws when it's stopped.
-                // We want to handle that gracefully, but allow any other error to bubble up.
-                catch (Exception e) when (disposed && (e is ObjectDisposedException || e is HttpListenerException))
-                {
-                    return;
-                }
-                try
-                {
-                    await HandleContext(context).ConfigureAwait(false);
-                }
-                catch (Exception e)
-                {
-                    var response = context.Response;
-                    var responseContent = Encoding.UTF8.GetBytes($"Error processing request: {e}");
-                    response.ContentLength64 = responseContent.Length;
-                    response.StatusCode = 500;
-                    response.OutputStream.Write(responseContent);
-                }
-                context.Response.Close();
-            }
-        }
-
-        private async Task HandleContext(HttpListenerContext requestContext)
-        {
-            var ctxHeaderValue = requestContext.Request.Headers[TestContextHeader]
-                ?? throw new InvalidOperationException("Test context header was missing");
-
-            if (PendingRequests.TryRemove(ctxHeaderValue, out var pending))
-            {
-                await pending(requestContext);
-            }
-            else
-            {
-                throw new Exception($"Request with context header '{ctxHeaderValue}' was not handled");
-            }
-        }
-
-        private static int GetRandomUnusedPort()
-        {
-            var listener = new TcpListener(IPAddress.Loopback, 0);
+            HttpListenerContext context;
             try
             {
-                listener.Start();
-                return ((IPEndPoint) listener.LocalEndpoint).Port;
+                context = await listener.GetContextAsync().ConfigureAwait(false);
             }
-            finally
+            // The listener throws when it's stopped.
+            // We want to handle that gracefully, but allow any other error to bubble up.
+            catch (Exception e) when (disposed && (e is ObjectDisposedException || e is HttpListenerException))
             {
-                listener.Stop();
+                return;
             }
+            try
+            {
+                await HandleContext(context).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                var response = context.Response;
+                var responseContent = Encoding.UTF8.GetBytes($"Error processing request: {e}");
+                response.ContentLength64 = responseContent.Length;
+                response.StatusCode = 500;
+                response.OutputStream.Write(responseContent);
+            }
+            context.Response.Close();
+        }
+    }
+
+    private async Task HandleContext(HttpListenerContext requestContext)
+    {
+        var ctxHeaderValue = requestContext.Request.Headers[TestContextHeader]
+            ?? throw new InvalidOperationException("Test context header was missing");
+
+        if (PendingRequests.TryRemove(ctxHeaderValue, out var pending))
+        {
+            await pending(requestContext);
+        }
+        else
+        {
+            throw new Exception($"Request with context header '{ctxHeaderValue}' was not handled");
+        }
+    }
+
+    private static int GetRandomUnusedPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        try
+        {
+            listener.Start();
+            return ((IPEndPoint) listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
         }
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/Http/HttpUtilitiesTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Http/HttpUtilitiesTest.cs
@@ -5,63 +5,62 @@
 using System;
 using Xunit;
 
-namespace CloudNative.CloudEvents.Http.UnitTests
+namespace CloudNative.CloudEvents.Http.UnitTests;
+
+public class HttpUtilitiesTest
 {
-    public class HttpUtilitiesTest
+    [Theory]
+    [InlineData("simple", "simple")]
+    [InlineData("Euro \u20AC \U0001F600", "Euro%20%E2%82%AC%20%F0%9F%98%80")]
+    [InlineData("space encoded", "space%20encoded")]
+    [InlineData("percent%encoded", "percent%25encoded")]
+    [InlineData("quote\"encoded", "quote%22encoded")]
+    [InlineData("caf\u00e9", "caf%C3%A9")]
+    // This wouldn't be a valid attribute value in CloudEvents 1.0, but we encode ASCII control characters
+    // for good measure, so let's test it.
+    [InlineData("line1\r\nline2", "line1%0D%0Aline2")]
+    public void RoundTripHeaderValue(string original, string encoded)
     {
-        [Theory]
-        [InlineData("simple", "simple")]
-        [InlineData("Euro \u20AC \U0001F600", "Euro%20%E2%82%AC%20%F0%9F%98%80")]
-        [InlineData("space encoded", "space%20encoded")]
-        [InlineData("percent%encoded", "percent%25encoded")]
-        [InlineData("quote\"encoded", "quote%22encoded")]
-        [InlineData("caf\u00e9", "caf%C3%A9")]
-        // This wouldn't be a valid attribute value in CloudEvents 1.0, but we encode ASCII control characters
-        // for good measure, so let's test it.
-        [InlineData("line1\r\nline2", "line1%0D%0Aline2")]
-        public void RoundTripHeaderValue(string original, string encoded)
-        {
-            var actualEncoded = HttpUtilities.EncodeHeaderValue(original);
-            Assert.Equal(encoded, actualEncoded);
+        var actualEncoded = HttpUtilities.EncodeHeaderValue(original);
+        Assert.Equal(encoded, actualEncoded);
 
-            var actualDecoded = HttpUtilities.DecodeHeaderValue(encoded);
-            Assert.Equal(original, actualDecoded);
-        }
-
-        // This is for values which would be encoded a different way, but we need to
-        // test the decode path
-        [Theory]
-        [InlineData("lenient decoding %30%31", "lenient decoding 01")]
-        [InlineData(@"""  quoted  text  ""unquoted", "  quoted  text  unquoted")]
-        [InlineData(@"""escaped quote\""end""", @"escaped quote""end")]
-        [InlineData(@"""escaped backslash\\end""", @"escaped backslash\end")]
-        [InlineData(@"non-escaping backslash\end", @"non-escaping backslash\end")]
-        // Mixed case for percent encoding
-        [InlineData("Euro%20%e2%82%ac%20%f0%9F%98%80", "Euro \u20AC \U0001F600")]
-        public void DecodeHeaderValue_NonRoundTrip(string headerValue, string expectedResult)
-        {
-            var actualResult = HttpUtilities.DecodeHeaderValue(headerValue);
-            Assert.Equal(expectedResult, actualResult);
-        }
-
-        [Theory]
-        [InlineData("unterminated percent %")]
-        [InlineData("unterminated percent %0")]
-        [InlineData("non hex percent %g0")]
-        [InlineData("non hex percent %0g")]
-        [InlineData("non hex percent %0$")]
-        [InlineData("low surrogate %ED%B0%80")]
-        [InlineData("high surrogate %ED%A0%80")]
-        [InlineData("surrogate pair via two UTF-16 %ED%A0%80%ED%B0%80")]
-        [InlineData("overlong UTF-8 %C0%A0")]
-        [InlineData("incomplete end UTF-8 %E2")]
-        [InlineData("incomplete end UTF-8 %E2%")]
-        [InlineData("incomplete non-percent UTF-8 %E2x")]
-        [InlineData("invalid UTF-8 first byte %82")]
-        [InlineData("invalid UTF-8 second byte %E2%E2")]
-        [InlineData(@"""unterminated quote")]
-        [InlineData(@"""unterminated escape \")]
-        public void DecodeHeaderValue_Invalid(string headerValue) =>
-            Assert.Throws<ArgumentException>(() => HttpUtilities.DecodeHeaderValue(headerValue));
+        var actualDecoded = HttpUtilities.DecodeHeaderValue(encoded);
+        Assert.Equal(original, actualDecoded);
     }
+
+    // This is for values which would be encoded a different way, but we need to
+    // test the decode path
+    [Theory]
+    [InlineData("lenient decoding %30%31", "lenient decoding 01")]
+    [InlineData(@"""  quoted  text  ""unquoted", "  quoted  text  unquoted")]
+    [InlineData(@"""escaped quote\""end""", @"escaped quote""end")]
+    [InlineData(@"""escaped backslash\\end""", @"escaped backslash\end")]
+    [InlineData(@"non-escaping backslash\end", @"non-escaping backslash\end")]
+    // Mixed case for percent encoding
+    [InlineData("Euro%20%e2%82%ac%20%f0%9F%98%80", "Euro \u20AC \U0001F600")]
+    public void DecodeHeaderValue_NonRoundTrip(string headerValue, string expectedResult)
+    {
+        var actualResult = HttpUtilities.DecodeHeaderValue(headerValue);
+        Assert.Equal(expectedResult, actualResult);
+    }
+
+    [Theory]
+    [InlineData("unterminated percent %")]
+    [InlineData("unterminated percent %0")]
+    [InlineData("non hex percent %g0")]
+    [InlineData("non hex percent %0g")]
+    [InlineData("non hex percent %0$")]
+    [InlineData("low surrogate %ED%B0%80")]
+    [InlineData("high surrogate %ED%A0%80")]
+    [InlineData("surrogate pair via two UTF-16 %ED%A0%80%ED%B0%80")]
+    [InlineData("overlong UTF-8 %C0%A0")]
+    [InlineData("incomplete end UTF-8 %E2")]
+    [InlineData("incomplete end UTF-8 %E2%")]
+    [InlineData("incomplete non-percent UTF-8 %E2x")]
+    [InlineData("invalid UTF-8 first byte %82")]
+    [InlineData("invalid UTF-8 second byte %E2%E2")]
+    [InlineData(@"""unterminated quote")]
+    [InlineData(@"""unterminated escape \")]
+    public void DecodeHeaderValue_Invalid(string headerValue) =>
+        Assert.Throws<ArgumentException>(() => HttpUtilities.DecodeHeaderValue(headerValue));
 }

--- a/test/CloudNative.CloudEvents.UnitTests/Http/HttpWebExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Http/HttpWebExtensionsTest.cs
@@ -14,170 +14,169 @@ using static CloudNative.CloudEvents.UnitTests.TestHelpers;
 
 // Type or member is obsolete - this whole file is testing WebRequest integration.
 #pragma warning disable SYSLIB0014
-namespace CloudNative.CloudEvents.Http.UnitTests
+namespace CloudNative.CloudEvents.Http.UnitTests;
+
+public class HttpWebExtensionsTest : HttpTestBase
 {
-    public class HttpWebExtensionsTest : HttpTestBase
+    [Fact]
+    public async Task HttpBinaryWebRequestSendTest()
     {
-        [Fact]
-        public async Task HttpBinaryWebRequestSendTest()
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent
-            {
-                Type = "com.github.pull.create",
-                Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
-                Id = "A234-1234-1234",
-                Time = SampleTimestamp,
-                DataContentType = MediaTypeNames.Text.Xml,
-                Data = "<much wow=\"xml\"/>",
-                ["comexampleextension1"] = "value",
-                ["utf8examplevalue"] = "æøå"
-            };
+            Type = "com.github.pull.create",
+            Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
+            Id = "A234-1234-1234",
+            Time = SampleTimestamp,
+            DataContentType = MediaTypeNames.Text.Xml,
+            Data = "<much wow=\"xml\"/>",
+            ["comexampleextension1"] = "value",
+            ["utf8examplevalue"] = "æøå"
+        };
 
-            string ctx = Guid.NewGuid().ToString();
-            HttpWebRequest httpWebRequest = WebRequest.CreateHttp(ListenerAddress + "ep");
-            httpWebRequest.Method = "POST";
-            await cloudEvent.CopyToHttpWebRequestAsync(httpWebRequest, ContentMode.Binary, new JsonEventFormatter());
-            httpWebRequest.Headers.Add(TestContextHeader, ctx);
+        string ctx = Guid.NewGuid().ToString();
+        HttpWebRequest httpWebRequest = WebRequest.CreateHttp(ListenerAddress + "ep");
+        httpWebRequest.Method = "POST";
+        await cloudEvent.CopyToHttpWebRequestAsync(httpWebRequest, ContentMode.Binary, new JsonEventFormatter());
+        httpWebRequest.Headers.Add(TestContextHeader, ctx);
 
-            PendingRequests.TryAdd(ctx, context =>
-            {
-                var receivedCloudEvent = context.Request.ToCloudEvent(new JsonEventFormatter());
-
-                Assert.Equal(CloudEventsSpecVersion.V1_0, receivedCloudEvent.SpecVersion);
-                Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
-                Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
-                Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-                AssertTimestampsEqual(SampleTimestamp, cloudEvent.Time.Value);
-                Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
-                Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
-
-                // The non-ASCII attribute value should have been URL-encoded using UTF-8 for the header.
-                Assert.Equal("%C3%A6%C3%B8%C3%A5", context.Request.Headers["ce-utf8examplevalue"]);
-
-                Assert.Equal("value", receivedCloudEvent["comexampleextension1"]);
-                Assert.Equal("æøå", receivedCloudEvent["utf8examplevalue"]);
-                context.Response.StatusCode = (int) HttpStatusCode.NoContent;
-                return Task.CompletedTask;
-            });
-
-            var result = (HttpWebResponse) await httpWebRequest.GetResponseAsync();
-            var content = new StreamReader(result.GetResponseStream()).ReadToEnd();
-            Assert.True(result.StatusCode == HttpStatusCode.NoContent, content);
-        }
-
-        [Fact]
-        public async Task HttpStructuredWebRequestSendTest()
+        PendingRequests.TryAdd(ctx, context =>
         {
-            var cloudEvent = new CloudEvent
-            {
-                Type = "com.github.pull.create",
-                Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
-                Id = "A234-1234-1234",
-                Time = SampleTimestamp,
-                DataContentType = MediaTypeNames.Text.Xml,
-                Data = "<much wow=\"xml\"/>",
-                ["comexampleextension1"] = "value",
-                ["utf8examplevalue"] = "æøå"
-            };
+            var receivedCloudEvent = context.Request.ToCloudEvent(new JsonEventFormatter());
 
-            string ctx = Guid.NewGuid().ToString();
-            HttpWebRequest httpWebRequest = WebRequest.CreateHttp(ListenerAddress + "ep");
-            httpWebRequest.Method = "POST";
-            await cloudEvent.CopyToHttpWebRequestAsync(httpWebRequest, ContentMode.Structured, new JsonEventFormatter());
-            httpWebRequest.Headers.Add(TestContextHeader, ctx);
+            Assert.Equal(CloudEventsSpecVersion.V1_0, receivedCloudEvent.SpecVersion);
+            Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
+            Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
+            Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
+            AssertTimestampsEqual(SampleTimestamp, cloudEvent.Time.Value);
+            Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
+            Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
 
-            PendingRequests.TryAdd(ctx, context =>
-            {
-                var receivedCloudEvent = context.Request.ToCloudEvent(new JsonEventFormatter());
+            // The non-ASCII attribute value should have been URL-encoded using UTF-8 for the header.
+            Assert.Equal("%C3%A6%C3%B8%C3%A5", context.Request.Headers["ce-utf8examplevalue"]);
 
-                Assert.Equal(CloudEventsSpecVersion.V1_0, receivedCloudEvent.SpecVersion);
-                Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
-                Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
-                Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-                AssertTimestampsEqual(SampleTimestamp, cloudEvent.Time.Value);
-                Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
-                Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
+            Assert.Equal("value", receivedCloudEvent["comexampleextension1"]);
+            Assert.Equal("æøå", receivedCloudEvent["utf8examplevalue"]);
+            context.Response.StatusCode = (int) HttpStatusCode.NoContent;
+            return Task.CompletedTask;
+        });
 
-                Assert.Equal("value", receivedCloudEvent["comexampleextension1"]);
-                Assert.Equal("æøå", receivedCloudEvent["utf8examplevalue"]);
-                context.Response.StatusCode = (int) HttpStatusCode.NoContent;
-                return Task.CompletedTask;
-            });
+        var result = (HttpWebResponse) await httpWebRequest.GetResponseAsync();
+        var content = new StreamReader(result.GetResponseStream()).ReadToEnd();
+        Assert.True(result.StatusCode == HttpStatusCode.NoContent, content);
+    }
 
-            var result = (HttpWebResponse) await httpWebRequest.GetResponseAsync();
-            var content = new StreamReader(result.GetResponseStream()).ReadToEnd();
-            Assert.True(result.StatusCode == HttpStatusCode.NoContent, content);
-        }
-
-        [Fact]
-        public async Task CopyToHttpWebRequestAsync_BinaryDataButNoDataContentType()
+    [Fact]
+    public async Task HttpStructuredWebRequestSendTest()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent
-            {
-                Data = new byte[10],
-            }.PopulateRequiredAttributes();
-            HttpWebRequest httpWebRequest = WebRequest.CreateHttp(ListenerAddress + "ep");
-            httpWebRequest.Method = "POST";
-            await Assert.ThrowsAsync<ArgumentException>(
-                async () => await cloudEvent.CopyToHttpWebRequestAsync(httpWebRequest, ContentMode.Binary, new JsonEventFormatter()));
-        }
+            Type = "com.github.pull.create",
+            Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
+            Id = "A234-1234-1234",
+            Time = SampleTimestamp,
+            DataContentType = MediaTypeNames.Text.Xml,
+            Data = "<much wow=\"xml\"/>",
+            ["comexampleextension1"] = "value",
+            ["utf8examplevalue"] = "æøå"
+        };
 
-        [Fact]
-        public async Task CopyToHttpWebRequestAsync_NonBinaryDataButNoDataContentType_ContentTypeIsInferred()
+        string ctx = Guid.NewGuid().ToString();
+        HttpWebRequest httpWebRequest = WebRequest.CreateHttp(ListenerAddress + "ep");
+        httpWebRequest.Method = "POST";
+        await cloudEvent.CopyToHttpWebRequestAsync(httpWebRequest, ContentMode.Structured, new JsonEventFormatter());
+        httpWebRequest.Headers.Add(TestContextHeader, ctx);
+
+        PendingRequests.TryAdd(ctx, context =>
         {
-            var cloudEvent = new CloudEvent
-            {
-                Data = "plain text",
-            }.PopulateRequiredAttributes();
-            HttpWebRequest httpWebRequest = WebRequest.CreateHttp(ListenerAddress + "ep");
-            httpWebRequest.Method = "POST";
-            await cloudEvent.CopyToHttpWebRequestAsync(httpWebRequest, ContentMode.Binary, new JsonEventFormatter());
-            Assert.Equal("application/json", httpWebRequest.ContentType);
-        }
+            var receivedCloudEvent = context.Request.ToCloudEvent(new JsonEventFormatter());
 
-        [Fact]
-        public async Task CopyToHttpWebRequestAsync_Batch()
+            Assert.Equal(CloudEventsSpecVersion.V1_0, receivedCloudEvent.SpecVersion);
+            Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
+            Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
+            Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
+            AssertTimestampsEqual(SampleTimestamp, cloudEvent.Time.Value);
+            Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
+            Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
+
+            Assert.Equal("value", receivedCloudEvent["comexampleextension1"]);
+            Assert.Equal("æøå", receivedCloudEvent["utf8examplevalue"]);
+            context.Response.StatusCode = (int) HttpStatusCode.NoContent;
+            return Task.CompletedTask;
+        });
+
+        var result = (HttpWebResponse) await httpWebRequest.GetResponseAsync();
+        var content = new StreamReader(result.GetResponseStream()).ReadToEnd();
+        Assert.True(result.StatusCode == HttpStatusCode.NoContent, content);
+    }
+
+    [Fact]
+    public async Task CopyToHttpWebRequestAsync_BinaryDataButNoDataContentType()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var batch = CreateSampleBatch();
-            HttpWebRequest request = WebRequest.CreateHttp(ListenerAddress + "ep");
-            request.Method = "POST";
-            await batch.CopyToHttpWebRequestAsync(request, new JsonEventFormatter());
+            Data = new byte[10],
+        }.PopulateRequiredAttributes();
+        HttpWebRequest httpWebRequest = WebRequest.CreateHttp(ListenerAddress + "ep");
+        httpWebRequest.Method = "POST";
+        await Assert.ThrowsAsync<ArgumentException>(
+            async () => await cloudEvent.CopyToHttpWebRequestAsync(httpWebRequest, ContentMode.Binary, new JsonEventFormatter()));
+    }
 
-            var (bytes, contentType) = await SendRequestAsync(request, async context =>
-            {
-                var bytes = await BinaryDataUtilities.ToReadOnlyMemoryAsync(context.Request.InputStream);
-                var contentType = context.Request.Headers["Content-Type"];
-                return (bytes, contentType);
-            });
-
-            Assert.Equal(MimeUtilities.BatchMediaType + "+json; charset=utf-8", contentType);
-            var parsedBatch = new JsonEventFormatter().DecodeBatchModeMessage(bytes, MimeUtilities.CreateContentTypeOrNull(contentType), extensionAttributes: null);
-            AssertBatchesEqual(batch, parsedBatch);
-        }
-
-        /// <summary>
-        /// Executes the given request, expecting the given handler to be called.
-        /// An empty response is proided on success.
-        /// </summary>
-        private async Task<T> SendRequestAsync<T>(HttpWebRequest request, Func<HttpListenerContext, Task<T>> handler)
+    [Fact]
+    public async Task CopyToHttpWebRequestAsync_NonBinaryDataButNoDataContentType_ContentTypeIsInferred()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var guid = Guid.NewGuid().ToString();
-            request.Headers.Add(TestContextHeader, guid);
+            Data = "plain text",
+        }.PopulateRequiredAttributes();
+        HttpWebRequest httpWebRequest = WebRequest.CreateHttp(ListenerAddress + "ep");
+        httpWebRequest.Method = "POST";
+        await cloudEvent.CopyToHttpWebRequestAsync(httpWebRequest, ContentMode.Binary, new JsonEventFormatter());
+        Assert.Equal("application/json", httpWebRequest.ContentType);
+    }
 
-            T result = default!;
-            bool executed = false;
+    [Fact]
+    public async Task CopyToHttpWebRequestAsync_Batch()
+    {
+        var batch = CreateSampleBatch();
+        HttpWebRequest request = WebRequest.CreateHttp(ListenerAddress + "ep");
+        request.Method = "POST";
+        await batch.CopyToHttpWebRequestAsync(request, new JsonEventFormatter());
 
-            PendingRequests[guid] = async context =>
-            {
-                executed = true;
-                result = await handler(context);
-                context.Response.StatusCode = (int) HttpStatusCode.NoContent;
-            };
+        var (bytes, contentType) = await SendRequestAsync(request, async context =>
+        {
+            var bytes = await BinaryDataUtilities.ToReadOnlyMemoryAsync(context.Request.InputStream);
+            var contentType = context.Request.Headers["Content-Type"];
+            return (bytes, contentType);
+        });
 
-            using var response = (HttpWebResponse) await request.GetResponseAsync();
-            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
-            Assert.True(executed);
-            return result!;
-        }
+        Assert.Equal(MimeUtilities.BatchMediaType + "+json; charset=utf-8", contentType);
+        var parsedBatch = new JsonEventFormatter().DecodeBatchModeMessage(bytes, MimeUtilities.CreateContentTypeOrNull(contentType), extensionAttributes: null);
+        AssertBatchesEqual(batch, parsedBatch);
+    }
+
+    /// <summary>
+    /// Executes the given request, expecting the given handler to be called.
+    /// An empty response is proided on success.
+    /// </summary>
+    private async Task<T> SendRequestAsync<T>(HttpWebRequest request, Func<HttpListenerContext, Task<T>> handler)
+    {
+        var guid = Guid.NewGuid().ToString();
+        request.Headers.Add(TestContextHeader, guid);
+
+        T result = default!;
+        bool executed = false;
+
+        PendingRequests[guid] = async context =>
+        {
+            executed = true;
+            result = await handler(context);
+            context.Response.StatusCode = (int) HttpStatusCode.NoContent;
+        };
+
+        using var response = (HttpWebResponse) await request.GetResponseAsync();
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.True(executed);
+        return result!;
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/Kafka/KafkaTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Kafka/KafkaTest.cs
@@ -14,243 +14,242 @@ using System.Text;
 using Xunit;
 using static CloudNative.CloudEvents.UnitTests.TestHelpers;
 
-namespace CloudNative.CloudEvents.Kafka.UnitTests
+namespace CloudNative.CloudEvents.Kafka.UnitTests;
+
+public class KafkaTest
 {
-    public class KafkaTest
+    [Theory]
+    [InlineData("content-type", "application/cloudevents", true)]
+    [InlineData("content-type", "APPLICATION/CLOUDEVENTS", true)]
+    [InlineData("CONTENT-TYPE", "application/cloudevents", false)]
+    [InlineData("ce_specversion", "1.0", true)]
+    [InlineData("CE_SPECVERSION", "1.0", false)]
+    public void IsCloudEvent(string headerName, string headerValue, bool expectedResult)
     {
-        [Theory]
-        [InlineData("content-type", "application/cloudevents", true)]
-        [InlineData("content-type", "APPLICATION/CLOUDEVENTS", true)]
-        [InlineData("CONTENT-TYPE", "application/cloudevents", false)]
-        [InlineData("ce_specversion", "1.0", true)]
-        [InlineData("CE_SPECVERSION", "1.0", false)]
-        public void IsCloudEvent(string headerName, string headerValue, bool expectedResult)
+        var message = new Message<string?, byte[]>
         {
-            var message = new Message<string?, byte[]>
-            {
-                Headers = new Headers { { headerName, Encoding.UTF8.GetBytes(headerValue) } }
-            };
-            Assert.Equal(expectedResult, message.IsCloudEvent());
+            Headers = new Headers { { headerName, Encoding.UTF8.GetBytes(headerValue) } }
+        };
+        Assert.Equal(expectedResult, message.IsCloudEvent());
+    }
+
+    [Fact]
+    public void IsCloudEvent_NoHeaders() =>
+        Assert.False(new Message<string?, byte[]>().IsCloudEvent());
+
+    [Fact]
+    public void KafkaStructuredMessageTest()
+    {
+        // Kafka doesn't provide any way to get to the message transport level to do the test properly
+        // and it doesn't have an embedded version of a server for .Net so the lowest we can get is 
+        // the `Message<T, K>`
+
+        var jsonEventFormatter = new JsonEventFormatter();
+
+        var cloudEvent = new CloudEvent
+        {
+            Type = "com.github.pull.create",
+            Source = new Uri("https://github.com/cloudevents/spec/pull"),
+            Subject = "123",
+            Id = "A234-1234-1234",
+            Time = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero),
+            DataContentType = MediaTypeNames.Text.Xml,
+            Data = "<much wow=\"xml\"/>",
+            ["comexampleextension1"] = "value"
+        };
+
+        var message = cloudEvent.ToKafkaMessage(ContentMode.Structured, new JsonEventFormatter());
+
+        Assert.True(message.IsCloudEvent());
+
+        // Using serialization to create fully independent copy thus simulating message transport.
+        // The real transport will work in a similar way.
+        var serialized = JsonConvert.SerializeObject(message, new HeaderConverter());
+        var messageCopy = JsonConvert.DeserializeObject<Message<string?, byte[]>>(serialized, new HeadersConverter(), new HeaderConverter())!;
+
+        Assert.True(messageCopy.IsCloudEvent());
+        var receivedCloudEvent = messageCopy.ToCloudEvent(jsonEventFormatter);
+
+        Assert.Equal(CloudEventsSpecVersion.Default, receivedCloudEvent.SpecVersion);
+        Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
+        Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull"), receivedCloudEvent.Source);
+        Assert.Equal("123", receivedCloudEvent.Subject);
+        Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
+        AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time!.Value);
+        Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
+        Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
+
+        Assert.Equal("value", (string?) receivedCloudEvent["comexampleextension1"]);
+    }
+
+    [Fact]
+    public void KafkaBinaryMessageTest()
+    {
+        // Kafka doesn't provide any way to get to the message transport level to do the test properly
+        // and it doesn't have an embedded version of a server for .Net so the lowest we can get is 
+        // the `Message<T, K>`
+
+        var jsonEventFormatter = new JsonEventFormatter();
+        var cloudEvent = new CloudEvent(Partitioning.AllAttributes)
+        {
+            Type = "com.github.pull.create",
+            Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
+            Id = "A234-1234-1234",
+            Time = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero),
+            DataContentType = MediaTypeNames.Text.Xml,
+            Data = Encoding.UTF8.GetBytes("<much wow=\"xml\"/>"),
+            ["comexampleextension1"] = "value",
+            [Partitioning.PartitionKeyAttribute] = "hello much wow"
+        };
+
+        var message = cloudEvent.ToKafkaMessage(ContentMode.Binary, new JsonEventFormatter());
+        Assert.True(message.IsCloudEvent());
+
+        // Using serialization to create fully independent copy thus simulating message transport.
+        // The real transport will work in a similar way.
+        var serialized = JsonConvert.SerializeObject(message, new HeaderConverter());
+        var settings = new JsonSerializerSettings
+        {
+            Converters = { new HeadersConverter(), new HeaderConverter() }
+        };
+        var messageCopy = JsonConvert.DeserializeObject<Message<string?, byte[]>>(serialized, settings)!;
+
+        Assert.True(messageCopy.IsCloudEvent());
+        var receivedCloudEvent = messageCopy.ToCloudEvent(jsonEventFormatter, Partitioning.AllAttributes);
+
+        Assert.Equal(CloudEventsSpecVersion.Default, receivedCloudEvent.SpecVersion);
+        Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
+        Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
+        Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
+        AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time!.Value);
+        Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
+        Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
+        Assert.Equal("hello much wow", (string?) receivedCloudEvent[Partitioning.PartitionKeyAttribute]);
+
+        Assert.Equal("value", (string?) receivedCloudEvent["comexampleextension1"]);
+    }
+
+    [Theory]
+    [InlineData(MediaTypeNames.Application.Octet, new byte[0])]
+    [InlineData(MediaTypeNames.Application.Json, null)]
+    [InlineData(MediaTypeNames.Application.Xml, new byte[0])]
+    [InlineData(MediaTypeNames.Text.Plain, "")]
+    [InlineData(null, null)]
+    public void KafkaBinaryMessageTombstoneTest(string? contentType, object? expectedDecodedResult)
+    {
+        var jsonEventFormatter = new JsonEventFormatter();
+        var cloudEvent = new CloudEvent(Partitioning.AllAttributes)
+        {
+            Type = "com.github.pull.create",
+            Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
+            Id = "A234-1234-1234",
+            Time = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero),
+            DataContentType = contentType,
+            Data = null,
+            ["comexampleextension1"] = "value",
+            [Partitioning.PartitionKeyAttribute] = "hello much wow"
+        };
+
+        var message = cloudEvent.ToKafkaMessage(ContentMode.Binary, new JsonEventFormatter());
+        Assert.True(message.IsCloudEvent());
+
+        // Sending an empty message is equivalent to a delete (tombstone) for that partition key, when using compacted topics in Kafka.
+        // This is the main use case for empty data messages with Kafka.
+        Assert.Empty(message.Value);
+
+        // Using serialization to create fully independent copy thus simulating message transport.
+        // The real transport will work in a similar way.
+        var serialized = JsonConvert.SerializeObject(message, new HeaderConverter());
+        var settings = new JsonSerializerSettings
+        {
+            Converters = { new HeadersConverter(), new HeaderConverter() }
+        };
+        var messageCopy = JsonConvert.DeserializeObject<Message<string?, byte[]>>(serialized, settings)!;
+
+        Assert.True(messageCopy.IsCloudEvent());
+        var receivedCloudEvent = messageCopy.ToCloudEvent(jsonEventFormatter, Partitioning.AllAttributes);
+
+        Assert.Equal(CloudEventsSpecVersion.Default, receivedCloudEvent.SpecVersion);
+        Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
+        Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
+        Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
+        AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time!.Value);
+        Assert.Equal(contentType, receivedCloudEvent.DataContentType);
+        Assert.Equal(expectedDecodedResult, receivedCloudEvent.Data);
+        Assert.Equal("hello much wow", (string?) receivedCloudEvent[Partitioning.PartitionKeyAttribute]);
+        Assert.Equal("value", (string?) receivedCloudEvent["comexampleextension1"]);
+    }
+
+    [Fact]
+    public void ContentTypeCanBeInferredByFormatter()
+    {
+        var cloudEvent = new CloudEvent
+        {
+            Data = "plain text"
+        }.PopulateRequiredAttributes();
+
+        var message = cloudEvent.ToKafkaMessage(ContentMode.Binary, new JsonEventFormatter());
+        var contentTypeHeader = message.Headers.Single(h => h.Key == KafkaExtensions.KafkaContentTypeAttributeName);
+        var contentTypeValue = Encoding.UTF8.GetString(contentTypeHeader.GetValueBytes());
+        Assert.Equal("application/json", contentTypeValue);
+    }
+
+    private class HeadersConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Headers);
         }
 
-        [Fact]
-        public void IsCloudEvent_NoHeaders() =>
-            Assert.False(new Message<string?, byte[]>().IsCloudEvent());
-
-        [Fact]
-        public void KafkaStructuredMessageTest()
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
-            // Kafka doesn't provide any way to get to the message transport level to do the test properly
-            // and it doesn't have an embedded version of a server for .Net so the lowest we can get is 
-            // the `Message<T, K>`
-
-            var jsonEventFormatter = new JsonEventFormatter();
-
-            var cloudEvent = new CloudEvent
+            if (reader.TokenType == JsonToken.Null)
             {
-                Type = "com.github.pull.create",
-                Source = new Uri("https://github.com/cloudevents/spec/pull"),
-                Subject = "123",
-                Id = "A234-1234-1234",
-                Time = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero),
-                DataContentType = MediaTypeNames.Text.Xml,
-                Data = "<much wow=\"xml\"/>",
-                ["comexampleextension1"] = "value"
-            };
-
-            var message = cloudEvent.ToKafkaMessage(ContentMode.Structured, new JsonEventFormatter());
-
-            Assert.True(message.IsCloudEvent());
-
-            // Using serialization to create fully independent copy thus simulating message transport.
-            // The real transport will work in a similar way.
-            var serialized = JsonConvert.SerializeObject(message, new HeaderConverter());
-            var messageCopy = JsonConvert.DeserializeObject<Message<string?, byte[]>>(serialized, new HeadersConverter(), new HeaderConverter())!;
-
-            Assert.True(messageCopy.IsCloudEvent());
-            var receivedCloudEvent = messageCopy.ToCloudEvent(jsonEventFormatter);
-
-            Assert.Equal(CloudEventsSpecVersion.Default, receivedCloudEvent.SpecVersion);
-            Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
-            Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull"), receivedCloudEvent.Source);
-            Assert.Equal("123", receivedCloudEvent.Subject);
-            Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-            AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time!.Value);
-            Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
-            Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
-
-            Assert.Equal("value", (string?) receivedCloudEvent["comexampleextension1"]);
-        }
-
-        [Fact]
-        public void KafkaBinaryMessageTest()
-        {
-            // Kafka doesn't provide any way to get to the message transport level to do the test properly
-            // and it doesn't have an embedded version of a server for .Net so the lowest we can get is 
-            // the `Message<T, K>`
-
-            var jsonEventFormatter = new JsonEventFormatter();
-            var cloudEvent = new CloudEvent(Partitioning.AllAttributes)
-            {
-                Type = "com.github.pull.create",
-                Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
-                Id = "A234-1234-1234",
-                Time = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero),
-                DataContentType = MediaTypeNames.Text.Xml,
-                Data = Encoding.UTF8.GetBytes("<much wow=\"xml\"/>"),
-                ["comexampleextension1"] = "value",
-                [Partitioning.PartitionKeyAttribute] = "hello much wow"
-            };
-
-            var message = cloudEvent.ToKafkaMessage(ContentMode.Binary, new JsonEventFormatter());
-            Assert.True(message.IsCloudEvent());
-
-            // Using serialization to create fully independent copy thus simulating message transport.
-            // The real transport will work in a similar way.
-            var serialized = JsonConvert.SerializeObject(message, new HeaderConverter());
-            var settings = new JsonSerializerSettings
-            {
-                Converters = { new HeadersConverter(), new HeaderConverter() }
-            };
-            var messageCopy = JsonConvert.DeserializeObject<Message<string?, byte[]>>(serialized, settings)!;
-
-            Assert.True(messageCopy.IsCloudEvent());
-            var receivedCloudEvent = messageCopy.ToCloudEvent(jsonEventFormatter, Partitioning.AllAttributes);
-
-            Assert.Equal(CloudEventsSpecVersion.Default, receivedCloudEvent.SpecVersion);
-            Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
-            Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
-            Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-            AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time!.Value);
-            Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
-            Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
-            Assert.Equal("hello much wow", (string?) receivedCloudEvent[Partitioning.PartitionKeyAttribute]);
-
-            Assert.Equal("value", (string?) receivedCloudEvent["comexampleextension1"]);
-        }
-
-        [Theory]
-        [InlineData(MediaTypeNames.Application.Octet, new byte[0])]
-        [InlineData(MediaTypeNames.Application.Json, null)]
-        [InlineData(MediaTypeNames.Application.Xml, new byte[0])]
-        [InlineData(MediaTypeNames.Text.Plain, "")]
-        [InlineData(null, null)]
-        public void KafkaBinaryMessageTombstoneTest(string? contentType, object? expectedDecodedResult)
-        {
-            var jsonEventFormatter = new JsonEventFormatter();
-            var cloudEvent = new CloudEvent(Partitioning.AllAttributes)
-            {
-                Type = "com.github.pull.create",
-                Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
-                Id = "A234-1234-1234",
-                Time = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero),
-                DataContentType = contentType,
-                Data = null,
-                ["comexampleextension1"] = "value",
-                [Partitioning.PartitionKeyAttribute] = "hello much wow"
-            };
-
-            var message = cloudEvent.ToKafkaMessage(ContentMode.Binary, new JsonEventFormatter());
-            Assert.True(message.IsCloudEvent());
-
-            // Sending an empty message is equivalent to a delete (tombstone) for that partition key, when using compacted topics in Kafka.
-            // This is the main use case for empty data messages with Kafka.
-            Assert.Empty(message.Value);
-
-            // Using serialization to create fully independent copy thus simulating message transport.
-            // The real transport will work in a similar way.
-            var serialized = JsonConvert.SerializeObject(message, new HeaderConverter());
-            var settings = new JsonSerializerSettings
-            {
-                Converters = { new HeadersConverter(), new HeaderConverter() }
-            };
-            var messageCopy = JsonConvert.DeserializeObject<Message<string?, byte[]>>(serialized, settings)!;
-
-            Assert.True(messageCopy.IsCloudEvent());
-            var receivedCloudEvent = messageCopy.ToCloudEvent(jsonEventFormatter, Partitioning.AllAttributes);
-
-            Assert.Equal(CloudEventsSpecVersion.Default, receivedCloudEvent.SpecVersion);
-            Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
-            Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
-            Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-            AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time!.Value);
-            Assert.Equal(contentType, receivedCloudEvent.DataContentType);
-            Assert.Equal(expectedDecodedResult, receivedCloudEvent.Data);
-            Assert.Equal("hello much wow", (string?) receivedCloudEvent[Partitioning.PartitionKeyAttribute]);
-            Assert.Equal("value", (string?) receivedCloudEvent["comexampleextension1"]);
-        }
-
-        [Fact]
-        public void ContentTypeCanBeInferredByFormatter()
-        {
-            var cloudEvent = new CloudEvent
-            {
-                Data = "plain text"
-            }.PopulateRequiredAttributes();
-
-            var message = cloudEvent.ToKafkaMessage(ContentMode.Binary, new JsonEventFormatter());
-            var contentTypeHeader = message.Headers.Single(h => h.Key == KafkaExtensions.KafkaContentTypeAttributeName);
-            var contentTypeValue = Encoding.UTF8.GetString(contentTypeHeader.GetValueBytes());
-            Assert.Equal("application/json", contentTypeValue);
-        }
-
-        private class HeadersConverter : JsonConverter
-        {
-            public override bool CanConvert(Type objectType)
-            {
-                return objectType == typeof(Headers);
+                return null;
             }
-
-            public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+            else
             {
-                if (reader.TokenType == JsonToken.Null)
+                var surrogate = serializer.Deserialize<List<Header>>(reader)!;
+                var headers = new Headers();
+
+                foreach (var header in surrogate)
                 {
-                    return null;
+                    headers.Add(header.Key, header.GetValueBytes());
                 }
-                else
-                {
-                    var surrogate = serializer.Deserialize<List<Header>>(reader)!;
-                    var headers = new Headers();
-
-                    foreach (var header in surrogate)
-                    {
-                        headers.Add(header.Key, header.GetValueBytes());
-                    }
-                    return headers;
-                }
-            }
-
-            public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
-            {
-                throw new NotImplementedException();
+                return headers;
             }
         }
 
-        private class HeaderConverter : JsonConverter
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
-            private class HeaderContainer
-            {
-                public string? Key { get; set; }
-                public byte[]? Value { get; set; }
-            }
+            throw new NotImplementedException();
+        }
+    }
 
-            public override bool CanConvert(Type objectType)
-            {
-                return objectType == typeof(Header) || objectType == typeof(IHeader);
-            }
+    private class HeaderConverter : JsonConverter
+    {
+        private class HeaderContainer
+        {
+            public string? Key { get; set; }
+            public byte[]? Value { get; set; }
+        }
 
-            public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
-            {
-                var headerContainer = serializer.Deserialize<HeaderContainer>(reader)!;
-                return new Header(headerContainer.Key, headerContainer.Value);
-            }
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Header) || objectType == typeof(IHeader);
+        }
 
-            public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
-            {
-                var header = (IHeader) value!;
-                var container = new HeaderContainer { Key = header.Key, Value = header.GetValueBytes() };
-                serializer.Serialize(writer, container);
-            }
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+        {
+            var headerContainer = serializer.Deserialize<HeaderContainer>(reader)!;
+            return new Header(headerContainer.Key, headerContainer.Value);
+        }
+
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+        {
+            var header = (IHeader) value!;
+            var container = new HeaderContainer { Key = header.Key, Value = header.GetValueBytes() };
+            serializer.Serialize(writer, container);
         }
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/Mqtt/MqttTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Mqtt/MqttTest.cs
@@ -12,73 +12,72 @@ using System.Threading.Tasks;
 using Xunit;
 using static CloudNative.CloudEvents.UnitTests.TestHelpers;
 
-namespace CloudNative.CloudEvents.Mqtt.UnitTests
+namespace CloudNative.CloudEvents.Mqtt.UnitTests;
+
+public class MqttTest : IDisposable
 {
-    public class MqttTest : IDisposable
+    private readonly MqttServer mqttServer;
+
+    public MqttTest()
     {
-        private readonly MqttServer mqttServer;
+        var optionsBuilder = new MqttServerOptionsBuilder()
+            .WithConnectionBacklog(100)
+            .WithDefaultEndpoint()
+            .WithDefaultEndpointPort(52355);
 
-        public MqttTest()
+        this.mqttServer = new MqttFactory().CreateMqttServer(optionsBuilder.Build());
+        mqttServer.StartAsync().GetAwaiter().GetResult();
+    }
+
+    public void Dispose()
+    {
+        mqttServer.StopAsync().GetAwaiter().GetResult();
+    }
+
+    [Fact]
+    public async Task MqttSendTest()
+    {
+
+        var jsonEventFormatter = new JsonEventFormatter();
+        var cloudEvent = new CloudEvent
         {
-            var optionsBuilder = new MqttServerOptionsBuilder()
-                .WithConnectionBacklog(100)
-                .WithDefaultEndpoint()
-                .WithDefaultEndpointPort(52355);
+            Type = "com.github.pull.create",
+            Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
+            Id = "A234-1234-1234",
+            Time = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero),
+            DataContentType = MediaTypeNames.Text.Xml,
+            Data = "<much wow=\"xml\"/>",
+            ["comexampleextension1"] = "value"
+        };
 
-            this.mqttServer = new MqttFactory().CreateMqttServer(optionsBuilder.Build());
-            mqttServer.StartAsync().GetAwaiter().GetResult();
-        }
+        var client = new MqttFactory().CreateMqttClient();
 
-        public void Dispose()
+        var options = new MqttClientOptionsBuilder()
+            .WithClientId("Client1")
+            .WithTcpServer("127.0.0.1", 52355)
+            .WithCleanSession()
+            .Build();
+
+        TaskCompletionSource<CloudEvent> tcs = new TaskCompletionSource<CloudEvent>();
+        await client.ConnectAsync(options);
+        client.ApplicationMessageReceivedAsync += args =>
         {
-            mqttServer.StopAsync().GetAwaiter().GetResult();
-        }
+            tcs.SetResult(args.ApplicationMessage.ToCloudEvent(jsonEventFormatter));
+            return Task.CompletedTask;
+        };
 
-        [Fact]
-        public async Task MqttSendTest()
-        {
+        var result = await client.SubscribeAsync("abc");
+        await client.PublishAsync(cloudEvent.ToMqttApplicationMessage(ContentMode.Structured, new JsonEventFormatter(), topic: "abc"));
+        var receivedCloudEvent = await tcs.Task;
 
-            var jsonEventFormatter = new JsonEventFormatter();
-            var cloudEvent = new CloudEvent
-            {
-                Type = "com.github.pull.create",
-                Source = new Uri("https://github.com/cloudevents/spec/pull/123"),
-                Id = "A234-1234-1234",
-                Time = new DateTimeOffset(2018, 4, 5, 17, 31, 0, TimeSpan.Zero),
-                DataContentType = MediaTypeNames.Text.Xml,
-                Data = "<much wow=\"xml\"/>",
-                ["comexampleextension1"] = "value"
-            };
+        Assert.Equal(CloudEventsSpecVersion.Default, receivedCloudEvent.SpecVersion);
+        Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
+        Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
+        Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
+        AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time!.Value);
+        Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
+        Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
 
-            var client = new MqttFactory().CreateMqttClient();
-
-            var options = new MqttClientOptionsBuilder()
-                .WithClientId("Client1")
-                .WithTcpServer("127.0.0.1", 52355)
-                .WithCleanSession()
-                .Build();
-
-            TaskCompletionSource<CloudEvent> tcs = new TaskCompletionSource<CloudEvent>();
-            await client.ConnectAsync(options);
-            client.ApplicationMessageReceivedAsync += args =>
-            {
-                tcs.SetResult(args.ApplicationMessage.ToCloudEvent(jsonEventFormatter));
-                return Task.CompletedTask;
-            };
-
-            var result = await client.SubscribeAsync("abc");
-            await client.PublishAsync(cloudEvent.ToMqttApplicationMessage(ContentMode.Structured, new JsonEventFormatter(), topic: "abc"));
-            var receivedCloudEvent = await tcs.Task;
-
-            Assert.Equal(CloudEventsSpecVersion.Default, receivedCloudEvent.SpecVersion);
-            Assert.Equal("com.github.pull.create", receivedCloudEvent.Type);
-            Assert.Equal(new Uri("https://github.com/cloudevents/spec/pull/123"), receivedCloudEvent.Source);
-            Assert.Equal("A234-1234-1234", receivedCloudEvent.Id);
-            AssertTimestampsEqual("2018-04-05T17:31:00Z", receivedCloudEvent.Time!.Value);
-            Assert.Equal(MediaTypeNames.Text.Xml, receivedCloudEvent.DataContentType);
-            Assert.Equal("<much wow=\"xml\"/>", receivedCloudEvent.Data);
-
-            Assert.Equal("value", (string?) receivedCloudEvent["comexampleextension1"]);
-        }
+        Assert.Equal("value", (string?) receivedCloudEvent["comexampleextension1"]);
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/AttributedModel.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/AttributedModel.cs
@@ -4,14 +4,13 @@
 
 using Newtonsoft.Json;
 
-namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
-{
-    [CloudEventFormatter(typeof(JsonEventFormatter<AttributedModel>))]
-    internal class AttributedModel
-    {
-        public const string JsonPropertyName = "customattribute";
+namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests;
 
-        [JsonProperty(JsonPropertyName)]
-        public string? AttributedProperty { get; set; }
-    }
+[CloudEventFormatter(typeof(JsonEventFormatter<AttributedModel>))]
+internal class AttributedModel
+{
+    public const string JsonPropertyName = "customattribute";
+
+    [JsonProperty(JsonPropertyName)]
+    public string? AttributedProperty { get; set; }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/GenericJsonEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/GenericJsonEventFormatterTest.cs
@@ -9,167 +9,166 @@ using System.Net.Mime;
 using System.Text;
 using Xunit;
 
-namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
+namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests;
+
+/// <summary>
+/// Tests for <see cref="JsonEventFormatter{T}"/>
+/// </summary>
+public class GenericJsonEventFormatterTest
 {
-    /// <summary>
-    /// Tests for <see cref="JsonEventFormatter{T}"/>
-    /// </summary>
-    public class GenericJsonEventFormatterTest
+    [Fact]
+    public void DecodeStructuredMode()
     {
-        [Fact]
-        public void DecodeStructuredMode()
-        {
-            var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
-            obj["data"] = new JObject { [AttributedModel.JsonPropertyName] = "test" };
-            byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
+        var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
+        obj["data"] = new JObject { [AttributedModel.JsonPropertyName] = "test" };
+        byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
 
-            var formatter = CreateFormatter<AttributedModel>();
-            var cloudEvent = formatter.DecodeStructuredModeMessage(bytes, null, null);
+        var formatter = CreateFormatter<AttributedModel>();
+        var cloudEvent = formatter.DecodeStructuredModeMessage(bytes, null, null);
 
-            var model = (AttributedModel) cloudEvent.Data!;
-            Assert.Equal("test", model.AttributedProperty);
-        }
+        var model = (AttributedModel) cloudEvent.Data!;
+        Assert.Equal("test", model.AttributedProperty);
+    }
 
-        [Fact]
-        public void DecodeStructuredMode_ContentTypeIgnored()
-        {
-            var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
-            obj["data"] = new JObject { [AttributedModel.JsonPropertyName] = "test" };
-            byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
+    [Fact]
+    public void DecodeStructuredMode_ContentTypeIgnored()
+    {
+        var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
+        obj["data"] = new JObject { [AttributedModel.JsonPropertyName] = "test" };
+        byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
 
-            var formatter = CreateFormatter<AttributedModel>();
-            var cloudEvent = formatter.DecodeStructuredModeMessage(bytes, new ContentType("text/plain"), null);
+        var formatter = CreateFormatter<AttributedModel>();
+        var cloudEvent = formatter.DecodeStructuredModeMessage(bytes, new ContentType("text/plain"), null);
 
-            var model = (AttributedModel) cloudEvent.Data!;
-            Assert.Equal("test", model.AttributedProperty);
-        }
+        var model = (AttributedModel) cloudEvent.Data!;
+        Assert.Equal("test", model.AttributedProperty);
+    }
 
-        [Fact]
-        public void DecodeStructuredMode_NoData()
-        {
-            var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
-            byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
+    [Fact]
+    public void DecodeStructuredMode_NoData()
+    {
+        var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
+        byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
 
-            var formatter = CreateFormatter<AttributedModel>();
-            var cloudEvent = formatter.DecodeStructuredModeMessage(bytes, null, null);
-            Assert.Null(cloudEvent.Data);
-        }
+        var formatter = CreateFormatter<AttributedModel>();
+        var cloudEvent = formatter.DecodeStructuredModeMessage(bytes, null, null);
+        Assert.Null(cloudEvent.Data);
+    }
 
-        [Fact]
-        public void DecodeStructuredMode_Base64Data()
-        {
-            var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
-            obj["data_base64"] = Convert.ToBase64String(Encoding.UTF8.GetBytes("{}"));
-            byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
+    [Fact]
+    public void DecodeStructuredMode_Base64Data()
+    {
+        var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
+        obj["data_base64"] = Convert.ToBase64String(Encoding.UTF8.GetBytes("{}"));
+        byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
 
-            var formatter = CreateFormatter<AttributedModel>();
-            Assert.Throws<ArgumentException>(() => formatter.DecodeStructuredModeMessage(bytes, null, null));
-        }
+        var formatter = CreateFormatter<AttributedModel>();
+        Assert.Throws<ArgumentException>(() => formatter.DecodeStructuredModeMessage(bytes, null, null));
+    }
 
-        [Fact]
-        public void DecodeBinaryEventModeData()
-        {
-            var obj = new JObject { [AttributedModel.JsonPropertyName] = "test" };
-            byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
+    [Fact]
+    public void DecodeBinaryEventModeData()
+    {
+        var obj = new JObject { [AttributedModel.JsonPropertyName] = "test" };
+        byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
 
-            var formatter = CreateFormatter<AttributedModel>();
-            var cloudEvent = new CloudEvent();
-            formatter.DecodeBinaryModeEventData(bytes, cloudEvent);
+        var formatter = CreateFormatter<AttributedModel>();
+        var cloudEvent = new CloudEvent();
+        formatter.DecodeBinaryModeEventData(bytes, cloudEvent);
 
-            var model = (AttributedModel) cloudEvent.Data!;
-            Assert.Equal("test", model.AttributedProperty);
-        }
+        var model = (AttributedModel) cloudEvent.Data!;
+        Assert.Equal("test", model.AttributedProperty);
+    }
 
-        [Fact]
-        public void DecodeBinaryEventModeData_NoData()
-        {
-            var formatter = CreateFormatter<AttributedModel>();
-            var cloudEvent = new CloudEvent { Data = "original" };
-            formatter.DecodeBinaryModeEventData(new byte[0], cloudEvent);
-            Assert.Null(cloudEvent.Data);
-        }
+    [Fact]
+    public void DecodeBinaryEventModeData_NoData()
+    {
+        var formatter = CreateFormatter<AttributedModel>();
+        var cloudEvent = new CloudEvent { Data = "original" };
+        formatter.DecodeBinaryModeEventData(new byte[0], cloudEvent);
+        Assert.Null(cloudEvent.Data);
+    }
 
-        [Fact]
-        public void EncodeStructuredMode()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new AttributedModel { AttributedProperty = "test" };
-            var formatter = CreateFormatter<AttributedModel>();
-            var body = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
-            var jobject = JsonEventFormatterTest.ParseJson(body);
-            Assert.False(jobject.ContainsKey("data_base64"));
-            var data = (JObject) jobject["data"]!;
+    [Fact]
+    public void EncodeStructuredMode()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new AttributedModel { AttributedProperty = "test" };
+        var formatter = CreateFormatter<AttributedModel>();
+        var body = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
+        var jobject = JsonEventFormatterTest.ParseJson(body);
+        Assert.False(jobject.ContainsKey("data_base64"));
+        var data = (JObject) jobject["data"]!;
 
-            new JTokenAsserter
+        new JTokenAsserter
             {
                 { AttributedModel.JsonPropertyName, JTokenType.String, "test" }
             }.AssertProperties(data, assertCount: true);
-        }
+    }
 
-        [Fact]
-        public void EncodeStructuredMode_NoData()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+    [Fact]
+    public void EncodeStructuredMode_NoData()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
 
-            var formatter = CreateFormatter<AttributedModel>();
-            var body = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
-            var jobject = JsonEventFormatterTest.ParseJson(body);
-            Assert.False(jobject.ContainsKey("data"));
-            Assert.False(jobject.ContainsKey("data_base64"));
-        }
+        var formatter = CreateFormatter<AttributedModel>();
+        var body = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
+        var jobject = JsonEventFormatterTest.ParseJson(body);
+        Assert.False(jobject.ContainsKey("data"));
+        Assert.False(jobject.ContainsKey("data_base64"));
+    }
 
-        [Fact]
-        public void EncodeStructuredMode_WrongType()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new OtherModelClass { Text = "Wrong type" };
-            var formatter = CreateFormatter<AttributedModel>();
-            Assert.Throws<InvalidCastException>(() => formatter.EncodeStructuredModeMessage(cloudEvent, out _));
-        }
+    [Fact]
+    public void EncodeStructuredMode_WrongType()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new OtherModelClass { Text = "Wrong type" };
+        var formatter = CreateFormatter<AttributedModel>();
+        Assert.Throws<InvalidCastException>(() => formatter.EncodeStructuredModeMessage(cloudEvent, out _));
+    }
 
-        [Fact]
-        public void EncodeBinaryModeEventData()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new AttributedModel { AttributedProperty = "test" };
-            var formatter = CreateFormatter<AttributedModel>();
-            var body = formatter.EncodeBinaryModeEventData(cloudEvent);
-            var jobject = JsonEventFormatterTest.ParseJson(body);
+    [Fact]
+    public void EncodeBinaryModeEventData()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new AttributedModel { AttributedProperty = "test" };
+        var formatter = CreateFormatter<AttributedModel>();
+        var body = formatter.EncodeBinaryModeEventData(cloudEvent);
+        var jobject = JsonEventFormatterTest.ParseJson(body);
 
-            new JTokenAsserter
+        new JTokenAsserter
             {
                 { AttributedModel.JsonPropertyName, JTokenType.String, "test" }
             }.AssertProperties(jobject, assertCount: true);
-        }
+    }
 
-        [Fact]
-        public void EncodeBinaryModeEventData_NoData()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            var formatter = CreateFormatter<AttributedModel>();
-            var bytes = formatter.EncodeBinaryModeEventData(cloudEvent);
-            Assert.True(bytes.IsEmpty);
-        }
+    [Fact]
+    public void EncodeBinaryModeEventData_NoData()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        var formatter = CreateFormatter<AttributedModel>();
+        var bytes = formatter.EncodeBinaryModeEventData(cloudEvent);
+        Assert.True(bytes.IsEmpty);
+    }
 
-        [Fact]
-        public void EncodeBinaryModeEventData_WrongType()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new OtherModelClass { Text = "Wrong type" };
-            var formatter = CreateFormatter<AttributedModel>();
-            Assert.Throws<InvalidCastException>(() => formatter.EncodeBinaryModeEventData(cloudEvent));
-        }
+    [Fact]
+    public void EncodeBinaryModeEventData_WrongType()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new OtherModelClass { Text = "Wrong type" };
+        var formatter = CreateFormatter<AttributedModel>();
+        Assert.Throws<InvalidCastException>(() => formatter.EncodeBinaryModeEventData(cloudEvent));
+    }
 
-        private static CloudEventFormatter CreateFormatter<T>()
-        {
-            var formatter = CloudEventFormatterAttribute.CreateFormatter(typeof(T));
-            Assert.NotNull(formatter);
-            return formatter!;
-        }
+    private static CloudEventFormatter CreateFormatter<T>()
+    {
+        var formatter = CloudEventFormatterAttribute.CreateFormatter(typeof(T));
+        Assert.NotNull(formatter);
+        return formatter!;
+    }
 
-        private class OtherModelClass
-        {
-            public string? Text { get; set; }
-        }
+    private class OtherModelClass
+    {
+        public string? Text { get; set; }
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/JTokenAsserter.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/JTokenAsserter.cs
@@ -8,38 +8,36 @@ using System.Collections;
 using System.Collections.Generic;
 using Xunit;
 
-namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
+namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests;
+
+internal class JTokenAsserter : IEnumerable
 {
+    private readonly List<(string name, JTokenType type, object? value)> expectations = new List<(string, JTokenType, object?)>();
 
-    internal class JTokenAsserter : IEnumerable
+    // Just for collection initializers
+    public IEnumerator GetEnumerator() => throw new NotImplementedException();
+
+    public void Add<T>(string name, JTokenType type, T value) =>
+        expectations.Add((name, type, value));
+
+    public void AssertProperties(JObject? obj, bool assertCount)
     {
-        private readonly List<(string name, JTokenType type, object? value)> expectations = new List<(string, JTokenType, object?)>();
-
-        // Just for collection initializers
-        public IEnumerator GetEnumerator() => throw new NotImplementedException();
-
-        public void Add<T>(string name, JTokenType type, T value) =>
-            expectations.Add((name, type, value));
-
-        public void AssertProperties(JObject? obj, bool assertCount)
+        Assert.NotNull(obj);
+        foreach (var expectation in expectations)
         {
-            Assert.NotNull(obj);
-            foreach (var expectation in expectations)
+            Assert.True(
+                obj!.TryGetValue(expectation.name, out var token),
+                $"Expected property '{expectation.name}' to be present");
+            Assert.Equal(expectation.type, token!.Type);
+            // No need to check null values, as they'll have a null token type.
+            if (expectation.value is object)
             {
-                Assert.True(
-                    obj!.TryGetValue(expectation.name, out var token),
-                    $"Expected property '{expectation.name}' to be present");
-                Assert.Equal(expectation.type, token!.Type);
-                // No need to check null values, as they'll have a null token type.
-                if (expectation.value is object)
-                {
-                    Assert.Equal(expectation.value, token.ToObject(expectation.value.GetType()));
-                }
+                Assert.Equal(expectation.value, token.ToObject(expectation.value.GetType()));
             }
-            if (assertCount)
-            {
-                Assert.Equal(expectations.Count, obj!.Count);
-            }
+        }
+        if (assertCount)
+        {
+            Assert.Equal(expectations.Count, obj!.Count);
         }
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/JsonEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/JsonEventFormatterTest.cs
@@ -15,37 +15,37 @@ using System.Threading.Tasks;
 using Xunit;
 using static CloudNative.CloudEvents.UnitTests.TestHelpers;
 
-namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
+namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests;
+
+public class JsonEventFormatterTest
 {
-    public class JsonEventFormatterTest
+    private static readonly ContentType s_jsonCloudEventContentType = new ContentType("application/cloudevents+json; charset=utf-8");
+    private static readonly ContentType s_jsonCloudEventBatchContentType = new ContentType("application/cloudevents-batch+json; charset=utf-8");
+    private const string NonAsciiValue = "GBP=\u00a3";
+
+    /// <summary>
+    /// A simple test that populates all known v1.0 attributes, so we don't need to test that
+    /// aspect in the future.
+    /// </summary>
+    [Fact]
+    public void EncodeStructuredModeMessage_V1Attributes()
     {
-        private static readonly ContentType s_jsonCloudEventContentType = new ContentType("application/cloudevents+json; charset=utf-8");
-        private static readonly ContentType s_jsonCloudEventBatchContentType = new ContentType("application/cloudevents-batch+json; charset=utf-8");
-        private const string NonAsciiValue = "GBP=\u00a3";
-
-        /// <summary>
-        /// A simple test that populates all known v1.0 attributes, so we don't need to test that
-        /// aspect in the future.
-        /// </summary>
-        [Fact]
-        public void EncodeStructuredModeMessage_V1Attributes()
+        var cloudEvent = new CloudEvent(CloudEventsSpecVersion.V1_0)
         {
-            var cloudEvent = new CloudEvent(CloudEventsSpecVersion.V1_0)
-            {
-                Data = "text", // Just so that it's reasonable to have a DataContentType
-                DataContentType = "text/plain",
-                DataSchema = new Uri("https://data-schema"),
-                Id = "event-id",
-                Source = new Uri("https://event-source"),
-                Subject = "event-subject",
-                Time = new DateTimeOffset(2021, 2, 19, 12, 34, 56, 789, TimeSpan.FromHours(1)),
-                Type = "event-type"
-            };
+            Data = "text", // Just so that it's reasonable to have a DataContentType
+            DataContentType = "text/plain",
+            DataSchema = new Uri("https://data-schema"),
+            Id = "event-id",
+            Source = new Uri("https://event-source"),
+            Subject = "event-subject",
+            Time = new DateTimeOffset(2021, 2, 19, 12, 34, 56, 789, TimeSpan.FromHours(1)),
+            Type = "event-type"
+        };
 
-            var encoded = new JsonEventFormatter().EncodeStructuredModeMessage(cloudEvent, out var contentType);
-            Assert.Equal("application/cloudevents+json; charset=utf-8", contentType.ToString());
-            JObject obj = ParseJson(encoded);
-            var asserter = new JTokenAsserter
+        var encoded = new JsonEventFormatter().EncodeStructuredModeMessage(cloudEvent, out var contentType);
+        Assert.Equal("application/cloudevents+json; charset=utf-8", contentType.ToString());
+        JObject obj = ParseJson(encoded);
+        var asserter = new JTokenAsserter
             {
                 { "data", JTokenType.String, "text" },
                 { "datacontenttype", JTokenType.String, "text/plain" },
@@ -57,27 +57,27 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
                 { "time", JTokenType.String, "2021-02-19T12:34:56.789+01:00" },
                 { "type", JTokenType.String, "event-type" },
             };
-            asserter.AssertProperties(obj, assertCount: true);
-        }
+        asserter.AssertProperties(obj, assertCount: true);
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_AllAttributeTypes()
+    [Fact]
+    public void EncodeStructuredModeMessage_AllAttributeTypes()
+    {
+        var cloudEvent = new CloudEvent(AllTypesExtensions)
         {
-            var cloudEvent = new CloudEvent(AllTypesExtensions)
-            {
-                ["binary"] = SampleBinaryData,
-                ["boolean"] = true,
-                ["integer"] = 10,
-                ["string"] = "text",
-                ["timestamp"] = SampleTimestamp,
-                ["uri"] = SampleUri,
-                ["urireference"] = SampleUriReference
-            };
-            // We're not going to check these.
-            cloudEvent.PopulateRequiredAttributes();
+            ["binary"] = SampleBinaryData,
+            ["boolean"] = true,
+            ["integer"] = 10,
+            ["string"] = "text",
+            ["timestamp"] = SampleTimestamp,
+            ["uri"] = SampleUri,
+            ["urireference"] = SampleUriReference
+        };
+        // We're not going to check these.
+        cloudEvent.PopulateRequiredAttributes();
 
-            JObject obj = EncodeAndParseStructured(cloudEvent);
-            var asserter = new JTokenAsserter
+        JObject obj = EncodeAndParseStructured(cloudEvent);
+        var asserter = new JTokenAsserter
             {
                 { "binary", JTokenType.String, SampleBinaryDataBase64 },
                 { "boolean", JTokenType.Boolean, true },
@@ -87,381 +87,381 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
                 { "uri", JTokenType.String, SampleUriText },
                 { "urireference", JTokenType.String, SampleUriReferenceText },
             };
-            asserter.AssertProperties(obj, assertCount: false);
-        }
+        asserter.AssertProperties(obj, assertCount: false);
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_JsonDataType_ObjectSerialization()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new { Text = "simple text" };
-            cloudEvent.DataContentType = "application/json";
-            JObject obj = EncodeAndParseStructured(cloudEvent);
-            JObject dataProperty = (JObject) obj["data"]!;
-            var asserter = new JTokenAsserter
+    [Fact]
+    public void EncodeStructuredModeMessage_JsonDataType_ObjectSerialization()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new { Text = "simple text" };
+        cloudEvent.DataContentType = "application/json";
+        JObject obj = EncodeAndParseStructured(cloudEvent);
+        JObject dataProperty = (JObject) obj["data"]!;
+        var asserter = new JTokenAsserter
             {
                 { "Text", JTokenType.String, "simple text" }
             };
-            asserter.AssertProperties(dataProperty, assertCount: true);
-        }
+        asserter.AssertProperties(dataProperty, assertCount: true);
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_JsonDataType_NumberSerialization()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = 10;
-            cloudEvent.DataContentType = "application/json";
-            JObject obj = EncodeAndParseStructured(cloudEvent);
-            var asserter = new JTokenAsserter
+    [Fact]
+    public void EncodeStructuredModeMessage_JsonDataType_NumberSerialization()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = 10;
+        cloudEvent.DataContentType = "application/json";
+        JObject obj = EncodeAndParseStructured(cloudEvent);
+        var asserter = new JTokenAsserter
             {
                 { "data", JTokenType.Integer, 10 }
             };
-            asserter.AssertProperties(obj, assertCount: false);
-        }
+        asserter.AssertProperties(obj, assertCount: false);
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_JsonDataType_CustomSerializer()
+    [Fact]
+    public void EncodeStructuredModeMessage_JsonDataType_CustomSerializer()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new { DateValue = new DateTime(2021, 2, 19, 12, 49, 34, DateTimeKind.Utc) };
+        cloudEvent.DataContentType = "application/json";
+
+        var serializer = new JsonSerializer
         {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new { DateValue = new DateTime(2021, 2, 19, 12, 49, 34, DateTimeKind.Utc) };
-            cloudEvent.DataContentType = "application/json";
-
-            var serializer = new JsonSerializer
-            {
-                DateFormatString = "yyyy-MM-dd"
-            };
-            var formatter = new JsonEventFormatter(serializer);
-            var encoded = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
-            JObject obj = ParseJson(encoded);
-            JObject dataProperty = (JObject) obj["data"]!;
-            var asserter = new JTokenAsserter
+            DateFormatString = "yyyy-MM-dd"
+        };
+        var formatter = new JsonEventFormatter(serializer);
+        var encoded = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
+        JObject obj = ParseJson(encoded);
+        JObject dataProperty = (JObject) obj["data"]!;
+        var asserter = new JTokenAsserter
             {
                 { "DateValue", JTokenType.String, "2021-02-19" }
             };
-            asserter.AssertProperties(dataProperty, assertCount: true);
-        }
+        asserter.AssertProperties(dataProperty, assertCount: true);
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_JsonDataType_AttributedModel()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new AttributedModel { AttributedProperty = "simple text" };
-            cloudEvent.DataContentType = "application/json";
-            JObject obj = EncodeAndParseStructured(cloudEvent);
-            JObject dataProperty = (JObject) obj["data"]!;
-            var asserter = new JTokenAsserter
+    [Fact]
+    public void EncodeStructuredModeMessage_JsonDataType_AttributedModel()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new AttributedModel { AttributedProperty = "simple text" };
+        cloudEvent.DataContentType = "application/json";
+        JObject obj = EncodeAndParseStructured(cloudEvent);
+        JObject dataProperty = (JObject) obj["data"]!;
+        var asserter = new JTokenAsserter
             {
                 { AttributedModel.JsonPropertyName, JTokenType.String, "simple text" }
             };
-            asserter.AssertProperties(dataProperty, assertCount: true);
-        }
+        asserter.AssertProperties(dataProperty, assertCount: true);
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_JsonDataType_JTokenObject()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new JObject { ["Key"] = "value" };
-            cloudEvent.DataContentType = "application/json";
-            JObject obj = EncodeAndParseStructured(cloudEvent);
-            JObject dataProperty = (JObject) obj["data"]!;
-            var asserter = new JTokenAsserter
+    [Fact]
+    public void EncodeStructuredModeMessage_JsonDataType_JTokenObject()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new JObject { ["Key"] = "value" };
+        cloudEvent.DataContentType = "application/json";
+        JObject obj = EncodeAndParseStructured(cloudEvent);
+        JObject dataProperty = (JObject) obj["data"]!;
+        var asserter = new JTokenAsserter
             {
                 { "Key", JTokenType.String, "value" }
             };
-            asserter.AssertProperties(dataProperty, assertCount: true);
-        }
+        asserter.AssertProperties(dataProperty, assertCount: true);
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_JsonDataType_JTokenString()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new JValue("text");
-            cloudEvent.DataContentType = "application/json";
-            JObject obj = EncodeAndParseStructured(cloudEvent);
-            JToken data = obj["data"]!;
-            Assert.Equal(JTokenType.String, data.Type);
-            Assert.Equal("text", (string) data!);
-        }
+    [Fact]
+    public void EncodeStructuredModeMessage_JsonDataType_JTokenString()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new JValue("text");
+        cloudEvent.DataContentType = "application/json";
+        JObject obj = EncodeAndParseStructured(cloudEvent);
+        JToken data = obj["data"]!;
+        Assert.Equal(JTokenType.String, data.Type);
+        Assert.Equal("text", (string) data!);
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_JsonDataType_JTokenNull()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new JValue((object?) null);
-            cloudEvent.DataContentType = "application/json";
-            JObject obj = EncodeAndParseStructured(cloudEvent);
-            JToken data = obj["data"]!;
-            Assert.Equal(JTokenType.Null, data.Type);
-        }
+    [Fact]
+    public void EncodeStructuredModeMessage_JsonDataType_JTokenNull()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new JValue((object?) null);
+        cloudEvent.DataContentType = "application/json";
+        JObject obj = EncodeAndParseStructured(cloudEvent);
+        JToken data = obj["data"]!;
+        Assert.Equal(JTokenType.Null, data.Type);
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_JsonDataType_JTokenNumeric()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new JValue(100);
-            cloudEvent.DataContentType = "application/json";
-            JObject obj = EncodeAndParseStructured(cloudEvent);
-            JToken data = obj["data"]!;
-            Assert.Equal(JTokenType.Integer, data.Type);
-            Assert.Equal(100, (int) data);
-        }
+    [Fact]
+    public void EncodeStructuredModeMessage_JsonDataType_JTokenNumeric()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new JValue(100);
+        cloudEvent.DataContentType = "application/json";
+        JObject obj = EncodeAndParseStructured(cloudEvent);
+        JToken data = obj["data"]!;
+        Assert.Equal(JTokenType.Integer, data.Type);
+        Assert.Equal(100, (int) data);
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_JsonDataType_NullValue()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = null;
-            cloudEvent.DataContentType = "application/json";
-            JObject obj = EncodeAndParseStructured(cloudEvent);
-            Assert.False(obj.ContainsKey("data"));
-        }
+    [Fact]
+    public void EncodeStructuredModeMessage_JsonDataType_NullValue()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = null;
+        cloudEvent.DataContentType = "application/json";
+        JObject obj = EncodeAndParseStructured(cloudEvent);
+        Assert.False(obj.ContainsKey("data"));
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_TextType_String()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = "some text";
-            cloudEvent.DataContentType = "text/anything";
-            JObject obj = EncodeAndParseStructured(cloudEvent);
-            var dataProperty = obj["data"]!;
-            Assert.Equal(JTokenType.String, dataProperty.Type);
-            Assert.Equal("some text", (string?) dataProperty);
-        }
+    [Fact]
+    public void EncodeStructuredModeMessage_TextType_String()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = "some text";
+        cloudEvent.DataContentType = "text/anything";
+        JObject obj = EncodeAndParseStructured(cloudEvent);
+        var dataProperty = obj["data"]!;
+        Assert.Equal(JTokenType.String, dataProperty.Type);
+        Assert.Equal("some text", (string?) dataProperty);
+    }
 
-        // A text content type with bytes as data is serialized like any other bytes.
-        [Fact]
-        public void EncodeStructuredModeMessage_TextType_Bytes()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = SampleBinaryData;
-            cloudEvent.DataContentType = "text/anything";
-            JObject obj = EncodeAndParseStructured(cloudEvent);
-            Assert.False(obj.ContainsKey("data"));
-            var dataBase64 = obj["data_base64"]!;
-            Assert.Equal(JTokenType.String, dataBase64.Type);
-            Assert.Equal(SampleBinaryDataBase64, (string?) dataBase64);
-        }
+    // A text content type with bytes as data is serialized like any other bytes.
+    [Fact]
+    public void EncodeStructuredModeMessage_TextType_Bytes()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = SampleBinaryData;
+        cloudEvent.DataContentType = "text/anything";
+        JObject obj = EncodeAndParseStructured(cloudEvent);
+        Assert.False(obj.ContainsKey("data"));
+        var dataBase64 = obj["data_base64"]!;
+        Assert.Equal(JTokenType.String, dataBase64.Type);
+        Assert.Equal(SampleBinaryDataBase64, (string?) dataBase64);
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_TextType_NotStringOrBytes()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new object();
-            cloudEvent.DataContentType = "text/anything";
-            var formatter = new JsonEventFormatter();
-            Assert.Throws<ArgumentException>(() => formatter.EncodeStructuredModeMessage(cloudEvent, out _));
-        }
+    [Fact]
+    public void EncodeStructuredModeMessage_TextType_NotStringOrBytes()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new object();
+        cloudEvent.DataContentType = "text/anything";
+        var formatter = new JsonEventFormatter();
+        Assert.Throws<ArgumentException>(() => formatter.EncodeStructuredModeMessage(cloudEvent, out _));
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_ArbitraryType_Bytes()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = SampleBinaryData;
-            cloudEvent.DataContentType = "not_text/or_json";
-            JObject obj = EncodeAndParseStructured(cloudEvent);
-            Assert.False(obj.ContainsKey("data"));
-            var dataBase64 = obj["data_base64"]!;
-            Assert.Equal(JTokenType.String, dataBase64.Type);
-            Assert.Equal(SampleBinaryDataBase64, (string?) dataBase64);
-        }
+    [Fact]
+    public void EncodeStructuredModeMessage_ArbitraryType_Bytes()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = SampleBinaryData;
+        cloudEvent.DataContentType = "not_text/or_json";
+        JObject obj = EncodeAndParseStructured(cloudEvent);
+        Assert.False(obj.ContainsKey("data"));
+        var dataBase64 = obj["data_base64"]!;
+        Assert.Equal(JTokenType.String, dataBase64.Type);
+        Assert.Equal(SampleBinaryDataBase64, (string?) dataBase64);
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_ArbitraryType_NotBytes()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new object();
-            cloudEvent.DataContentType = "not_text/or_json";
-            var formatter = new JsonEventFormatter();
-            Assert.Throws<ArgumentException>(() => formatter.EncodeStructuredModeMessage(cloudEvent, out _));
-        }
+    [Fact]
+    public void EncodeStructuredModeMessage_ArbitraryType_NotBytes()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new object();
+        cloudEvent.DataContentType = "not_text/or_json";
+        var formatter = new JsonEventFormatter();
+        Assert.Throws<ArgumentException>(() => formatter.EncodeStructuredModeMessage(cloudEvent, out _));
+    }
 
-        [Fact]
-        public void EncodeBinaryModeEventData_JsonDataType_ObjectSerialization()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new { Text = "simple text" };
-            cloudEvent.DataContentType = "application/json";
-            var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
-            JObject data = ParseJson(bytes);
-            var asserter = new JTokenAsserter
+    [Fact]
+    public void EncodeBinaryModeEventData_JsonDataType_ObjectSerialization()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new { Text = "simple text" };
+        cloudEvent.DataContentType = "application/json";
+        var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
+        JObject data = ParseJson(bytes);
+        var asserter = new JTokenAsserter
             {
                 { "Text", JTokenType.String, "simple text" }
             };
-            asserter.AssertProperties(data, assertCount: true);
-        }
+        asserter.AssertProperties(data, assertCount: true);
+    }
 
-        [Fact]
-        public void EncodeBinaryModeEventData_JsonDataType_CustomSerializer()
+    [Fact]
+    public void EncodeBinaryModeEventData_JsonDataType_CustomSerializer()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new { DateValue = new DateTime(2021, 2, 19, 12, 49, 34, DateTimeKind.Utc) };
+        cloudEvent.DataContentType = "application/json";
+
+        var serializer = new JsonSerializer
         {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new { DateValue = new DateTime(2021, 2, 19, 12, 49, 34, DateTimeKind.Utc) };
-            cloudEvent.DataContentType = "application/json";
-
-            var serializer = new JsonSerializer
-            {
-                DateFormatString = "yyyy-MM-dd"
-            };
-            var formatter = new JsonEventFormatter(serializer);
-            var bytes = formatter.EncodeBinaryModeEventData(cloudEvent);
-            JObject data = ParseJson(bytes);
-            var asserter = new JTokenAsserter
+            DateFormatString = "yyyy-MM-dd"
+        };
+        var formatter = new JsonEventFormatter(serializer);
+        var bytes = formatter.EncodeBinaryModeEventData(cloudEvent);
+        JObject data = ParseJson(bytes);
+        var asserter = new JTokenAsserter
             {
                 { "DateValue", JTokenType.String, "2021-02-19" }
             };
-            asserter.AssertProperties(data, assertCount: true);
-        }
+        asserter.AssertProperties(data, assertCount: true);
+    }
 
-        [Fact]
-        public void EncodeBinaryModeEventData_JsonDataType_AttributedModel()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new AttributedModel { AttributedProperty = "simple text" };
-            cloudEvent.DataContentType = "application/json";
-            var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
-            JObject data = ParseJson(bytes);
-            var asserter = new JTokenAsserter
+    [Fact]
+    public void EncodeBinaryModeEventData_JsonDataType_AttributedModel()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new AttributedModel { AttributedProperty = "simple text" };
+        cloudEvent.DataContentType = "application/json";
+        var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
+        JObject data = ParseJson(bytes);
+        var asserter = new JTokenAsserter
             {
                 { AttributedModel.JsonPropertyName, JTokenType.String, "simple text" }
             };
-            asserter.AssertProperties(data, assertCount: true);
-        }
+        asserter.AssertProperties(data, assertCount: true);
+    }
 
-        [Fact]
-        public void EncodeBinaryModeEventData_JsonDataType_JToken()
+    [Fact]
+    public void EncodeBinaryModeEventData_JsonDataType_JToken()
+    {
+        // This would definitely be an odd thing to do, admittedly...
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new JValue(100);
+        cloudEvent.DataContentType = "application/json";
+        var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
+        Assert.Equal("100", BinaryDataUtilities.GetString(bytes, Encoding.UTF8));
+    }
+
+    [Fact]
+    public void EncodeBinaryModeEventData_JsonDataType_NullValue()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = null;
+        cloudEvent.DataContentType = "application/json";
+        var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
+        Assert.True(bytes.IsEmpty);
+    }
+
+    [Fact]
+    public void EncodeBinaryModeEventData_TextType_String()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = "some text";
+        cloudEvent.DataContentType = "text/anything";
+        var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
+        Assert.Equal("some text", BinaryDataUtilities.GetString(bytes, Encoding.UTF8));
+    }
+
+    // A text content type with bytes as data is serialized like any other bytes.
+    [Fact]
+    public void EncodeBinaryModeEventData_TextType_Bytes()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = SampleBinaryData;
+        cloudEvent.DataContentType = "text/anything";
+        var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
+        Assert.Equal(SampleBinaryData, bytes);
+    }
+
+    [Fact]
+    public void EncodeBinaryModeEventData_TextType_NotStringOrBytes()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new object();
+        cloudEvent.DataContentType = "text/anything";
+        var formatter = new JsonEventFormatter();
+        Assert.Throws<ArgumentException>(() => formatter.EncodeBinaryModeEventData(cloudEvent));
+    }
+
+    [Fact]
+    public void EncodeBinaryModeEventData_ArbitraryType_Bytes()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = SampleBinaryData;
+        cloudEvent.DataContentType = "not_text/or_json";
+        var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
+        Assert.Equal(SampleBinaryData, bytes);
+    }
+
+    [Fact]
+    public void EncodeBinaryModeEventData_ArbitraryType_NotBytes()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new object();
+        cloudEvent.DataContentType = "not_text/or_json";
+        var formatter = new JsonEventFormatter();
+        Assert.Throws<ArgumentException>(() => formatter.EncodeBinaryModeEventData(cloudEvent));
+    }
+
+
+    [Fact]
+    public void EncodeBinaryModeEventData_NoContentType_ConvertsStringToJson()
+    {
+        var cloudEvent = new CloudEvent
         {
-            // This would definitely be an odd thing to do, admittedly...
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new JValue(100);
-            cloudEvent.DataContentType = "application/json";
-            var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
-            Assert.Equal("100", BinaryDataUtilities.GetString(bytes, Encoding.UTF8));
-        }
+            Data = "some text"
+        }.PopulateRequiredAttributes();
 
-        [Fact]
-        public void EncodeBinaryModeEventData_JsonDataType_NullValue()
+        // EncodeBinaryModeEventData doesn't actually populate the content type of the CloudEvent,
+        // but treat the data as if we'd explicitly specified application/json.
+        var data = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
+        string text = BinaryDataUtilities.GetString(data, Encoding.UTF8);
+        Assert.Equal("\"some text\"", text);
+    }
+
+    [Fact]
+    public void EncodeBinaryModeEventData_NoContentType_LeavesBinaryData()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = null;
-            cloudEvent.DataContentType = "application/json";
-            var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
-            Assert.True(bytes.IsEmpty);
-        }
+            Data = SampleBinaryData
+        }.PopulateRequiredAttributes();
 
-        [Fact]
-        public void EncodeBinaryModeEventData_TextType_String()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = "some text";
-            cloudEvent.DataContentType = "text/anything";
-            var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
-            Assert.Equal("some text", BinaryDataUtilities.GetString(bytes, Encoding.UTF8));
-        }
+        // EncodeBinaryModeEventData does *not* implicitly encode binary data as JSON.
+        var data = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
+        var array = BinaryDataUtilities.AsArray(data);
+        Assert.Equal(array, SampleBinaryData);
+    }
 
-        // A text content type with bytes as data is serialized like any other bytes.
-        [Fact]
-        public void EncodeBinaryModeEventData_TextType_Bytes()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = SampleBinaryData;
-            cloudEvent.DataContentType = "text/anything";
-            var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
-            Assert.Equal(SampleBinaryData, bytes);
-        }
+    // Note: batch mode testing is restricted to the batch aspects; we assume that the
+    // per-CloudEvent implementation is shared with structured mode, so we rely on
+    // structured mode testing for things like custom serialization.
 
-        [Fact]
-        public void EncodeBinaryModeEventData_TextType_NotStringOrBytes()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new object();
-            cloudEvent.DataContentType = "text/anything";
-            var formatter = new JsonEventFormatter();
-            Assert.Throws<ArgumentException>(() => formatter.EncodeBinaryModeEventData(cloudEvent));
-        }
+    [Fact]
+    public void EncodeBatchModeMessage_Empty()
+    {
+        var cloudEvents = new CloudEvent[0];
+        var formatter = new JsonEventFormatter();
+        var bytes = formatter.EncodeBatchModeMessage(cloudEvents, out var contentType);
+        Assert.Equal("application/cloudevents-batch+json; charset=utf-8", contentType.ToString());
+        var array = ParseJsonArray(bytes);
+        Assert.Empty(array);
+    }
 
-        [Fact]
-        public void EncodeBinaryModeEventData_ArbitraryType_Bytes()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = SampleBinaryData;
-            cloudEvent.DataContentType = "not_text/or_json";
-            var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
-            Assert.Equal(SampleBinaryData, bytes);
-        }
+    [Fact]
+    public void EncodeBatchModeMessage_TwoEvents()
+    {
+        var event1 = new CloudEvent().PopulateRequiredAttributes();
+        event1.Id = "event1";
+        event1.Data = "simple text";
+        event1.DataContentType = "text/plain";
 
-        [Fact]
-        public void EncodeBinaryModeEventData_ArbitraryType_NotBytes()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new object();
-            cloudEvent.DataContentType = "not_text/or_json";
-            var formatter = new JsonEventFormatter();
-            Assert.Throws<ArgumentException>(() => formatter.EncodeBinaryModeEventData(cloudEvent));
-        }
+        var event2 = new CloudEvent().PopulateRequiredAttributes();
+        event2.Id = "event2";
 
+        var cloudEvents = new[] { event1, event2 };
+        var formatter = new JsonEventFormatter();
+        var bytes = formatter.EncodeBatchModeMessage(cloudEvents, out var contentType);
+        Assert.Equal("application/cloudevents-batch+json; charset=utf-8", contentType.ToString());
+        var array = ParseJsonArray(bytes);
+        Assert.Equal(2, array.Count);
 
-        [Fact]
-        public void EncodeBinaryModeEventData_NoContentType_ConvertsStringToJson()
-        {
-            var cloudEvent = new CloudEvent
-            {
-                Data = "some text"
-            }.PopulateRequiredAttributes();
-
-            // EncodeBinaryModeEventData doesn't actually populate the content type of the CloudEvent,
-            // but treat the data as if we'd explicitly specified application/json.
-            var data = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
-            string text = BinaryDataUtilities.GetString(data, Encoding.UTF8);
-            Assert.Equal("\"some text\"", text);
-        }
-
-        [Fact]
-        public void EncodeBinaryModeEventData_NoContentType_LeavesBinaryData()
-        {
-            var cloudEvent = new CloudEvent
-            {
-                Data = SampleBinaryData
-            }.PopulateRequiredAttributes();
-
-            // EncodeBinaryModeEventData does *not* implicitly encode binary data as JSON.
-            var data = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
-            var array = BinaryDataUtilities.AsArray(data);
-            Assert.Equal(array, SampleBinaryData);
-        }
-
-        // Note: batch mode testing is restricted to the batch aspects; we assume that the
-        // per-CloudEvent implementation is shared with structured mode, so we rely on
-        // structured mode testing for things like custom serialization.
-
-        [Fact]
-        public void EncodeBatchModeMessage_Empty()
-        {
-            var cloudEvents = new CloudEvent[0];
-            var formatter = new JsonEventFormatter();
-            var bytes = formatter.EncodeBatchModeMessage(cloudEvents, out var contentType);
-            Assert.Equal("application/cloudevents-batch+json; charset=utf-8", contentType.ToString());
-            var array = ParseJsonArray(bytes);
-            Assert.Empty(array);
-        }
-
-        [Fact]
-        public void EncodeBatchModeMessage_TwoEvents()
-        {
-            var event1 = new CloudEvent().PopulateRequiredAttributes();
-            event1.Id = "event1";
-            event1.Data = "simple text";
-            event1.DataContentType = "text/plain";
-
-            var event2 = new CloudEvent().PopulateRequiredAttributes();
-            event2.Id = "event2";
-
-            var cloudEvents = new[] { event1, event2 };
-            var formatter = new JsonEventFormatter();
-            var bytes = formatter.EncodeBatchModeMessage(cloudEvents, out var contentType);
-            Assert.Equal("application/cloudevents-batch+json; charset=utf-8", contentType.ToString());
-            var array = ParseJsonArray(bytes);
-            Assert.Equal(2, array.Count);
-
-            var asserter1 = new JTokenAsserter
+        var asserter1 = new JTokenAsserter
             {
                 { "specversion", JTokenType.String, "1.0" },
                 { "id", JTokenType.String, event1.Id },
@@ -470,513 +470,513 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
                 { "data", JTokenType.String, "simple text" },
                 { "datacontenttype", JTokenType.String, event1.DataContentType }
             };
-            asserter1.AssertProperties((JObject) array[0], assertCount: true);
+        asserter1.AssertProperties((JObject) array[0], assertCount: true);
 
-            var asserter2 = new JTokenAsserter
+        var asserter2 = new JTokenAsserter
             {
                 { "specversion", JTokenType.String, "1.0" },
                 { "id", JTokenType.String, event2.Id },
                 { "type", JTokenType.String, event2.Type },
                 { "source", JTokenType.String, "//test" },
             };
-            asserter2.AssertProperties((JObject) array[1], assertCount: true);
-        }
+        asserter2.AssertProperties((JObject) array[1], assertCount: true);
+    }
 
-        [Fact]
-        public void EncodeBatchModeMessage_Invalid()
+    [Fact]
+    public void EncodeBatchModeMessage_Invalid()
+    {
+        var formatter = new JsonEventFormatter();
+        // Invalid CloudEvent
+        Assert.Throws<ArgumentException>(() => formatter.EncodeBatchModeMessage(new[] { new CloudEvent() }, out _));
+        // Null argument
+        Assert.Throws<ArgumentNullException>(() => formatter.EncodeBatchModeMessage(null!, out _));
+        // Null value within the argument. Arguably this should throw ArgumentException instead of
+        // ArgumentNullException, but it's unlikely to cause confusion.
+        Assert.Throws<ArgumentNullException>(() => formatter.EncodeBatchModeMessage(new CloudEvent[1], out _));
+    }
+
+    [Fact]
+    public void DecodeStructuredModeMessage_NotJson()
+    {
+        var formatter = new JsonEventFormatter();
+        Assert.Throws<JsonReaderException>(() => formatter.DecodeStructuredModeMessage(new byte[10], new ContentType("application/json"), null));
+    }
+
+    // Just a single test for the code that parses asynchronously... the guts are all the same.
+    [Fact]
+    public async Task DecodeStructuredModeMessageAsync_Minimal()
+    {
+        var obj = new JObject
         {
-            var formatter = new JsonEventFormatter();
-            // Invalid CloudEvent
-            Assert.Throws<ArgumentException>(() => formatter.EncodeBatchModeMessage(new[] { new CloudEvent() }, out _));
-            // Null argument
-            Assert.Throws<ArgumentNullException>(() => formatter.EncodeBatchModeMessage(null!, out _));
-            // Null value within the argument. Arguably this should throw ArgumentException instead of
-            // ArgumentNullException, but it's unlikely to cause confusion.
-            Assert.Throws<ArgumentNullException>(() => formatter.EncodeBatchModeMessage(new CloudEvent[1], out _));
-        }
+            ["specversion"] = "1.0",
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["source"] = SampleUriText,
+        };
+        byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
+        var stream = new MemoryStream(bytes);
+        var formatter = new JsonEventFormatter();
+        var cloudEvent = await formatter.DecodeStructuredModeMessageAsync(stream, s_jsonCloudEventContentType, null);
+        Assert.Equal("test-type", cloudEvent.Type);
+        Assert.Equal("test-id", cloudEvent.Id);
+        Assert.Equal(SampleUri, cloudEvent.Source);
+    }
 
-        [Fact]
-        public void DecodeStructuredModeMessage_NotJson()
+    [Fact]
+    public void DecodeStructuredModeMessage_Minimal()
+    {
+        var obj = new JObject
         {
-            var formatter = new JsonEventFormatter();
-            Assert.Throws<JsonReaderException>(() => formatter.DecodeStructuredModeMessage(new byte[10], new ContentType("application/json"), null));
-        }
+            ["specversion"] = "1.0",
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["source"] = SampleUriText,
+        };
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Equal("test-type", cloudEvent.Type);
+        Assert.Equal("test-id", cloudEvent.Id);
+        Assert.Equal(SampleUri, cloudEvent.Source);
+    }
 
-        // Just a single test for the code that parses asynchronously... the guts are all the same.
-        [Fact]
-        public async Task DecodeStructuredModeMessageAsync_Minimal()
+    [Fact]
+    public void DecodeStructuredModeMessage_NoSpecVersion()
+    {
+        var obj = new JObject
         {
-            var obj = new JObject
-            {
-                ["specversion"] = "1.0",
-                ["type"] = "test-type",
-                ["id"] = "test-id",
-                ["source"] = SampleUriText,
-            };
-            byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
-            var stream = new MemoryStream(bytes);
-            var formatter = new JsonEventFormatter();
-            var cloudEvent = await formatter.DecodeStructuredModeMessageAsync(stream, s_jsonCloudEventContentType, null);
-            Assert.Equal("test-type", cloudEvent.Type);
-            Assert.Equal("test-id", cloudEvent.Id);
-            Assert.Equal(SampleUri, cloudEvent.Source);
-        }
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["source"] = SampleUriText,
+        };
+        Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
+    }
 
-        [Fact]
-        public void DecodeStructuredModeMessage_Minimal()
+    [Fact]
+    public void DecodeStructuredModeMessage_UnknownSpecVersion()
+    {
+        var obj = new JObject
         {
-            var obj = new JObject
-            {
-                ["specversion"] = "1.0",
-                ["type"] = "test-type",
-                ["id"] = "test-id",
-                ["source"] = SampleUriText,
-            };
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Equal("test-type", cloudEvent.Type);
-            Assert.Equal("test-id", cloudEvent.Id);
-            Assert.Equal(SampleUri, cloudEvent.Source);
-        }
+            ["specversion"] = "0.5",
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["source"] = SampleUriText,
+        };
+        Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
+    }
 
-        [Fact]
-        public void DecodeStructuredModeMessage_NoSpecVersion()
+    [Fact]
+    public void DecodeStructuredModeMessage_MissingRequiredAttributes()
+    {
+        var obj = new JObject
         {
-            var obj = new JObject
-            {
-                ["type"] = "test-type",
-                ["id"] = "test-id",
-                ["source"] = SampleUriText,
-            };
-            Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
-        }
+            ["specversion"] = "1.0",
+            ["type"] = "test-type",
+            ["id"] = "test-id"
+            // Source is missing
+        };
+        Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
+    }
 
-        [Fact]
-        public void DecodeStructuredModeMessage_UnknownSpecVersion()
+    [Fact]
+    public void DecodeStructuredModeMessage_SpecVersionNotString()
+    {
+        var obj = new JObject
         {
-            var obj = new JObject
-            {
-                ["specversion"] = "0.5",
-                ["type"] = "test-type",
-                ["id"] = "test-id",
-                ["source"] = SampleUriText,
-            };
-            Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
-        }
+            ["specversion"] = 1,
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["source"] = SampleUriText,
+        };
+        Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
+    }
 
-        [Fact]
-        public void DecodeStructuredModeMessage_MissingRequiredAttributes()
+    [Fact]
+    public void DecodeStructuredModeMessage_TypeNotString()
+    {
+        var obj = new JObject
         {
-            var obj = new JObject
-            {
-                ["specversion"] = "1.0",
-                ["type"] = "test-type",
-                ["id"] = "test-id"
-                // Source is missing
-            };
-            Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
-        }
+            ["specversion"] = "1.0",
+            ["type"] = 1,
+            ["id"] = "test-id",
+            ["source"] = SampleUriText,
+        };
+        Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
+    }
 
-        [Fact]
-        public void DecodeStructuredModeMessage_SpecVersionNotString()
+    [Fact]
+    public void DecodeStructuredModeMessage_V1Attributes()
+    {
+        var obj = new JObject
         {
-            var obj = new JObject
-            {
-                ["specversion"] = 1,
-                ["type"] = "test-type",
-                ["id"] = "test-id",
-                ["source"] = SampleUriText,
-            };
-            Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
-        }
+            ["specversion"] = "1.0",
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["data"] = "text", // Just so that it's reasonable to have a DataContentType,
+            ["datacontenttype"] = "text/plain",
+            ["dataschema"] = "https://data-schema",
+            ["subject"] = "event-subject",
+            ["source"] = "//event-source",
+            ["time"] = SampleTimestampText
+        };
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
+        Assert.Equal("test-type", cloudEvent.Type);
+        Assert.Equal("test-id", cloudEvent.Id);
+        Assert.Equal("text/plain", cloudEvent.DataContentType);
+        Assert.Equal(new Uri("https://data-schema"), cloudEvent.DataSchema);
+        Assert.Equal("event-subject", cloudEvent.Subject);
+        Assert.Equal(new Uri("//event-source", UriKind.RelativeOrAbsolute), cloudEvent.Source);
+        AssertTimestampsEqual(SampleTimestamp, cloudEvent.Time);
+    }
 
-        [Fact]
-        public void DecodeStructuredModeMessage_TypeNotString()
+    [Fact]
+    public void DecodeStructuredModeMessage_AllAttributeTypes()
+    {
+        var obj = new JObject
         {
-            var obj = new JObject
-            {
-                ["specversion"] = "1.0",
-                ["type"] = 1,
-                ["id"] = "test-id",
-                ["source"] = SampleUriText,
-            };
-            Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
-        }
+            // Required attributes
+            ["specversion"] = "1.0",
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["source"] = "//source",
+            // Extension attributes
+            ["binary"] = SampleBinaryDataBase64,
+            ["boolean"] = true,
+            ["integer"] = 10,
+            ["string"] = "text",
+            ["timestamp"] = SampleTimestampText,
+            ["uri"] = SampleUriText,
+            ["urireference"] = SampleUriReferenceText
+        };
 
-        [Fact]
-        public void DecodeStructuredModeMessage_V1Attributes()
+        byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
+        var formatter = new JsonEventFormatter();
+        var cloudEvent = formatter.DecodeStructuredModeMessage(bytes, s_jsonCloudEventContentType, AllTypesExtensions);
+        Assert.Equal(SampleBinaryData, cloudEvent["binary"]);
+        Assert.True((bool) cloudEvent["boolean"]!);
+        Assert.Equal(10, cloudEvent["integer"]);
+        Assert.Equal("text", cloudEvent["string"]);
+        AssertTimestampsEqual(SampleTimestamp, (DateTimeOffset) cloudEvent["timestamp"]!);
+        Assert.Equal(SampleUri, cloudEvent["uri"]);
+        Assert.Equal(SampleUriReference, cloudEvent["urireference"]);
+    }
+
+    [Fact]
+    public void DecodeStructuredModeMessage_IncorrectExtensionTypeWithValidValue()
+    {
+        var obj = new JObject
         {
-            var obj = new JObject
-            {
-                ["specversion"] = "1.0",
-                ["type"] = "test-type",
-                ["id"] = "test-id",
-                ["data"] = "text", // Just so that it's reasonable to have a DataContentType,
-                ["datacontenttype"] = "text/plain",
-                ["dataschema"] = "https://data-schema",
-                ["subject"] = "event-subject",
-                ["source"] = "//event-source",
-                ["time"] = SampleTimestampText
-            };
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
-            Assert.Equal("test-type", cloudEvent.Type);
-            Assert.Equal("test-id", cloudEvent.Id);
-            Assert.Equal("text/plain", cloudEvent.DataContentType);
-            Assert.Equal(new Uri("https://data-schema"), cloudEvent.DataSchema);
-            Assert.Equal("event-subject", cloudEvent.Subject);
-            Assert.Equal(new Uri("//event-source", UriKind.RelativeOrAbsolute), cloudEvent.Source);
-            AssertTimestampsEqual(SampleTimestamp, cloudEvent.Time);
-        }
+            ["specversion"] = "1.0",
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["source"] = "//source",
+            // Incorrect type, but is a valid value for the extension
+            ["integer"] = "10",
+        };
+        // Decode the event, providing the extension with the correct type.
+        byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
+        var formatter = new JsonEventFormatter();
+        var cloudEvent = formatter.DecodeStructuredModeMessage(bytes, s_jsonCloudEventContentType, AllTypesExtensions);
 
-        [Fact]
-        public void DecodeStructuredModeMessage_AllAttributeTypes()
+        // The value will have been decoded according to the extension.
+        Assert.Equal(10, cloudEvent["integer"]);
+    }
+
+    // There are other invalid token types as well; this is just one of them.
+    [Fact]
+    public void DecodeStructuredModeMessage_AttributeValueAsArrayToken()
+    {
+        var obj = CreateMinimalValidJObject();
+        obj["attr"] = new JArray();
+        Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
+    }
+
+    [Fact]
+    public void DecodeStructuredModeMessage_Null()
+    {
+        var obj = CreateMinimalValidJObject();
+        obj["attr"] = JValue.CreateNull();
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        // The JSON event format spec demands that we ignore null values, so we shouldn't
+        // have created an extension attribute.
+        Assert.Null(cloudEvent.GetAttribute("attr"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("application/json")]
+    [InlineData("text/plain")]
+    [InlineData("application/binary")]
+    public void DecodeStructuredModeMessage_NoData(string? contentType)
+    {
+        var obj = CreateMinimalValidJObject();
+        if (contentType is object)
         {
-            var obj = new JObject
-            {
-                // Required attributes
-                ["specversion"] = "1.0",
-                ["type"] = "test-type",
-                ["id"] = "test-id",
-                ["source"] = "//source",
-                // Extension attributes
-                ["binary"] = SampleBinaryDataBase64,
-                ["boolean"] = true,
-                ["integer"] = 10,
-                ["string"] = "text",
-                ["timestamp"] = SampleTimestampText,
-                ["uri"] = SampleUriText,
-                ["urireference"] = SampleUriReferenceText
-            };
-
-            byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
-            var formatter = new JsonEventFormatter();
-            var cloudEvent = formatter.DecodeStructuredModeMessage(bytes, s_jsonCloudEventContentType, AllTypesExtensions);
-            Assert.Equal(SampleBinaryData, cloudEvent["binary"]);
-            Assert.True((bool) cloudEvent["boolean"]!);
-            Assert.Equal(10, cloudEvent["integer"]);
-            Assert.Equal("text", cloudEvent["string"]);
-            AssertTimestampsEqual(SampleTimestamp, (DateTimeOffset) cloudEvent["timestamp"]!);
-            Assert.Equal(SampleUri, cloudEvent["uri"]);
-            Assert.Equal(SampleUriReference, cloudEvent["urireference"]);
-        }
-
-        [Fact]
-        public void DecodeStructuredModeMessage_IncorrectExtensionTypeWithValidValue()
-        {
-            var obj = new JObject
-            {
-                ["specversion"] = "1.0",
-                ["type"] = "test-type",
-                ["id"] = "test-id",
-                ["source"] = "//source",
-                // Incorrect type, but is a valid value for the extension
-                ["integer"] = "10",
-            };
-            // Decode the event, providing the extension with the correct type.
-            byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
-            var formatter = new JsonEventFormatter();
-            var cloudEvent = formatter.DecodeStructuredModeMessage(bytes, s_jsonCloudEventContentType, AllTypesExtensions);
-
-            // The value will have been decoded according to the extension.
-            Assert.Equal(10, cloudEvent["integer"]);
-        }
-
-        // There are other invalid token types as well; this is just one of them.
-        [Fact]
-        public void DecodeStructuredModeMessage_AttributeValueAsArrayToken()
-        {
-            var obj = CreateMinimalValidJObject();
-            obj["attr"] = new JArray();
-            Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
-        }
-
-        [Fact]
-        public void DecodeStructuredModeMessage_Null()
-        {
-            var obj = CreateMinimalValidJObject();
-            obj["attr"] = JValue.CreateNull();
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            // The JSON event format spec demands that we ignore null values, so we shouldn't
-            // have created an extension attribute.
-            Assert.Null(cloudEvent.GetAttribute("attr"));
-        }
-
-        [Theory]
-        [InlineData(null)]
-        [InlineData("application/json")]
-        [InlineData("text/plain")]
-        [InlineData("application/binary")]
-        public void DecodeStructuredModeMessage_NoData(string? contentType)
-        {
-            var obj = CreateMinimalValidJObject();
-            if (contentType is object)
-            {
-                obj["datacontenttype"] = contentType;
-            }
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Null(cloudEvent.Data);
-        }
-
-        [Fact]
-        public void DecodeStructuredModeMessage_BothDataAndDataBase64()
-        {
-            var obj = CreateMinimalValidJObject();
-            obj["data"] = "text";
-            obj["data_base64"] = SampleBinaryDataBase64;
-            Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
-        }
-
-        [Fact]
-        public void DecodeStructuredModeMessage_DataBase64NonString()
-        {
-            var obj = CreateMinimalValidJObject();
-            obj["data_base64"] = 10;
-            Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
-        }
-
-        // data_base64 always ends up as bytes, regardless of content type.
-        [Theory]
-        [InlineData(null)]
-        [InlineData("application/json")]
-        [InlineData("text/plain")]
-        [InlineData("application/binary")]
-        public void DecodeStructuredModeMessage_Base64(string? contentType)
-        {
-            var obj = CreateMinimalValidJObject();
-            if (contentType is object)
-            {
-                obj["datacontenttype"] = contentType;
-            }
-            obj["data_base64"] = SampleBinaryDataBase64;
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Equal(SampleBinaryData, cloudEvent.Data);
-        }
-
-        [Theory]
-        [InlineData("text/plain")]
-        [InlineData("image/png")]
-        public void DecodeStructuredModeMessage_NonJsonContentType_JsonStringToken(string contentType)
-        {
-            var obj = CreateMinimalValidJObject();
             obj["datacontenttype"] = contentType;
-            obj["data"] = "some text";
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Equal("some text", cloudEvent.Data);
         }
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Null(cloudEvent.Data);
+    }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("application/json")]
-        [InlineData("application/json; charset=utf-8")]
-        public void DecodeStructuredModeMessage_JsonContentType_JsonStringToken(string? contentType)
+    [Fact]
+    public void DecodeStructuredModeMessage_BothDataAndDataBase64()
+    {
+        var obj = CreateMinimalValidJObject();
+        obj["data"] = "text";
+        obj["data_base64"] = SampleBinaryDataBase64;
+        Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
+    }
+
+    [Fact]
+    public void DecodeStructuredModeMessage_DataBase64NonString()
+    {
+        var obj = CreateMinimalValidJObject();
+        obj["data_base64"] = 10;
+        Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
+    }
+
+    // data_base64 always ends up as bytes, regardless of content type.
+    [Theory]
+    [InlineData(null)]
+    [InlineData("application/json")]
+    [InlineData("text/plain")]
+    [InlineData("application/binary")]
+    public void DecodeStructuredModeMessage_Base64(string? contentType)
+    {
+        var obj = CreateMinimalValidJObject();
+        if (contentType is object)
         {
-            var obj = CreateMinimalValidJObject();
-            if (contentType is object)
-            {
-                obj["datacontenttype"] = contentType;
-            }
-            obj["data"] = "text";
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            var token = (JToken) cloudEvent.Data!;
-            Assert.Equal(JTokenType.String, token!.Type);
-            Assert.Equal("text", (string) token!);
+            obj["datacontenttype"] = contentType;
         }
+        obj["data_base64"] = SampleBinaryDataBase64;
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Equal(SampleBinaryData, cloudEvent.Data);
+    }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("application/json")]
-        [InlineData("application/xyz+json")]
-        [InlineData("application/xyz+json; charset=utf-8")]
-        public void DecodeStructuredModeMessage_JsonContentType_NonStringValue(string? contentType)
+    [Theory]
+    [InlineData("text/plain")]
+    [InlineData("image/png")]
+    public void DecodeStructuredModeMessage_NonJsonContentType_JsonStringToken(string contentType)
+    {
+        var obj = CreateMinimalValidJObject();
+        obj["datacontenttype"] = contentType;
+        obj["data"] = "some text";
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Equal("some text", cloudEvent.Data);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("application/json")]
+    [InlineData("application/json; charset=utf-8")]
+    public void DecodeStructuredModeMessage_JsonContentType_JsonStringToken(string? contentType)
+    {
+        var obj = CreateMinimalValidJObject();
+        if (contentType is object)
         {
-            var obj = CreateMinimalValidJObject();
-            if (contentType is object)
-            {
-                obj["datacontenttype"] = contentType;
-            }
-            obj["data"] = 10;
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            var token = (JToken) cloudEvent.Data!;
-            Assert.Equal(JTokenType.Integer, token!.Type);
-            Assert.Equal(10, (int) token);
+            obj["datacontenttype"] = contentType;
         }
+        obj["data"] = "text";
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        var token = (JToken) cloudEvent.Data!;
+        Assert.Equal(JTokenType.String, token!.Type);
+        Assert.Equal("text", (string) token!);
+    }
 
-        [Fact]
-        public void DecodeStructuredModeMessage_NonJsonContentType_NonStringValue()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("application/json")]
+    [InlineData("application/xyz+json")]
+    [InlineData("application/xyz+json; charset=utf-8")]
+    public void DecodeStructuredModeMessage_JsonContentType_NonStringValue(string? contentType)
+    {
+        var obj = CreateMinimalValidJObject();
+        if (contentType is object)
         {
-            var obj = CreateMinimalValidJObject();
-            obj["datacontenttype"] = "text/plain";
-            obj["data"] = 10;
-            Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
+            obj["datacontenttype"] = contentType;
         }
+        obj["data"] = 10;
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        var token = (JToken) cloudEvent.Data!;
+        Assert.Equal(JTokenType.Integer, token!.Type);
+        Assert.Equal(10, (int) token);
+    }
 
-        [Fact]
-        public void DecodeStructuredModeMessage_NullDataBase64Ignored()
-        {
-            var obj = CreateMinimalValidJObject();
-            obj["data_base64"] = JValue.CreateNull();
-            obj["data"] = "some text";
-            obj["datacontenttype"] = "text/plain";
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Equal("some text", cloudEvent.Data);
-        }
+    [Fact]
+    public void DecodeStructuredModeMessage_NonJsonContentType_NonStringValue()
+    {
+        var obj = CreateMinimalValidJObject();
+        obj["datacontenttype"] = "text/plain";
+        obj["data"] = 10;
+        Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
+    }
 
-        [Fact]
-        public void DecodeStructuredModeMessage_NullDataIgnored()
-        {
-            var obj = CreateMinimalValidJObject();
-            obj["data_base64"] = SampleBinaryDataBase64;
-            obj["data"] = JValue.CreateNull();
-            obj["datacontenttype"] = "application/binary";
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Equal(SampleBinaryData, cloudEvent.Data);
-        }
+    [Fact]
+    public void DecodeStructuredModeMessage_NullDataBase64Ignored()
+    {
+        var obj = CreateMinimalValidJObject();
+        obj["data_base64"] = JValue.CreateNull();
+        obj["data"] = "some text";
+        obj["datacontenttype"] = "text/plain";
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Equal("some text", cloudEvent.Data);
+    }
 
-        [Fact]
-        public void DecodeBinaryModeEventData_EmptyData_JsonContentType()
-        {
-            var data = DecodeBinaryModeEventData(new byte[0], "application/json");
-            Assert.Null(data);
-        }
+    [Fact]
+    public void DecodeStructuredModeMessage_NullDataIgnored()
+    {
+        var obj = CreateMinimalValidJObject();
+        obj["data_base64"] = SampleBinaryDataBase64;
+        obj["data"] = JValue.CreateNull();
+        obj["datacontenttype"] = "application/binary";
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Equal(SampleBinaryData, cloudEvent.Data);
+    }
 
-        [Fact]
-        public void DecodeBinaryModeEventData_EmptyData_TextContentType()
-        {
-            var data = DecodeBinaryModeEventData(new byte[0], "text/plain");
-            var text = Assert.IsType<string>(data);
-            Assert.Equal("", text);
-        }
+    [Fact]
+    public void DecodeBinaryModeEventData_EmptyData_JsonContentType()
+    {
+        var data = DecodeBinaryModeEventData(new byte[0], "application/json");
+        Assert.Null(data);
+    }
 
-        [Fact]
-        public void DecodeBinaryModeEventData_EmptyData_OtherContentType()
-        {
-            var data = DecodeBinaryModeEventData(new byte[0], "application/binary");
-            var byteArray = Assert.IsType<byte[]>(data);
-            Assert.Empty(byteArray);
-        }
+    [Fact]
+    public void DecodeBinaryModeEventData_EmptyData_TextContentType()
+    {
+        var data = DecodeBinaryModeEventData(new byte[0], "text/plain");
+        var text = Assert.IsType<string>(data);
+        Assert.Equal("", text);
+    }
 
-        [Theory]
-        [InlineData("utf-8")]
-        [InlineData("iso-8859-1")]
-        public void DecodeBinaryModeEventData_Json(string charset)
-        {
-            var encoding = Encoding.GetEncoding(charset);
-            var bytes = encoding.GetBytes(new JObject { ["test"] = NonAsciiValue }.ToString());
-            var data = DecodeBinaryModeEventData(bytes, $"application/json; charset={charset}");
-            var obj = Assert.IsType<JObject>(data);
-            var asserter = new JTokenAsserter
+    [Fact]
+    public void DecodeBinaryModeEventData_EmptyData_OtherContentType()
+    {
+        var data = DecodeBinaryModeEventData(new byte[0], "application/binary");
+        var byteArray = Assert.IsType<byte[]>(data);
+        Assert.Empty(byteArray);
+    }
+
+    [Theory]
+    [InlineData("utf-8")]
+    [InlineData("iso-8859-1")]
+    public void DecodeBinaryModeEventData_Json(string charset)
+    {
+        var encoding = Encoding.GetEncoding(charset);
+        var bytes = encoding.GetBytes(new JObject { ["test"] = NonAsciiValue }.ToString());
+        var data = DecodeBinaryModeEventData(bytes, $"application/json; charset={charset}");
+        var obj = Assert.IsType<JObject>(data);
+        var asserter = new JTokenAsserter
             {
                 { "test", JTokenType.String, NonAsciiValue }
             };
-            asserter.AssertProperties(obj, assertCount: true);
-        }
+        asserter.AssertProperties(obj, assertCount: true);
+    }
 
-        [Theory]
-        [InlineData("utf-8")]
-        [InlineData("iso-8859-1")]
-        public void DecodeBinaryModeEventData_JsonString(string charset)
+    [Theory]
+    [InlineData("utf-8")]
+    [InlineData("iso-8859-1")]
+    public void DecodeBinaryModeEventData_JsonString(string charset)
+    {
+        var encoding = Encoding.GetEncoding(charset);
+        var bytes = encoding.GetBytes("\"text\"");
+        var data = DecodeBinaryModeEventData(bytes, $"application/json; charset={charset}");
+        var obj = Assert.IsType<JValue>(data);
+        Assert.Equal(JTokenType.String, obj.Type);
+        Assert.Equal("text", (string) obj!);
+    }
+
+    [Theory]
+    [InlineData("utf-8")]
+    [InlineData("iso-8859-1")]
+    public void DecodeBinaryModeEventData_JsonNonString(string charset)
+    {
+        var encoding = Encoding.GetEncoding(charset);
+        var bytes = encoding.GetBytes("15");
+        var data = DecodeBinaryModeEventData(bytes, $"application/json; charset={charset}");
+        var obj = Assert.IsType<JValue>(data);
+        Assert.Equal(JTokenType.Integer, obj.Type);
+        Assert.Equal(15, (int) obj);
+    }
+
+    [Theory]
+    [InlineData("utf-8")]
+    [InlineData("iso-8859-1")]
+    public void DecodeBinaryModeEventData_Text(string charset)
+    {
+        var encoding = Encoding.GetEncoding(charset);
+        var bytes = encoding.GetBytes(NonAsciiValue);
+        var data = DecodeBinaryModeEventData(bytes, $"text/plain; charset={charset}");
+        var text = Assert.IsType<string>(data);
+        Assert.Equal(NonAsciiValue, text);
+    }
+
+    [Fact]
+    public void DecodeBinaryModeEventData_Binary()
+    {
+        byte[] bytes = { 0, 1, 2, 3 };
+        var data = DecodeBinaryModeEventData(bytes, "application/binary");
+        Assert.Equal(bytes, data);
+    }
+
+    [Fact]
+    public void DecodeBatchMode_NotArray()
+    {
+        var formatter = new JsonEventFormatter();
+        var data = Encoding.UTF8.GetBytes(CreateMinimalValidJObject().ToString());
+        Assert.Throws<JsonReaderException>(() => formatter.DecodeBatchModeMessage(data, s_jsonCloudEventBatchContentType, extensionAttributes: null));
+    }
+
+    [Fact]
+    public void DecodeBatchMode_ArrayContainingNonObject()
+    {
+        var formatter = new JsonEventFormatter();
+        var array = new JArray { CreateMinimalValidJObject(), "text" };
+        var data = Encoding.UTF8.GetBytes(array.ToString());
+        Assert.Throws<ArgumentException>(() => formatter.DecodeBatchModeMessage(data, s_jsonCloudEventBatchContentType, extensionAttributes: null));
+    }
+
+    [Fact]
+    public void DecodeBatchMode_Empty()
+    {
+        var cloudEvents = DecodeBatchModeMessage(new JArray());
+        Assert.Empty(cloudEvents);
+    }
+
+    [Fact]
+    public void DecodeBatchMode_Minimal()
+    {
+        var cloudEvents = DecodeBatchModeMessage(new JArray { CreateMinimalValidJObject() });
+        var cloudEvent = Assert.Single(cloudEvents);
+        Assert.Equal("event-type", cloudEvent.Type);
+        Assert.Equal("event-id", cloudEvent.Id);
+        Assert.Equal(new Uri("//event-source", UriKind.RelativeOrAbsolute), cloudEvent.Source);
+    }
+
+    // Just a single test for the code that parses asynchronously... the guts are all the same.
+    [Fact]
+    public async Task DecodeBatchModeMessageAsync_Minimal()
+    {
+        var obj = new JObject
         {
-            var encoding = Encoding.GetEncoding(charset);
-            var bytes = encoding.GetBytes("\"text\"");
-            var data = DecodeBinaryModeEventData(bytes, $"application/json; charset={charset}");
-            var obj = Assert.IsType<JValue>(data);
-            Assert.Equal(JTokenType.String, obj.Type);
-            Assert.Equal("text", (string) obj!);
-        }
-
-        [Theory]
-        [InlineData("utf-8")]
-        [InlineData("iso-8859-1")]
-        public void DecodeBinaryModeEventData_JsonNonString(string charset)
-        {
-            var encoding = Encoding.GetEncoding(charset);
-            var bytes = encoding.GetBytes("15");
-            var data = DecodeBinaryModeEventData(bytes, $"application/json; charset={charset}");
-            var obj = Assert.IsType<JValue>(data);
-            Assert.Equal(JTokenType.Integer, obj.Type);
-            Assert.Equal(15, (int) obj);
-        }
-
-        [Theory]
-        [InlineData("utf-8")]
-        [InlineData("iso-8859-1")]
-        public void DecodeBinaryModeEventData_Text(string charset)
-        {
-            var encoding = Encoding.GetEncoding(charset);
-            var bytes = encoding.GetBytes(NonAsciiValue);
-            var data = DecodeBinaryModeEventData(bytes, $"text/plain; charset={charset}");
-            var text = Assert.IsType<string>(data);
-            Assert.Equal(NonAsciiValue, text);
-        }
-
-        [Fact]
-        public void DecodeBinaryModeEventData_Binary()
-        {
-            byte[] bytes = { 0, 1, 2, 3 };
-            var data = DecodeBinaryModeEventData(bytes, "application/binary");
-            Assert.Equal(bytes, data);
-        }
-
-        [Fact]
-        public void DecodeBatchMode_NotArray()
-        {
-            var formatter = new JsonEventFormatter();
-            var data = Encoding.UTF8.GetBytes(CreateMinimalValidJObject().ToString());
-            Assert.Throws<JsonReaderException>(() => formatter.DecodeBatchModeMessage(data, s_jsonCloudEventBatchContentType, extensionAttributes: null));
-        }
-
-        [Fact]
-        public void DecodeBatchMode_ArrayContainingNonObject()
-        {
-            var formatter = new JsonEventFormatter();
-            var array = new JArray { CreateMinimalValidJObject(), "text" };
-            var data = Encoding.UTF8.GetBytes(array.ToString());
-            Assert.Throws<ArgumentException>(() => formatter.DecodeBatchModeMessage(data, s_jsonCloudEventBatchContentType, extensionAttributes: null));
-        }
-
-        [Fact]
-        public void DecodeBatchMode_Empty()
-        {
-            var cloudEvents = DecodeBatchModeMessage(new JArray());
-            Assert.Empty(cloudEvents);
-        }
-
-        [Fact]
-        public void DecodeBatchMode_Minimal()
-        {
-            var cloudEvents = DecodeBatchModeMessage(new JArray { CreateMinimalValidJObject() });
-            var cloudEvent = Assert.Single(cloudEvents);
-            Assert.Equal("event-type", cloudEvent.Type);
-            Assert.Equal("event-id", cloudEvent.Id);
-            Assert.Equal(new Uri("//event-source", UriKind.RelativeOrAbsolute), cloudEvent.Source);
-        }
-
-        // Just a single test for the code that parses asynchronously... the guts are all the same.
-        [Fact]
-        public async Task DecodeBatchModeMessageAsync_Minimal()
-        {
-            var obj = new JObject
-            {
-                ["specversion"] = "1.0",
-                ["type"] = "test-type",
-                ["id"] = "test-id",
-                ["source"] = SampleUriText,
-            };
-            byte[] bytes = Encoding.UTF8.GetBytes(new JArray { obj }.ToString());
-            var stream = new MemoryStream(bytes);
-            var formatter = new JsonEventFormatter();
-            var cloudEvents = await formatter.DecodeBatchModeMessageAsync(stream, s_jsonCloudEventBatchContentType, null);
-            var cloudEvent = Assert.Single(cloudEvents);
-            Assert.Equal("test-type", cloudEvent.Type);
-            Assert.Equal("test-id", cloudEvent.Id);
-            Assert.Equal(SampleUri, cloudEvent.Source);
-        }
+            ["specversion"] = "1.0",
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["source"] = SampleUriText,
+        };
+        byte[] bytes = Encoding.UTF8.GetBytes(new JArray { obj }.ToString());
+        var stream = new MemoryStream(bytes);
+        var formatter = new JsonEventFormatter();
+        var cloudEvents = await formatter.DecodeBatchModeMessageAsync(stream, s_jsonCloudEventBatchContentType, null);
+        var cloudEvent = Assert.Single(cloudEvents);
+        Assert.Equal("test-type", cloudEvent.Type);
+        Assert.Equal("test-id", cloudEvent.Id);
+        Assert.Equal(SampleUri, cloudEvent.Source);
+    }
 
 
-        [Fact]
-        public void DecodeBatchMode_Multiple()
-        {
-            var array = new JArray
+    [Fact]
+    public void DecodeBatchMode_Multiple()
+    {
+        var array = new JArray
             {
                 new JObject
                 {
@@ -995,37 +995,37 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
                     ["source"] = "//event-source2"
                 },
             };
-            var cloudEvents = DecodeBatchModeMessage(array);
-            Assert.Equal(2, cloudEvents.Count);
+        var cloudEvents = DecodeBatchModeMessage(array);
+        Assert.Equal(2, cloudEvents.Count);
 
-            var event1 = cloudEvents[0];
-            Assert.Equal("type1", event1.Type);
-            Assert.Equal("event1", event1.Id);
-            Assert.Equal(new Uri("//event-source1", UriKind.RelativeOrAbsolute), event1.Source);
-            Assert.Equal("simple text", event1.Data);
-            Assert.Equal("text/plain", event1.DataContentType);
+        var event1 = cloudEvents[0];
+        Assert.Equal("type1", event1.Type);
+        Assert.Equal("event1", event1.Id);
+        Assert.Equal(new Uri("//event-source1", UriKind.RelativeOrAbsolute), event1.Source);
+        Assert.Equal("simple text", event1.Data);
+        Assert.Equal("text/plain", event1.DataContentType);
 
-            var event2 = cloudEvents[1];
-            Assert.Equal("type2", event2.Type);
-            Assert.Equal("event2", event2.Id);
-            Assert.Equal(new Uri("//event-source2", UriKind.RelativeOrAbsolute), event2.Source);
-            Assert.Null(event2.Data);
-            Assert.Null(event2.DataContentType);
-        }
+        var event2 = cloudEvents[1];
+        Assert.Equal("type2", event2.Type);
+        Assert.Equal("event2", event2.Id);
+        Assert.Equal(new Uri("//event-source2", UriKind.RelativeOrAbsolute), event2.Source);
+        Assert.Null(event2.Data);
+        Assert.Null(event2.DataContentType);
+    }
 
-        // Additional tests for the changes/clarifications in https://github.com/cloudevents/spec/pull/861
-        [Fact]
-        public void EncodeStructured_DefaultContentTypeToApplicationJson()
+    // Additional tests for the changes/clarifications in https://github.com/cloudevents/spec/pull/861
+    [Fact]
+    public void EncodeStructured_DefaultContentTypeToApplicationJson()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent
-            {
-                Data = new { Key = "value" }
-            }.PopulateRequiredAttributes();
+            Data = new { Key = "value" }
+        }.PopulateRequiredAttributes();
 
-            var encoded = new JsonEventFormatter().EncodeStructuredModeMessage(cloudEvent, out var contentType);
-            Assert.Equal("application/cloudevents+json; charset=utf-8", contentType.ToString());
-            JObject obj = ParseJson(encoded);
-            var asserter = new JTokenAsserter
+        var encoded = new JsonEventFormatter().EncodeStructuredModeMessage(cloudEvent, out var contentType);
+        Assert.Equal("application/cloudevents+json; charset=utf-8", contentType.ToString());
+        JObject obj = ParseJson(encoded);
+        var asserter = new JTokenAsserter
             {
                 { "data", JTokenType.Object, cloudEvent.Data },
                 { "datacontenttype", JTokenType.String, "application/json" },
@@ -1034,77 +1034,24 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
                 { "specversion", JTokenType.String, "1.0" },
                 { "type", JTokenType.String, "test-type" },
             };
-            asserter.AssertProperties(obj, assertCount: true);
-        }
+        asserter.AssertProperties(obj, assertCount: true);
+    }
 
-        [Fact]
-        public void EncodeStructured_BinaryData_DefaultContentTypeIsNotImplied()
+    [Fact]
+    public void EncodeStructured_BinaryData_DefaultContentTypeIsNotImplied()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent
-            {
-                Data = SampleBinaryData
-            }.PopulateRequiredAttributes();
+            Data = SampleBinaryData
+        }.PopulateRequiredAttributes();
 
-            // If a CloudEvent to have binary data but no data content type,
-            // the spec says the data should be placed in data_base64, but the content type
-            // should *not* be defaulted to application/json, as clarified in https://github.com/cloudevents/spec/issues/933
-            var encoded = new JsonEventFormatter().EncodeStructuredModeMessage(cloudEvent, out var contentType);
-            Assert.Equal("application/cloudevents+json; charset=utf-8", contentType.ToString());
-            JObject obj = ParseJson(encoded);
-            var asserter = new JTokenAsserter
-            {
-                { "data_base64", JTokenType.String, SampleBinaryDataBase64 },
-                { "id", JTokenType.String, "test-id" },
-                { "source", JTokenType.String, "//test" },
-                { "specversion", JTokenType.String, "1.0" },
-                { "type", JTokenType.String, "test-type" },
-            };
-            asserter.AssertProperties(obj, assertCount: true);
-        }
-
-        [Fact]
-        public void DecodeStructured_DefaultContentTypeToApplicationJson()
-        {
-            var obj = new JObject
-            {
-                ["specversion"] = "1.0",
-                ["type"] = "test-type",
-                ["id"] = "test-id",
-                ["source"] = SampleUriText,
-                ["data"] = "some text"
-            };
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Equal("application/json", cloudEvent.DataContentType);
-            var jsonData = Assert.IsType<JValue>(cloudEvent.Data);
-            Assert.Equal(JTokenType.String, jsonData.Type);
-            Assert.Equal("some text", jsonData.Value);
-        }
-
-        [Fact]
-        public void EncodeStructured_IndentationSettings()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            var formatter = new JsonEventFormatter(new JsonSerializer { Formatting = Formatting.Indented });
-            var encoded = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
-            // Normalize the result to LF line endings.
-            var json = BinaryDataUtilities.GetString(encoded, Encoding.UTF8).Replace("\r\n", "\n").Replace("\r", "\n");
-            var expected = "{\n  \"specversion\": \"1.0\",\n  \"id\": \"test-id\",\n  \"source\": \"//test\",\n  \"type\": \"test-type\"\n}";
-            Assert.Equal(expected, json);
-        }
-
-        // Effectively smoke tests for LINQ to JSON conversions; these piggy-back on the same implementation
-        // as the rest of the code, so we don't need to test exhaustively.
-
-        [Fact]
-        public void ConvertToJObject()
-        {
-            var cloudEvent = new CloudEvent
-            {
-                Data = SampleBinaryData
-            }.PopulateRequiredAttributes();
-
-            JObject obj = new JsonEventFormatter().ConvertToJObject(cloudEvent);
-            var asserter = new JTokenAsserter
+        // If a CloudEvent to have binary data but no data content type,
+        // the spec says the data should be placed in data_base64, but the content type
+        // should *not* be defaulted to application/json, as clarified in https://github.com/cloudevents/spec/issues/933
+        var encoded = new JsonEventFormatter().EncodeStructuredModeMessage(cloudEvent, out var contentType);
+        Assert.Equal("application/cloudevents+json; charset=utf-8", contentType.ToString());
+        JObject obj = ParseJson(encoded);
+        var asserter = new JTokenAsserter
             {
                 { "data_base64", JTokenType.String, SampleBinaryDataBase64 },
                 { "id", JTokenType.String, "test-id" },
@@ -1112,107 +1059,159 @@ namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
                 { "specversion", JTokenType.String, "1.0" },
                 { "type", JTokenType.String, "test-type" },
             };
-            asserter.AssertProperties(obj, assertCount: true);
-        }
+        asserter.AssertProperties(obj, assertCount: true);
+    }
 
-        [Fact]
-        public void ConvertFromJObject()
+    [Fact]
+    public void DecodeStructured_DefaultContentTypeToApplicationJson()
+    {
+        var obj = new JObject
         {
-            var obj = new JObject
+            ["specversion"] = "1.0",
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["source"] = SampleUriText,
+            ["data"] = "some text"
+        };
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Equal("application/json", cloudEvent.DataContentType);
+        var jsonData = Assert.IsType<JValue>(cloudEvent.Data);
+        Assert.Equal(JTokenType.String, jsonData.Type);
+        Assert.Equal("some text", jsonData.Value);
+    }
+
+    [Fact]
+    public void EncodeStructured_IndentationSettings()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        var formatter = new JsonEventFormatter(new JsonSerializer { Formatting = Formatting.Indented });
+        var encoded = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
+        // Normalize the result to LF line endings.
+        var json = BinaryDataUtilities.GetString(encoded, Encoding.UTF8).Replace("\r\n", "\n").Replace("\r", "\n");
+        var expected = "{\n  \"specversion\": \"1.0\",\n  \"id\": \"test-id\",\n  \"source\": \"//test\",\n  \"type\": \"test-type\"\n}";
+        Assert.Equal(expected, json);
+    }
+
+    // Effectively smoke tests for LINQ to JSON conversions; these piggy-back on the same implementation
+    // as the rest of the code, so we don't need to test exhaustively.
+
+    [Fact]
+    public void ConvertToJObject()
+    {
+        var cloudEvent = new CloudEvent
+        {
+            Data = SampleBinaryData
+        }.PopulateRequiredAttributes();
+
+        JObject obj = new JsonEventFormatter().ConvertToJObject(cloudEvent);
+        var asserter = new JTokenAsserter
             {
-                ["specversion"] = "1.0",
-                ["type"] = "test-type",
-                ["id"] = "test-id",
-                ["data"] = "text", // Just so that it's reasonable to have a DataContentType,
-                ["datacontenttype"] = "text/plain",
-                ["dataschema"] = "https://data-schema",
-                ["subject"] = "event-subject",
-                ["source"] = "//event-source",
-                ["time"] = SampleTimestampText
+                { "data_base64", JTokenType.String, SampleBinaryDataBase64 },
+                { "id", JTokenType.String, "test-id" },
+                { "source", JTokenType.String, "//test" },
+                { "specversion", JTokenType.String, "1.0" },
+                { "type", JTokenType.String, "test-type" },
             };
-            var cloudEvent = new JsonEventFormatter().ConvertFromJObject(obj, extensionAttributes: null);
-            Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
-            Assert.Equal("test-type", cloudEvent.Type);
-            Assert.Equal("test-id", cloudEvent.Id);
-            Assert.Equal("text/plain", cloudEvent.DataContentType);
-            Assert.Equal(new Uri("https://data-schema"), cloudEvent.DataSchema);
-            Assert.Equal("event-subject", cloudEvent.Subject);
-            Assert.Equal(new Uri("//event-source", UriKind.RelativeOrAbsolute), cloudEvent.Source);
-            AssertTimestampsEqual(SampleTimestamp, cloudEvent.Time);
-        }
+        asserter.AssertProperties(obj, assertCount: true);
+    }
 
-        // Utility methods
-        private static object? DecodeBinaryModeEventData(byte[] bytes, string contentType)
+    [Fact]
+    public void ConvertFromJObject()
+    {
+        var obj = new JObject
         {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.DataContentType = contentType;
-            new JsonEventFormatter().DecodeBinaryModeEventData(bytes, cloudEvent);
-            return cloudEvent.Data;
-        }
+            ["specversion"] = "1.0",
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["data"] = "text", // Just so that it's reasonable to have a DataContentType,
+            ["datacontenttype"] = "text/plain",
+            ["dataschema"] = "https://data-schema",
+            ["subject"] = "event-subject",
+            ["source"] = "//event-source",
+            ["time"] = SampleTimestampText
+        };
+        var cloudEvent = new JsonEventFormatter().ConvertFromJObject(obj, extensionAttributes: null);
+        Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
+        Assert.Equal("test-type", cloudEvent.Type);
+        Assert.Equal("test-id", cloudEvent.Id);
+        Assert.Equal("text/plain", cloudEvent.DataContentType);
+        Assert.Equal(new Uri("https://data-schema"), cloudEvent.DataSchema);
+        Assert.Equal("event-subject", cloudEvent.Subject);
+        Assert.Equal(new Uri("//event-source", UriKind.RelativeOrAbsolute), cloudEvent.Source);
+        AssertTimestampsEqual(SampleTimestamp, cloudEvent.Time);
+    }
 
-        internal static JObject CreateMinimalValidJObject() =>
-            new JObject
-            {
-                ["specversion"] = "1.0",
-                ["type"] = "event-type",
-                ["id"] = "event-id",
-                ["source"] = "//event-source"
-            };
+    // Utility methods
+    private static object? DecodeBinaryModeEventData(byte[] bytes, string contentType)
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.DataContentType = contentType;
+        new JsonEventFormatter().DecodeBinaryModeEventData(bytes, cloudEvent);
+        return cloudEvent.Data;
+    }
 
-        /// <summary>
-        /// Parses JSON as a JObject with settings that prevent any additional conversions.
-        /// </summary>
-        internal static JObject ParseJson(byte[] data) => ParseJsonImpl<JObject>(data);
-
-        internal static JObject ParseJson(ReadOnlyMemory<byte> data) => ParseJsonImpl<JObject>(data);
-
-        /// <summary>
-        /// Parses JSON as a JArray with settings that prevent any additional conversions.
-        /// </summary>
-        internal static JArray ParseJsonArray(ReadOnlyMemory<byte> data) => ParseJsonImpl<JArray>(data);
-
-        private static T ParseJsonImpl<T>(ReadOnlyMemory<byte> data)
+    internal static JObject CreateMinimalValidJObject() =>
+        new JObject
         {
-            string text = BinaryDataUtilities.GetString(data, Encoding.UTF8);
-            var serializer = new JsonSerializer
-            {
-                DateParseHandling = DateParseHandling.None
-            };
-            return serializer.Deserialize<T>(new JsonTextReader(new StringReader(text)))!;
-        }
+            ["specversion"] = "1.0",
+            ["type"] = "event-type",
+            ["id"] = "event-id",
+            ["source"] = "//event-source"
+        };
 
+    /// <summary>
+    /// Parses JSON as a JObject with settings that prevent any additional conversions.
+    /// </summary>
+    internal static JObject ParseJson(byte[] data) => ParseJsonImpl<JObject>(data);
 
-        /// <summary>
-        /// Convenience method to format a CloudEvent with the default JsonEventFormatter in
-        /// structured mode, then parse the result as a JObject.
-        /// </summary>
-        private static JObject EncodeAndParseStructured(CloudEvent cloudEvent)
+    internal static JObject ParseJson(ReadOnlyMemory<byte> data) => ParseJsonImpl<JObject>(data);
+
+    /// <summary>
+    /// Parses JSON as a JArray with settings that prevent any additional conversions.
+    /// </summary>
+    internal static JArray ParseJsonArray(ReadOnlyMemory<byte> data) => ParseJsonImpl<JArray>(data);
+
+    private static T ParseJsonImpl<T>(ReadOnlyMemory<byte> data)
+    {
+        string text = BinaryDataUtilities.GetString(data, Encoding.UTF8);
+        var serializer = new JsonSerializer
         {
-            var formatter = new JsonEventFormatter();
-            var encoded = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
-            return ParseJson(encoded);
-        }
+            DateParseHandling = DateParseHandling.None
+        };
+        return serializer.Deserialize<T>(new JsonTextReader(new StringReader(text)))!;
+    }
 
-        /// <summary>
-        /// Convenience method to serialize a JObject to bytes, then
-        /// decode it as a structured event with the default JsonEventFormatter and no extension attributes.
-        /// </summary>
-        private static CloudEvent DecodeStructuredModeMessage(JObject obj)
-        {
-            byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
-            var formatter = new JsonEventFormatter();
-            return formatter.DecodeStructuredModeMessage(bytes, s_jsonCloudEventContentType, null);
-        }
 
-        /// <summary>
-        /// Convenience method to serialize a JArray to bytes, then
-        /// decode it as a batch mode message with the default JsonEventFormatter and no extension attributes.
-        /// </summary>
-        private static IReadOnlyList<CloudEvent> DecodeBatchModeMessage(JArray array)
-        {
-            byte[] bytes = Encoding.UTF8.GetBytes(array.ToString());
-            var formatter = new JsonEventFormatter();
-            return formatter.DecodeBatchModeMessage(bytes, s_jsonCloudEventContentType, null);
-        }
+    /// <summary>
+    /// Convenience method to format a CloudEvent with the default JsonEventFormatter in
+    /// structured mode, then parse the result as a JObject.
+    /// </summary>
+    private static JObject EncodeAndParseStructured(CloudEvent cloudEvent)
+    {
+        var formatter = new JsonEventFormatter();
+        var encoded = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
+        return ParseJson(encoded);
+    }
+
+    /// <summary>
+    /// Convenience method to serialize a JObject to bytes, then
+    /// decode it as a structured event with the default JsonEventFormatter and no extension attributes.
+    /// </summary>
+    private static CloudEvent DecodeStructuredModeMessage(JObject obj)
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
+        var formatter = new JsonEventFormatter();
+        return formatter.DecodeStructuredModeMessage(bytes, s_jsonCloudEventContentType, null);
+    }
+
+    /// <summary>
+    /// Convenience method to serialize a JArray to bytes, then
+    /// decode it as a batch mode message with the default JsonEventFormatter and no extension attributes.
+    /// </summary>
+    private static IReadOnlyList<CloudEvent> DecodeBatchModeMessage(JArray array)
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes(array.ToString());
+        var formatter = new JsonEventFormatter();
+        return formatter.DecodeBatchModeMessage(bytes, s_jsonCloudEventContentType, null);
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/SpecializedFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/SpecializedFormatterTest.cs
@@ -10,196 +10,195 @@ using System.Text;
 using Xunit;
 using static CloudNative.CloudEvents.UnitTests.TestHelpers;
 
-namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
+namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests;
+
+/// <summary>
+/// Tests for encoding/decoding using a subclass of <see cref="JsonEventFormatter"/>.
+/// This is effectively testing when the virtual methods are invoked.
+/// </summary>
+public class SpecializedFormatterTest
 {
-    /// <summary>
-    /// Tests for encoding/decoding using a subclass of <see cref="JsonEventFormatter"/>.
-    /// This is effectively testing when the virtual methods are invoked.
-    /// </summary>
-    public class SpecializedFormatterTest
+    private const string GuidPrefix = "guid:";
+    private const string TextBinaryContentType = "text/binary";
+    private const string GuidContentType = "application/guid";
+
+    // Just to validate delegation to base methods
+    [Fact]
+    public void EncodePlainText()
     {
-        private const string GuidPrefix = "guid:";
-        private const string TextBinaryContentType = "text/binary";
-        private const string GuidContentType = "application/guid";
-
-        // Just to validate delegation to base methods
-        [Fact]
-        public void EncodePlainText()
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent
+            Data = "some text",
+            DataContentType = "text/plain"
+        }.PopulateRequiredAttributes();
+        var obj = EncodeAndParseStructured(cloudEvent);
+        AssertToken(JTokenType.String, "some text", obj["data"]);
+    }
+
+    // Just to validate delegation to base methods
+    [Fact]
+    public void EncodeByteArray()
+    {
+        var cloudEvent = new CloudEvent
+        {
+            Data = SampleBinaryData,
+            DataContentType = "application/binary"
+        }.PopulateRequiredAttributes();
+        var obj = EncodeAndParseStructured(cloudEvent);
+        AssertToken(JTokenType.String, SampleBinaryDataBase64, obj["data_base64"]);
+    }
+
+    [Fact]
+    public void EncodeGuid()
+    {
+        Guid guid = Guid.NewGuid();
+        var cloudEvent = new CloudEvent
+        {
+            Data = guid,
+            DataContentType = GuidContentType
+        }.PopulateRequiredAttributes();
+        var obj = EncodeAndParseStructured(cloudEvent);
+        string expectedText = GuidPrefix + Convert.ToBase64String(guid.ToByteArray());
+        AssertToken(JTokenType.String, expectedText, obj["data"]);
+    }
+
+    [Fact]
+    public void EncodeTextBinary()
+    {
+        var cloudEvent = new CloudEvent
+        {
+            Data = "some text",
+            DataContentType = TextBinaryContentType
+        }.PopulateRequiredAttributes();
+        var obj = EncodeAndParseStructured(cloudEvent);
+        string expectedText = Convert.ToBase64String(Encoding.UTF8.GetBytes("some text"));
+        AssertToken(JTokenType.String, expectedText, obj["data_base64"]);
+    }
+
+    // Just to validate delegation to base methods
+    [Fact]
+    public void DecodePlainText()
+    {
+        var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
+        obj["data"] = "some text";
+        obj["datacontenttype"] = "text/plain";
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Equal("some text", cloudEvent.Data);
+    }
+
+    // Just to validate delegation to base methods
+    [Fact]
+    public void DecodeByteArray()
+    {
+        var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
+        obj["data_base64"] = SampleBinaryDataBase64;
+        obj["datacontenttype"] = "application/binary";
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Equal(SampleBinaryData, cloudEvent.Data);
+    }
+
+    [Fact]
+    public void DecodeGuid()
+    {
+        Guid guid = Guid.NewGuid();
+        var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
+        obj["data"] = GuidPrefix + Convert.ToBase64String(guid.ToByteArray());
+        obj["datacontenttype"] = GuidContentType;
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Equal(guid, cloudEvent.Data);
+    }
+
+    [Fact]
+    public void DecodeTextBinary()
+    {
+        var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
+        obj["data_base64"] = Convert.ToBase64String(Encoding.UTF8.GetBytes("some text"));
+        obj["datacontenttype"] = TextBinaryContentType;
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Equal("some text", cloudEvent.Data);
+    }
+
+    private static void AssertToken(JTokenType expectedType, object expectedValue, JToken? token)
+    {
+        Assert.NotNull(token);
+        Assert.Equal(expectedType, token!.Type);
+        Assert.Equal(expectedValue, token.ToObject(expectedValue.GetType()));
+    }
+
+    /// <summary>
+    /// Convenience method to format a CloudEvent with a specialized formatter in
+    /// structured mode, then parse the result as a JObject.
+    /// </summary>
+    private static JObject EncodeAndParseStructured(CloudEvent cloudEvent)
+    {
+        var formatter = new SpecializedFormatter();
+        var encoded = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
+        return JsonEventFormatterTest.ParseJson(encoded);
+    }
+
+    /// <summary>
+    /// Convenience method to serialize a JObject to bytes, then
+    /// decode it as a structured event with a specialized formatter and no extension attributes.
+    /// </summary>
+    private static CloudEvent DecodeStructuredModeMessage(JObject obj)
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
+        var formatter = new SpecializedFormatter();
+        return formatter.DecodeStructuredModeMessage(bytes, null, null);
+    }
+
+    /// <summary>
+    /// Specialized formatter:
+    /// - Content type of "text/binary" is encoded in base64
+    /// - Guid with a content type of "application/guid" is encoded as a string with content "guid:base64-data"
+    /// </summary>
+    private class SpecializedFormatter : JsonEventFormatter
+    {
+        protected override void DecodeStructuredModeDataBase64Property(JToken dataBase64Token, CloudEvent cloudEvent)
+        {
+            if (cloudEvent.DataContentType == TextBinaryContentType && dataBase64Token.Type == JTokenType.String)
             {
-                Data = "some text",
-                DataContentType = "text/plain"
-            }.PopulateRequiredAttributes();
-            var obj = EncodeAndParseStructured(cloudEvent);
-            AssertToken(JTokenType.String, "some text", obj["data"]);
-        }
-
-        // Just to validate delegation to base methods
-        [Fact]
-        public void EncodeByteArray()
-        {
-            var cloudEvent = new CloudEvent
-            {
-                Data = SampleBinaryData,
-                DataContentType = "application/binary"
-            }.PopulateRequiredAttributes();
-            var obj = EncodeAndParseStructured(cloudEvent);
-            AssertToken(JTokenType.String, SampleBinaryDataBase64, obj["data_base64"]);
-        }
-
-        [Fact]
-        public void EncodeGuid()
-        {
-            Guid guid = Guid.NewGuid();
-            var cloudEvent = new CloudEvent
-            {
-                Data = guid,
-                DataContentType = GuidContentType
-            }.PopulateRequiredAttributes();
-            var obj = EncodeAndParseStructured(cloudEvent);
-            string expectedText = GuidPrefix + Convert.ToBase64String(guid.ToByteArray());
-            AssertToken(JTokenType.String, expectedText, obj["data"]);
-        }
-
-        [Fact]
-        public void EncodeTextBinary()
-        {
-            var cloudEvent = new CloudEvent
-            {
-                Data = "some text",
-                DataContentType = TextBinaryContentType
-            }.PopulateRequiredAttributes();
-            var obj = EncodeAndParseStructured(cloudEvent);
-            string expectedText = Convert.ToBase64String(Encoding.UTF8.GetBytes("some text"));
-            AssertToken(JTokenType.String, expectedText, obj["data_base64"]);
-        }
-
-        // Just to validate delegation to base methods
-        [Fact]
-        public void DecodePlainText()
-        {
-            var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
-            obj["data"] = "some text";
-            obj["datacontenttype"] = "text/plain";
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Equal("some text", cloudEvent.Data);
-        }
-
-        // Just to validate delegation to base methods
-        [Fact]
-        public void DecodeByteArray()
-        {
-            var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
-            obj["data_base64"] = SampleBinaryDataBase64;
-            obj["datacontenttype"] = "application/binary";
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Equal(SampleBinaryData, cloudEvent.Data);
-        }
-
-        [Fact]
-        public void DecodeGuid()
-        {
-            Guid guid = Guid.NewGuid();
-            var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
-            obj["data"] = GuidPrefix + Convert.ToBase64String(guid.ToByteArray());
-            obj["datacontenttype"] = GuidContentType;
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Equal(guid, cloudEvent.Data);
-        }
-
-        [Fact]
-        public void DecodeTextBinary()
-        {
-            var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
-            obj["data_base64"] = Convert.ToBase64String(Encoding.UTF8.GetBytes("some text"));
-            obj["datacontenttype"] = TextBinaryContentType;
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Equal("some text", cloudEvent.Data);
-        }
-
-        private static void AssertToken(JTokenType expectedType, object expectedValue, JToken? token)
-        {
-            Assert.NotNull(token);
-            Assert.Equal(expectedType, token!.Type);
-            Assert.Equal(expectedValue, token.ToObject(expectedValue.GetType()));
-        }
-
-        /// <summary>
-        /// Convenience method to format a CloudEvent with a specialized formatter in
-        /// structured mode, then parse the result as a JObject.
-        /// </summary>
-        private static JObject EncodeAndParseStructured(CloudEvent cloudEvent)
-        {
-            var formatter = new SpecializedFormatter();
-            var encoded = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
-            return JsonEventFormatterTest.ParseJson(encoded);
-        }
-
-        /// <summary>
-        /// Convenience method to serialize a JObject to bytes, then
-        /// decode it as a structured event with a specialized formatter and no extension attributes.
-        /// </summary>
-        private static CloudEvent DecodeStructuredModeMessage(JObject obj)
-        {
-            byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
-            var formatter = new SpecializedFormatter();
-            return formatter.DecodeStructuredModeMessage(bytes, null, null);
-        }
-
-        /// <summary>
-        /// Specialized formatter:
-        /// - Content type of "text/binary" is encoded in base64
-        /// - Guid with a content type of "application/guid" is encoded as a string with content "guid:base64-data"
-        /// </summary>
-        private class SpecializedFormatter : JsonEventFormatter
-        {
-            protected override void DecodeStructuredModeDataBase64Property(JToken dataBase64Token, CloudEvent cloudEvent)
-            {
-                if (cloudEvent.DataContentType == TextBinaryContentType && dataBase64Token.Type == JTokenType.String)
-                {
-                    cloudEvent.Data = Encoding.UTF8.GetString(Convert.FromBase64String((string) dataBase64Token!));
-                }
-                else
-                {
-                    base.DecodeStructuredModeDataBase64Property(dataBase64Token, cloudEvent);
-                }
+                cloudEvent.Data = Encoding.UTF8.GetString(Convert.FromBase64String((string) dataBase64Token!));
             }
-
-            protected override void DecodeStructuredModeDataProperty(JToken dataToken, CloudEvent cloudEvent)
+            else
             {
-                if (cloudEvent.DataContentType == GuidContentType && dataToken.Type == JTokenType.String)
-                {
-                    string text = (string) dataToken!;
-                    if (!text.StartsWith(GuidPrefix))
-                    {
-                        throw new ArgumentException("Invalid GUID text data");
-                    }
-                    cloudEvent.Data = new Guid(Convert.FromBase64String(text.Substring(GuidPrefix.Length)));
-                }
-                else
-                {
-                    base.DecodeStructuredModeDataProperty(dataToken, cloudEvent);
-                }
+                base.DecodeStructuredModeDataBase64Property(dataBase64Token, cloudEvent);
             }
+        }
 
-            protected override void EncodeStructuredModeData(CloudEvent cloudEvent, JsonWriter writer)
+        protected override void DecodeStructuredModeDataProperty(JToken dataToken, CloudEvent cloudEvent)
+        {
+            if (cloudEvent.DataContentType == GuidContentType && dataToken.Type == JTokenType.String)
             {
-                var data = cloudEvent.Data;
-                if (data is Guid guid && cloudEvent.DataContentType == GuidContentType)
+                string text = (string) dataToken!;
+                if (!text.StartsWith(GuidPrefix))
                 {
-                    writer.WritePropertyName(DataPropertyName);
-                    writer.WriteValue(GuidPrefix + Convert.ToBase64String(guid.ToByteArray()));
+                    throw new ArgumentException("Invalid GUID text data");
                 }
-                else if (data is string text && cloudEvent.DataContentType == TextBinaryContentType)
-                {
-                    writer.WritePropertyName(DataBase64PropertyName);
-                    writer.WriteValue(Convert.ToBase64String(Encoding.UTF8.GetBytes(text)));
-                }
-                else
-                {
-                    base.EncodeStructuredModeData(cloudEvent, writer);
-                }
+                cloudEvent.Data = new Guid(Convert.FromBase64String(text.Substring(GuidPrefix.Length)));
+            }
+            else
+            {
+                base.DecodeStructuredModeDataProperty(dataToken, cloudEvent);
+            }
+        }
+
+        protected override void EncodeStructuredModeData(CloudEvent cloudEvent, JsonWriter writer)
+        {
+            var data = cloudEvent.Data;
+            if (data is Guid guid && cloudEvent.DataContentType == GuidContentType)
+            {
+                writer.WritePropertyName(DataPropertyName);
+                writer.WriteValue(GuidPrefix + Convert.ToBase64String(guid.ToByteArray()));
+            }
+            else if (data is string text && cloudEvent.DataContentType == TextBinaryContentType)
+            {
+                writer.WritePropertyName(DataBase64PropertyName);
+                writer.WriteValue(Convert.ToBase64String(Encoding.UTF8.GetBytes(text)));
+            }
+            else
+            {
+                base.EncodeStructuredModeData(cloudEvent, writer);
             }
         }
     }

--- a/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/SpecializedJsonReaderTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/SpecializedJsonReaderTest.cs
@@ -11,86 +11,85 @@ using System.Linq;
 using System.Text;
 using Xunit;
 
-namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests
+namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests;
+
+/// <summary>
+/// Tests for the specialization of <see cref="JsonEventFormatter.CreateJsonReader(System.IO.Stream, Encoding)"/>
+/// </summary>
+public class SpecializedJsonReaderTest
 {
-    /// <summary>
-    /// Tests for the specialization of <see cref="JsonEventFormatter.CreateJsonReader(System.IO.Stream, Encoding)"/>
-    /// </summary>
-    public class SpecializedJsonReaderTest
+    [Fact]
+    public void DefaultImplementation_ReturnsJsonTextReader()
     {
-        [Fact]
-        public void DefaultImplementation_ReturnsJsonTextReader()
+        var formatter = new CreateJsonReaderExposingFormatter();
+        var reader = formatter.CreateJsonReaderPublic(CreateJsonStream(), null);
+        Assert.IsType<JsonTextReader>(reader);
+    }
+
+    [Fact]
+    public void DefaultImplementation_NoPropertyNameTable()
+    {
+        var formatter = new JsonEventFormatter();
+        var event1 = formatter.DecodeStructuredModeMessage(CreateJsonStream(), null, null);
+        var event2 = formatter.DecodeStructuredModeMessage(CreateJsonStream(), null, null);
+
+        JObject data1 = (JObject) event1.Data!;
+        JObject data2 = (JObject) event2.Data!;
+
+        var property1 = data1.Properties().Single();
+        var property2 = data2.Properties().Single();
+        Assert.Equal(property1.Name, property2.Name);
+        Assert.NotSame(property1.Name, property2.Name);
+    }
+
+    [Fact]
+    public void Specialization_WithPropertyNameTable()
+    {
+        var formatter = new PropertyNameTableFormatter();
+        var event1 = formatter.DecodeStructuredModeMessage(CreateJsonStream(), null, null);
+        var event2 = formatter.DecodeStructuredModeMessage(CreateJsonStream(), null, null);
+
+        JObject data1 = (JObject) event1.Data!;
+        JObject data2 = (JObject) event2.Data!;
+
+        var property1 = data1.Properties().Single();
+        var property2 = data2.Properties().Single();
+        Assert.Equal(property1.Name, property2.Name);
+        Assert.Same(property1.Name, property2.Name);
+    }
+
+    private Stream CreateJsonStream()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var formatter = new CreateJsonReaderExposingFormatter();
-            var reader = formatter.CreateJsonReaderPublic(CreateJsonStream(), null);
-            Assert.IsType<JsonTextReader>(reader);
+            Data = new { DataName = "DataValue" }
+        }.PopulateRequiredAttributes();
+        var bytes = new JsonEventFormatter().EncodeStructuredModeMessage(cloudEvent, out _);
+        return BinaryDataUtilities.AsStream(bytes);
+    }
+
+    private class CreateJsonReaderExposingFormatter : JsonEventFormatter
+    {
+        public JsonReader CreateJsonReaderPublic(Stream stream, Encoding? encoding) =>
+            base.CreateJsonReader(stream, encoding);
+    }
+
+    private class PropertyNameTableFormatter : JsonEventFormatter
+    {
+        private readonly DefaultJsonNameTable table;
+
+        public PropertyNameTableFormatter()
+        {
+            // Names aren't automatically cached by JsonTextReader, so we need to prepopulate the table.
+            table = new DefaultJsonNameTable();
+            table.Add("DataName");
         }
 
-        [Fact]
-        public void DefaultImplementation_NoPropertyNameTable()
+        protected override JsonReader CreateJsonReader(Stream stream, Encoding? encoding)
         {
-            var formatter = new JsonEventFormatter();
-            var event1 = formatter.DecodeStructuredModeMessage(CreateJsonStream(), null, null);
-            var event2 = formatter.DecodeStructuredModeMessage(CreateJsonStream(), null, null);
-
-            JObject data1 = (JObject) event1.Data!;
-            JObject data2 = (JObject) event2.Data!;
-
-            var property1 = data1.Properties().Single();
-            var property2 = data2.Properties().Single();
-            Assert.Equal(property1.Name, property2.Name);
-            Assert.NotSame(property1.Name, property2.Name);
-        }
-
-        [Fact]
-        public void Specialization_WithPropertyNameTable()
-        {
-            var formatter = new PropertyNameTableFormatter();
-            var event1 = formatter.DecodeStructuredModeMessage(CreateJsonStream(), null, null);
-            var event2 = formatter.DecodeStructuredModeMessage(CreateJsonStream(), null, null);
-
-            JObject data1 = (JObject) event1.Data!;
-            JObject data2 = (JObject) event2.Data!;
-
-            var property1 = data1.Properties().Single();
-            var property2 = data2.Properties().Single();
-            Assert.Equal(property1.Name, property2.Name);
-            Assert.Same(property1.Name, property2.Name);
-        }
-
-        private Stream CreateJsonStream()
-        {
-            var cloudEvent = new CloudEvent
-            {
-                Data = new { DataName = "DataValue" }
-            }.PopulateRequiredAttributes();
-            var bytes = new JsonEventFormatter().EncodeStructuredModeMessage(cloudEvent, out _);
-            return BinaryDataUtilities.AsStream(bytes);
-        }
-
-        private class CreateJsonReaderExposingFormatter : JsonEventFormatter
-        {
-            public JsonReader CreateJsonReaderPublic(Stream stream, Encoding? encoding) =>
-                base.CreateJsonReader(stream, encoding);
-        }
-
-        private class PropertyNameTableFormatter : JsonEventFormatter
-        {
-            private readonly DefaultJsonNameTable table;
-
-            public PropertyNameTableFormatter()
-            {
-                // Names aren't automatically cached by JsonTextReader, so we need to prepopulate the table.
-                table = new DefaultJsonNameTable();
-                table.Add("DataName");
-            }
-
-            protected override JsonReader CreateJsonReader(Stream stream, Encoding? encoding)
-            {
-                var reader = (JsonTextReader) base.CreateJsonReader(stream, encoding);
-                reader.PropertyNameTable = table;
-                return reader;
-            }
+            var reader = (JsonTextReader) base.CreateJsonReader(stream, encoding);
+            reader.PropertyNameTable = table;
+            return reader;
         }
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/Protobuf/ProtobufEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Protobuf/ProtobufEventFormatterTest.cs
@@ -14,70 +14,70 @@ using Xunit;
 using static CloudNative.CloudEvents.UnitTests.TestHelpers;
 using static CloudNative.CloudEvents.V1.CloudEvent.Types;
 
-namespace CloudNative.CloudEvents.Protobuf.UnitTests
+namespace CloudNative.CloudEvents.Protobuf.UnitTests;
+
+/// <summary>
+/// Tests for ProtobufEventFormatter. Note that most tests for encoding/decoding of
+/// structured mode events (and batches) are performed via the public methods that
+/// perform proto/CloudEvent conversions - the regular event formatter methods are
+/// only wrappers around those, covered by minimal tests here.
+/// </summary>
+public class ProtobufEventFormatterTest
 {
-    /// <summary>
-    /// Tests for ProtobufEventFormatter. Note that most tests for encoding/decoding of
-    /// structured mode events (and batches) are performed via the public methods that
-    /// perform proto/CloudEvent conversions - the regular event formatter methods are
-    /// only wrappers around those, covered by minimal tests here.
-    /// </summary>
-    public class ProtobufEventFormatterTest
+    private static readonly ContentType s_protobufCloudEventContentType = new ContentType("application/cloudevents+protobuf");
+    private static readonly ContentType s_protobufCloudEventBatchContentType = new ContentType("application/cloudevents-batch+protobuf");
+
+    [Fact]
+    public void EncodeStructuredModeMessage_Minimal()
     {
-        private static readonly ContentType s_protobufCloudEventContentType = new ContentType("application/cloudevents+protobuf");
-        private static readonly ContentType s_protobufCloudEventBatchContentType = new ContentType("application/cloudevents-batch+protobuf");
-
-        [Fact]
-        public void EncodeStructuredModeMessage_Minimal()
+        var cloudEvent = new CloudEvent(CloudEventsSpecVersion.V1_0)
         {
-            var cloudEvent = new CloudEvent(CloudEventsSpecVersion.V1_0)
-            {
-                Id = "event-id",
-                Source = new Uri("https://event-source"),
-                Type = "event-type",
-            };
+            Id = "event-id",
+            Source = new Uri("https://event-source"),
+            Type = "event-type",
+        };
 
-            var encoded = new ProtobufEventFormatter().EncodeStructuredModeMessage(cloudEvent, out var contentType);
-            Assert.Equal("application/cloudevents+protobuf; charset=utf-8", contentType.ToString());
-            var actualProto = V1.CloudEvent.Parser.ParseFrom(encoded.ToArray());
+        var encoded = new ProtobufEventFormatter().EncodeStructuredModeMessage(cloudEvent, out var contentType);
+        Assert.Equal("application/cloudevents+protobuf; charset=utf-8", contentType.ToString());
+        var actualProto = V1.CloudEvent.Parser.ParseFrom(encoded.ToArray());
 
-            var expectedProto = new V1.CloudEvent
-            {
-                SpecVersion = "1.0",
-                Id = "event-id",
-                Source = "https://event-source",
-                Type = "event-type"
-            };
-            Assert.Equal(expectedProto, actualProto);
-        }
-
-        /// <summary>
-        /// A simple test that populates all known v1.0 attributes, so we don't need to test that
-        /// aspect in the future.
-        /// </summary>
-        [Fact]
-        public void ConvertToProto_V1Attributes()
+        var expectedProto = new V1.CloudEvent
         {
-            var cloudEvent = new CloudEvent(CloudEventsSpecVersion.V1_0)
-            {
-                Data = "text",
-                DataContentType = "text/plain",
-                DataSchema = new Uri("https://data-schema"),
-                Id = "event-id",
-                Source = new Uri("https://event-source"),
-                Subject = "event-subject",
-                Time = new DateTimeOffset(2021, 2, 19, 12, 34, 56, 789, TimeSpan.FromHours(1)),
-                Type = "event-type"
-            };
+            SpecVersion = "1.0",
+            Id = "event-id",
+            Source = "https://event-source",
+            Type = "event-type"
+        };
+        Assert.Equal(expectedProto, actualProto);
+    }
 
-            var actualProto = new ProtobufEventFormatter().ConvertToProto(cloudEvent);
-            var expectedProto = new V1.CloudEvent
-            {
-                SpecVersion = "1.0",
-                Id = "event-id",
-                Source = "https://event-source",
-                Type = "event-type",
-                Attributes =
+    /// <summary>
+    /// A simple test that populates all known v1.0 attributes, so we don't need to test that
+    /// aspect in the future.
+    /// </summary>
+    [Fact]
+    public void ConvertToProto_V1Attributes()
+    {
+        var cloudEvent = new CloudEvent(CloudEventsSpecVersion.V1_0)
+        {
+            Data = "text",
+            DataContentType = "text/plain",
+            DataSchema = new Uri("https://data-schema"),
+            Id = "event-id",
+            Source = new Uri("https://event-source"),
+            Subject = "event-subject",
+            Time = new DateTimeOffset(2021, 2, 19, 12, 34, 56, 789, TimeSpan.FromHours(1)),
+            Type = "event-type"
+        };
+
+        var actualProto = new ProtobufEventFormatter().ConvertToProto(cloudEvent);
+        var expectedProto = new V1.CloudEvent
+        {
+            SpecVersion = "1.0",
+            Id = "event-id",
+            Source = "https://event-source",
+            Type = "event-type",
+            Attributes =
                 {
                     { "datacontenttype", StringAttribute("text/plain") },
                     { "dataschema", UriAttribute("https://data-schema") },
@@ -86,30 +86,30 @@ namespace CloudNative.CloudEvents.Protobuf.UnitTests
                     // is relevant, not the UTC offset.
                     { "time", TimestampAttribute(new DateTimeOffset(2021, 2, 19, 11, 34, 56, 789, TimeSpan.Zero)) }
                 },
-                TextData = "text"
-            };
-            Assert.Equal(expectedProto, actualProto);
-        }
+            TextData = "text"
+        };
+        Assert.Equal(expectedProto, actualProto);
+    }
 
-        [Fact]
-        public void ConvertToProto_AllAttributeTypes()
+    [Fact]
+    public void ConvertToProto_AllAttributeTypes()
+    {
+        var cloudEvent = new CloudEvent(AllTypesExtensions)
         {
-            var cloudEvent = new CloudEvent(AllTypesExtensions)
-            {
-                ["binary"] = SampleBinaryData,
-                ["boolean"] = true,
-                ["integer"] = 10,
-                ["string"] = "text",
-                ["timestamp"] = SampleTimestamp,
-                ["uri"] = SampleUri,
-                ["urireference"] = SampleUriReference
-            };
-            // We're not going to check these.
-            cloudEvent.PopulateRequiredAttributes();
+            ["binary"] = SampleBinaryData,
+            ["boolean"] = true,
+            ["integer"] = 10,
+            ["string"] = "text",
+            ["timestamp"] = SampleTimestamp,
+            ["uri"] = SampleUri,
+            ["urireference"] = SampleUriReference
+        };
+        // We're not going to check these.
+        cloudEvent.PopulateRequiredAttributes();
 
-            var proto = new ProtobufEventFormatter().ConvertToProto(cloudEvent);
+        var proto = new ProtobufEventFormatter().ConvertToProto(cloudEvent);
 
-            var expectedAttributes = new MapField<string, CloudEventAttributeValue>
+        var expectedAttributes = new MapField<string, CloudEventAttributeValue>
             {
                 { "binary", BinaryAttribute(SampleBinaryData) },
                 { "boolean", BooleanAttribute(true) },
@@ -119,213 +119,213 @@ namespace CloudNative.CloudEvents.Protobuf.UnitTests
                 { "uri", UriAttribute(SampleUriText) },
                 { "urireference", UriRefAttribute(SampleUriReferenceText) }
             };
-            Assert.Equal(proto.Attributes, expectedAttributes);
-        }
+        Assert.Equal(proto.Attributes, expectedAttributes);
+    }
 
-        [Fact]
-        public void ConvertToProto_NoData()
+    [Fact]
+    public void ConvertToProto_NoData()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        var proto = new ProtobufEventFormatter().ConvertToProto(cloudEvent);
+        Assert.Equal(V1.CloudEvent.DataOneofCase.None, proto.DataCase);
+    }
+
+    [Fact]
+    public void ConvertToProto_TextData()
+    {
+        var cloudEvent = new CloudEvent { Data = "text" }.PopulateRequiredAttributes();
+        var proto = new ProtobufEventFormatter().ConvertToProto(cloudEvent);
+        Assert.Equal("text", proto.TextData);
+    }
+
+    [Fact]
+    public void ConvertToProto_BinaryData()
+    {
+        var cloudEvent = new CloudEvent { Data = SampleBinaryData }.PopulateRequiredAttributes();
+        var proto = new ProtobufEventFormatter().ConvertToProto(cloudEvent);
+        Assert.Equal(SampleBinaryData, proto.BinaryData.ToByteArray());
+    }
+
+    [Fact]
+    public void ConvertToProto_MessageData()
+    {
+        var data = new PayloadData1 { Name = "test" };
+        var cloudEvent = new CloudEvent { Data = data }.PopulateRequiredAttributes();
+        var proto = new ProtobufEventFormatter().ConvertToProto(cloudEvent);
+        Assert.Equal(Any.Pack(data), proto.ProtoData);
+    }
+
+    [Fact]
+    public void ConvertToProto_MessageData_AlreadyPacked()
+    {
+        var data = new PayloadData1 { Name = "test" };
+        var packedData = Any.Pack(data);
+        var cloudEvent = new CloudEvent { Data = packedData }.PopulateRequiredAttributes();
+        var proto = new ProtobufEventFormatter().ConvertToProto(cloudEvent);
+        // This verifies that the formatter doesn't "double-encode".
+        Assert.Equal(packedData, proto.ProtoData);
+    }
+
+    [Fact]
+    public void ConvertToProto_MessageData_CustomTypeUrlPrefix()
+    {
+        string typeUrlPrefix = "cloudevents.io/xyz";
+        var data = new PayloadData1 { Name = "test" };
+        var cloudEvent = new CloudEvent { Data = data }.PopulateRequiredAttributes();
+        var proto = new ProtobufEventFormatter(typeUrlPrefix).ConvertToProto(cloudEvent);
+        Assert.Equal(Any.Pack(data, typeUrlPrefix), proto.ProtoData);
+    }
+
+    [Fact]
+    public void ConvertToProto_InvalidData()
+    {
+        var cloudEvent = new CloudEvent { Data = new object() }.PopulateRequiredAttributes();
+        var formatter = new ProtobufEventFormatter();
+        Assert.Throws<ArgumentException>(() => formatter.ConvertToProto(cloudEvent));
+    }
+
+    [Fact]
+    public void EncodeBinaryModeData_Bytes()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            var proto = new ProtobufEventFormatter().ConvertToProto(cloudEvent);
-            Assert.Equal(V1.CloudEvent.DataOneofCase.None, proto.DataCase);
-        }
+            Data = SampleBinaryData
+        }.PopulateRequiredAttributes();
+        var formatter = new ProtobufEventFormatter();
 
-        [Fact]
-        public void ConvertToProto_TextData()
+        var result = formatter.EncodeBinaryModeEventData(cloudEvent);
+        Assert.Equal(SampleBinaryData, result.ToArray());
+    }
+
+    [Theory]
+    [InlineData("utf-8")]
+    [InlineData("iso-8859-1")]
+    [InlineData(null)]
+    public void EncodeBinaryModeData_String_TextContentType(string? charset)
+    {
+        string text = "caf\u00e9"; // Valid in both UTF-8 and ISO-8859-1, but with different representations
+        var encoding = charset is null ? Encoding.UTF8 : Encoding.GetEncoding(charset);
+        string contentType = charset is null ? "text/plain" : $"text/plain; charset={charset}";
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent { Data = "text" }.PopulateRequiredAttributes();
-            var proto = new ProtobufEventFormatter().ConvertToProto(cloudEvent);
-            Assert.Equal("text", proto.TextData);
-        }
+            Data = text,
+            DataContentType = contentType
+        }.PopulateRequiredAttributes();
 
-        [Fact]
-        public void ConvertToProto_BinaryData()
+        var formatter = new ProtobufEventFormatter();
+        var result = formatter.EncodeBinaryModeEventData(cloudEvent);
+        Assert.Equal(encoding.GetBytes(text), result.ToArray());
+    }
+
+    [Fact]
+    public void EncodeBinaryModeData_String_NonTextContentType()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent { Data = SampleBinaryData }.PopulateRequiredAttributes();
-            var proto = new ProtobufEventFormatter().ConvertToProto(cloudEvent);
-            Assert.Equal(SampleBinaryData, proto.BinaryData.ToByteArray());
-        }
+            Data = "text",
+            DataContentType = "application/json"
+        }.PopulateRequiredAttributes();
+        var formatter = new ProtobufEventFormatter();
+        Assert.Throws<ArgumentException>(() => formatter.EncodeBinaryModeEventData(cloudEvent));
+    }
 
-        [Fact]
-        public void ConvertToProto_MessageData()
+    [Fact]
+    public void EncodeBinaryModeData_ProtoMessage()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var data = new PayloadData1 { Name = "test" };
-            var cloudEvent = new CloudEvent { Data = data }.PopulateRequiredAttributes();
-            var proto = new ProtobufEventFormatter().ConvertToProto(cloudEvent);
-            Assert.Equal(Any.Pack(data), proto.ProtoData);
-        }
+            Data = new PayloadData1 { Name = "fail" },
+            DataContentType = "application/protobuf"
+        }.PopulateRequiredAttributes();
+        var formatter = new ProtobufEventFormatter();
+        // See summary documentation for ProtobufEventFormatter for the reasoning for this
+        Assert.Throws<ArgumentException>(() => formatter.EncodeBinaryModeEventData(cloudEvent));
+    }
 
-        [Fact]
-        public void ConvertToProto_MessageData_AlreadyPacked()
+    [Fact]
+    public void EncodeBinaryModeData_ArbitraryObject()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var data = new PayloadData1 { Name = "test" };
-            var packedData = Any.Pack(data);
-            var cloudEvent = new CloudEvent { Data = packedData }.PopulateRequiredAttributes();
-            var proto = new ProtobufEventFormatter().ConvertToProto(cloudEvent);
-            // This verifies that the formatter doesn't "double-encode".
-            Assert.Equal(packedData, proto.ProtoData);
-        }
+            Data = new object(),
+            DataContentType = "application/octet-stream"
+        }.PopulateRequiredAttributes();
+        var formatter = new ProtobufEventFormatter();
+        // See summary documentation for ProtobufEventFormatter for the reasoning for this
+        Assert.Throws<ArgumentException>(() => formatter.EncodeBinaryModeEventData(cloudEvent));
+    }
 
-        [Fact]
-        public void ConvertToProto_MessageData_CustomTypeUrlPrefix()
+    [Fact]
+    public void EncodeBinaryModeData_NoData()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        var formatter = new ProtobufEventFormatter();
+        Assert.Empty(formatter.EncodeBinaryModeEventData(cloudEvent).ToArray());
+    }
+
+    // Just a single test for the code that parses asynchronously... the guts are all the same.
+    [Fact]
+    public async Task DecodeStructuredModeMessageAsync_Minimal()
+    {
+        var proto = CreateMinimalCloudEventProto();
+        byte[] bytes = proto.ToByteArray();
+        var stream = new MemoryStream(bytes);
+        var formatter = new ProtobufEventFormatter();
+        var cloudEvent = await formatter.DecodeStructuredModeMessageAsync(stream, s_protobufCloudEventContentType, null);
+        Assert.Equal("test-type", cloudEvent.Type);
+        Assert.Equal("test-id", cloudEvent.Id);
+        Assert.Equal(SampleUri, cloudEvent.Source);
+    }
+
+    [Fact]
+    public void DecodeStructuredModeMessage_Minimal()
+    {
+        var proto = CreateMinimalCloudEventProto();
+        byte[] bytes = proto.ToByteArray();
+        var stream = new MemoryStream(bytes);
+        var formatter = new ProtobufEventFormatter();
+        var cloudEvent = formatter.DecodeStructuredModeMessage(stream, s_protobufCloudEventContentType, null);
+        Assert.Equal("test-type", cloudEvent.Type);
+        Assert.Equal("test-id", cloudEvent.Id);
+        Assert.Equal(SampleUri, cloudEvent.Source);
+    }
+
+    [Fact]
+    public void EncodeBatchModeMessage_Empty()
+    {
+        var formatter = new ProtobufEventFormatter();
+        var bytes = formatter.EncodeBatchModeMessage(new CloudEvent[0], out var contentType);
+        Assert.Equal("application/cloudevents-batch+protobuf; charset=utf-8", contentType.ToString());
+        var batch = V1.CloudEventBatch.Parser.ParseFrom(bytes.ToArray());
+        Assert.Empty(batch.Events);
+    }
+
+    [Fact]
+    public void EncodeBatchModeMessage_TwoEvents()
+    {
+        var event1 = new CloudEvent
         {
-            string typeUrlPrefix = "cloudevents.io/xyz";
-            var data = new PayloadData1 { Name = "test" };
-            var cloudEvent = new CloudEvent { Data = data }.PopulateRequiredAttributes();
-            var proto = new ProtobufEventFormatter(typeUrlPrefix).ConvertToProto(cloudEvent);
-            Assert.Equal(Any.Pack(data, typeUrlPrefix), proto.ProtoData);
-        }
-
-        [Fact]
-        public void ConvertToProto_InvalidData()
+            Id = "event1",
+            Type = "type1",
+            Source = new Uri("//event-source1", UriKind.RelativeOrAbsolute),
+            Data = "simple text",
+            DataContentType = "text/plain"
+        };
+        var event2 = new CloudEvent
         {
-            var cloudEvent = new CloudEvent { Data = new object() }.PopulateRequiredAttributes();
-            var formatter = new ProtobufEventFormatter();
-            Assert.Throws<ArgumentException>(() => formatter.ConvertToProto(cloudEvent));
-        }
+            Id = "event2",
+            Type = "type2",
+            Source = new Uri("//event-source2", UriKind.RelativeOrAbsolute),
+        };
 
-        [Fact]
-        public void EncodeBinaryModeData_Bytes()
+        var cloudEvents = new[] { event1, event2 };
+        var formatter = new ProtobufEventFormatter();
+        var bytes = formatter.EncodeBatchModeMessage(cloudEvents, out var contentType);
+        Assert.Equal("application/cloudevents-batch+protobuf; charset=utf-8", contentType.ToString());
+        var actualBatch = V1.CloudEventBatch.Parser.ParseFrom(bytes.ToArray());
+        var expectedBatch = new V1.CloudEventBatch
         {
-            var cloudEvent = new CloudEvent
-            {
-                Data = SampleBinaryData
-            }.PopulateRequiredAttributes();
-            var formatter = new ProtobufEventFormatter();
-
-            var result = formatter.EncodeBinaryModeEventData(cloudEvent);
-            Assert.Equal(SampleBinaryData, result.ToArray());
-        }
-
-        [Theory]
-        [InlineData("utf-8")]
-        [InlineData("iso-8859-1")]
-        [InlineData(null)]
-        public void EncodeBinaryModeData_String_TextContentType(string? charset)
-        {
-            string text = "caf\u00e9"; // Valid in both UTF-8 and ISO-8859-1, but with different representations
-            var encoding = charset is null ? Encoding.UTF8 : Encoding.GetEncoding(charset);
-            string contentType = charset is null ? "text/plain" : $"text/plain; charset={charset}";
-            var cloudEvent = new CloudEvent
-            {
-                Data = text,
-                DataContentType = contentType
-            }.PopulateRequiredAttributes();
-
-            var formatter = new ProtobufEventFormatter();
-            var result = formatter.EncodeBinaryModeEventData(cloudEvent);
-            Assert.Equal(encoding.GetBytes(text), result.ToArray());
-        }
-
-        [Fact]
-        public void EncodeBinaryModeData_String_NonTextContentType()
-        {
-            var cloudEvent = new CloudEvent
-            {
-                Data = "text",
-                DataContentType = "application/json"
-            }.PopulateRequiredAttributes();
-            var formatter = new ProtobufEventFormatter();
-            Assert.Throws<ArgumentException>(() => formatter.EncodeBinaryModeEventData(cloudEvent));
-        }
-
-        [Fact]
-        public void EncodeBinaryModeData_ProtoMessage()
-        {
-            var cloudEvent = new CloudEvent
-            {
-                Data = new PayloadData1 { Name = "fail" },
-                DataContentType = "application/protobuf"
-            }.PopulateRequiredAttributes();
-            var formatter = new ProtobufEventFormatter();
-            // See summary documentation for ProtobufEventFormatter for the reasoning for this
-            Assert.Throws<ArgumentException>(() => formatter.EncodeBinaryModeEventData(cloudEvent));
-        }
-
-        [Fact]
-        public void EncodeBinaryModeData_ArbitraryObject()
-        {
-            var cloudEvent = new CloudEvent
-            {
-                Data = new object(),
-                DataContentType = "application/octet-stream"
-            }.PopulateRequiredAttributes();
-            var formatter = new ProtobufEventFormatter();
-            // See summary documentation for ProtobufEventFormatter for the reasoning for this
-            Assert.Throws<ArgumentException>(() => formatter.EncodeBinaryModeEventData(cloudEvent));
-        }
-
-        [Fact]
-        public void EncodeBinaryModeData_NoData()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            var formatter = new ProtobufEventFormatter();
-            Assert.Empty(formatter.EncodeBinaryModeEventData(cloudEvent).ToArray());
-        }
-
-        // Just a single test for the code that parses asynchronously... the guts are all the same.
-        [Fact]
-        public async Task DecodeStructuredModeMessageAsync_Minimal()
-        {
-            var proto = CreateMinimalCloudEventProto();
-            byte[] bytes = proto.ToByteArray();
-            var stream = new MemoryStream(bytes);
-            var formatter = new ProtobufEventFormatter();
-            var cloudEvent = await formatter.DecodeStructuredModeMessageAsync(stream, s_protobufCloudEventContentType, null);
-            Assert.Equal("test-type", cloudEvent.Type);
-            Assert.Equal("test-id", cloudEvent.Id);
-            Assert.Equal(SampleUri, cloudEvent.Source);
-        }
-
-        [Fact]
-        public void DecodeStructuredModeMessage_Minimal()
-        {
-            var proto = CreateMinimalCloudEventProto();
-            byte[] bytes = proto.ToByteArray();
-            var stream = new MemoryStream(bytes);
-            var formatter = new ProtobufEventFormatter();
-            var cloudEvent = formatter.DecodeStructuredModeMessage(stream, s_protobufCloudEventContentType, null);
-            Assert.Equal("test-type", cloudEvent.Type);
-            Assert.Equal("test-id", cloudEvent.Id);
-            Assert.Equal(SampleUri, cloudEvent.Source);
-        }
-
-        [Fact]
-        public void EncodeBatchModeMessage_Empty()
-        {
-            var formatter = new ProtobufEventFormatter();
-            var bytes = formatter.EncodeBatchModeMessage(new CloudEvent[0], out var contentType);
-            Assert.Equal("application/cloudevents-batch+protobuf; charset=utf-8", contentType.ToString());
-            var batch = V1.CloudEventBatch.Parser.ParseFrom(bytes.ToArray());
-            Assert.Empty(batch.Events);
-        }
-
-        [Fact]
-        public void EncodeBatchModeMessage_TwoEvents()
-        {
-            var event1 = new CloudEvent
-            {
-                Id = "event1",
-                Type = "type1",
-                Source = new Uri("//event-source1", UriKind.RelativeOrAbsolute),
-                Data = "simple text",
-                DataContentType = "text/plain"
-            };
-            var event2 = new CloudEvent
-            {
-                Id = "event2",
-                Type = "type2",
-                Source = new Uri("//event-source2", UriKind.RelativeOrAbsolute),
-            };
-
-            var cloudEvents = new[] { event1, event2 };
-            var formatter = new ProtobufEventFormatter();
-            var bytes = formatter.EncodeBatchModeMessage(cloudEvents, out var contentType);
-            Assert.Equal("application/cloudevents-batch+protobuf; charset=utf-8", contentType.ToString());
-            var actualBatch = V1.CloudEventBatch.Parser.ParseFrom(bytes.ToArray());
-            var expectedBatch = new V1.CloudEventBatch
-            {
-                Events =
+            Events =
                 {
                     new V1.CloudEvent
                     {
@@ -344,288 +344,288 @@ namespace CloudNative.CloudEvents.Protobuf.UnitTests
                         Source = "//event-source2"
                     }
                 }
-            };
-            Assert.Equal(expectedBatch, actualBatch);
-        }
+        };
+        Assert.Equal(expectedBatch, actualBatch);
+    }
 
-        [Fact]
-        public void EncodeBatchModeMessage_Invalid()
-        {
-            var formatter = new ProtobufEventFormatter();
-            // Invalid CloudEvent
-            Assert.Throws<ArgumentException>(() => formatter.EncodeBatchModeMessage(new[] { new CloudEvent() }, out _));
-            // Null argument
-            Assert.Throws<ArgumentNullException>(() => formatter.EncodeBatchModeMessage(null!, out _));
-            // Null value within the argument. Arguably this should throw ArgumentException instead of
-            // ArgumentNullException, but it's unlikely to cause confusion.
-            Assert.Throws<ArgumentNullException>(() => formatter.EncodeBatchModeMessage(new CloudEvent[1], out _));
-        }
+    [Fact]
+    public void EncodeBatchModeMessage_Invalid()
+    {
+        var formatter = new ProtobufEventFormatter();
+        // Invalid CloudEvent
+        Assert.Throws<ArgumentException>(() => formatter.EncodeBatchModeMessage(new[] { new CloudEvent() }, out _));
+        // Null argument
+        Assert.Throws<ArgumentNullException>(() => formatter.EncodeBatchModeMessage(null!, out _));
+        // Null value within the argument. Arguably this should throw ArgumentException instead of
+        // ArgumentNullException, but it's unlikely to cause confusion.
+        Assert.Throws<ArgumentNullException>(() => formatter.EncodeBatchModeMessage(new CloudEvent[1], out _));
+    }
 
-        [Fact]
-        public void ConvertFromProto_V1Attributes()
+    [Fact]
+    public void ConvertFromProto_V1Attributes()
+    {
+        var proto = new V1.CloudEvent
         {
-            var proto = new V1.CloudEvent
-            {
-                SpecVersion = "1.0",
-                Type = "test-type",
-                Id = "test-id",
-                TextData = "text",
-                Source = "//event-source",
-                Attributes =
+            SpecVersion = "1.0",
+            Type = "test-type",
+            Id = "test-id",
+            TextData = "text",
+            Source = "//event-source",
+            Attributes =
                 {
                     { "datacontenttype", StringAttribute("text/plain") },
                     { "dataschema", UriAttribute("https://data-schema") },
                     { "subject", StringAttribute("event-subject") },
                     { "time", TimestampAttribute(SampleTimestamp) }
                 }
-            };
-            var cloudEvent = new ProtobufEventFormatter().ConvertFromProto(proto, null);
-            Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
-            Assert.Equal("test-type", cloudEvent.Type);
-            Assert.Equal("test-id", cloudEvent.Id);
-            Assert.Equal("text/plain", cloudEvent.DataContentType);
-            Assert.Equal(new Uri("https://data-schema"), cloudEvent.DataSchema);
-            Assert.Equal("event-subject", cloudEvent.Subject);
-            Assert.Equal(new Uri("//event-source", UriKind.RelativeOrAbsolute), cloudEvent.Source);
-            // The protobuf timestamp loses the offset information, but is still the correct instant.
-            AssertTimestampsEqual(SampleTimestamp.ToUniversalTime(), cloudEvent.Time);
-        }
+        };
+        var cloudEvent = new ProtobufEventFormatter().ConvertFromProto(proto, null);
+        Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
+        Assert.Equal("test-type", cloudEvent.Type);
+        Assert.Equal("test-id", cloudEvent.Id);
+        Assert.Equal("text/plain", cloudEvent.DataContentType);
+        Assert.Equal(new Uri("https://data-schema"), cloudEvent.DataSchema);
+        Assert.Equal("event-subject", cloudEvent.Subject);
+        Assert.Equal(new Uri("//event-source", UriKind.RelativeOrAbsolute), cloudEvent.Source);
+        // The protobuf timestamp loses the offset information, but is still the correct instant.
+        AssertTimestampsEqual(SampleTimestamp.ToUniversalTime(), cloudEvent.Time);
+    }
 
-        [Theory]
-        // These are required, so have to be specified in the dedicated protobuf field
-        [InlineData("id")]
-        [InlineData("type")]
-        [InlineData("source")]
-        // These are generally invalid attribute names
-        [InlineData("specversion")]
-        [InlineData("a b c")]
-        [InlineData("ABC")]
-        public void ConvertFromProto_InvalidAttributeNames(string attributeName)
+    [Theory]
+    // These are required, so have to be specified in the dedicated protobuf field
+    [InlineData("id")]
+    [InlineData("type")]
+    [InlineData("source")]
+    // These are generally invalid attribute names
+    [InlineData("specversion")]
+    [InlineData("a b c")]
+    [InlineData("ABC")]
+    public void ConvertFromProto_InvalidAttributeNames(string attributeName)
+    {
+        var proto = CreateMinimalCloudEventProto();
+        proto.Attributes.Add(attributeName, StringAttribute("value"));
+        var formatter = new ProtobufEventFormatter();
+        Assert.Throws<ArgumentException>(() => formatter.ConvertFromProto(proto, null));
+    }
+
+    [Fact]
+    public void ConvertFromProto_AllAttributeTypes()
+    {
+        var proto = CreateMinimalCloudEventProto();
+        proto.Attributes.Add("binary", BinaryAttribute(SampleBinaryData));
+        proto.Attributes.Add("boolean", BooleanAttribute(true));
+        proto.Attributes.Add("integer", IntegerAttribute(10));
+        proto.Attributes.Add("string", StringAttribute("text"));
+        proto.Attributes.Add("timestamp", TimestampAttribute(SampleTimestamp));
+        proto.Attributes.Add("uri", UriAttribute(SampleUriText));
+        proto.Attributes.Add("urireference", UriRefAttribute(SampleUriReferenceText));
+
+        var cloudEvent = new ProtobufEventFormatter().ConvertFromProto(proto, null);
+        Assert.Equal(SampleBinaryData, cloudEvent["binary"]);
+        Assert.True((bool) cloudEvent["boolean"]!);
+        Assert.Equal(10, cloudEvent["integer"]);
+        Assert.Equal("text", cloudEvent["string"]);
+        // The protobuf timestamp loses the offset information, but is still the correct instant.
+        AssertTimestampsEqual(SampleTimestamp.ToUniversalTime(), (DateTimeOffset) cloudEvent["timestamp"]!);
+        Assert.Equal(SampleUri, cloudEvent["uri"]);
+        Assert.Equal(SampleUriReference, cloudEvent["urireference"]);
+    }
+
+    [Fact]
+    public void ConvertFromProto_NoData()
+    {
+        var proto = CreateMinimalCloudEventProto();
+        var cloudEvent = new ProtobufEventFormatter().ConvertFromProto(proto, null);
+        Assert.Null(cloudEvent.Data);
+    }
+
+    [Fact]
+    public void ConvertFromProto_TextData()
+    {
+        var proto = CreateMinimalCloudEventProto();
+        proto.TextData = "text";
+        var cloudEvent = new ProtobufEventFormatter().ConvertFromProto(proto, null);
+        Assert.Equal("text", cloudEvent.Data);
+    }
+
+    [Fact]
+    public void ConvertFromProto_BinaryData()
+    {
+        var proto = CreateMinimalCloudEventProto();
+        proto.BinaryData = ByteString.CopyFrom(SampleBinaryData);
+        var cloudEvent = new ProtobufEventFormatter().ConvertFromProto(proto, null);
+        Assert.Equal(SampleBinaryData, cloudEvent.Data);
+    }
+
+    [Fact]
+    public void ConvertFromProto_MessageData()
+    {
+        var message = new PayloadData1 { Name = "testing" };
+        var proto = CreateMinimalCloudEventProto();
+        proto.ProtoData = Any.Pack(message);
+        var cloudEvent = new ProtobufEventFormatter().ConvertFromProto(proto, null);
+        // Note: this isn't unpacked automatically.
+        Assert.Equal(Any.Pack(message), cloudEvent.Data);
+    }
+
+    [Fact]
+    public void ConvertFromProto_UnspecifiedExtensionAttributes()
+    {
+        var proto = CreateMinimalCloudEventProto();
+        proto.Attributes.Add("xyz", StringAttribute("abc"));
+        var cloudEvent = new ProtobufEventFormatter().ConvertFromProto(proto, null);
+        Assert.Equal("abc", cloudEvent["xyz"]);
+    }
+
+    [Fact]
+    public void ConvertFromProto_SpecifiedExtensionAttributes_Valid()
+    {
+        var attribute = CloudEventAttribute.CreateExtension("xyz", CloudEventAttributeType.String);
+        var proto = CreateMinimalCloudEventProto();
+        proto.Attributes.Add(attribute.Name, StringAttribute("abc"));
+        var cloudEvent = new ProtobufEventFormatter().ConvertFromProto(proto, new[] { attribute });
+        Assert.Equal("abc", cloudEvent[attribute]);
+    }
+
+    [Fact]
+    public void ConvertFromProto_SpecifiedExtensionAttributes_UnexpectedType()
+    {
+        var attribute = CloudEventAttribute.CreateExtension("xyz", CloudEventAttributeType.UriReference);
+        var proto = CreateMinimalCloudEventProto();
+        proto.Attributes.Add(attribute.Name, UriAttribute("https://xyz"));
+        // Even though the value would be valid as a URI reference, we fail because
+        // the type in the proto message is not the same as the type we've specified in the method argument.
+        Assert.Throws<ArgumentException>(() => new ProtobufEventFormatter().ConvertFromProto(proto, new[] { attribute }));
+    }
+
+    [Fact]
+    public void ConvertFromProto_SpecifiedExtensionAttributes_InvalidValue()
+    {
+        var attribute = CloudEventAttribute.CreateExtension("xyz", CloudEventAttributeType.Integer, ValidateValue);
+        var proto = CreateMinimalCloudEventProto();
+        proto.Attributes.Add(attribute.Name, IntegerAttribute(1000));
+        var exception = Assert.Throws<ArgumentException>(() => new ProtobufEventFormatter().ConvertFromProto(proto, new[] { attribute }));
+        Assert.Equal("Boom!", exception!.InnerException!.Message);
+
+        void ValidateValue(object value)
         {
-            var proto = CreateMinimalCloudEventProto();
-            proto.Attributes.Add(attributeName, StringAttribute("value"));
-            var formatter = new ProtobufEventFormatter();
-            Assert.Throws<ArgumentException>(() => formatter.ConvertFromProto(proto, null));
-        }
-
-        [Fact]
-        public void ConvertFromProto_AllAttributeTypes()
-        {
-            var proto = CreateMinimalCloudEventProto();
-            proto.Attributes.Add("binary", BinaryAttribute(SampleBinaryData));
-            proto.Attributes.Add("boolean", BooleanAttribute(true));
-            proto.Attributes.Add("integer", IntegerAttribute(10));
-            proto.Attributes.Add("string", StringAttribute("text"));
-            proto.Attributes.Add("timestamp", TimestampAttribute(SampleTimestamp));
-            proto.Attributes.Add("uri", UriAttribute(SampleUriText));
-            proto.Attributes.Add("urireference", UriRefAttribute(SampleUriReferenceText));
-
-            var cloudEvent = new ProtobufEventFormatter().ConvertFromProto(proto, null);
-            Assert.Equal(SampleBinaryData, cloudEvent["binary"]);
-            Assert.True((bool) cloudEvent["boolean"]!);
-            Assert.Equal(10, cloudEvent["integer"]);
-            Assert.Equal("text", cloudEvent["string"]);
-            // The protobuf timestamp loses the offset information, but is still the correct instant.
-            AssertTimestampsEqual(SampleTimestamp.ToUniversalTime(), (DateTimeOffset) cloudEvent["timestamp"]!);
-            Assert.Equal(SampleUri, cloudEvent["uri"]);
-            Assert.Equal(SampleUriReference, cloudEvent["urireference"]);
-        }
-
-        [Fact]
-        public void ConvertFromProto_NoData()
-        {
-            var proto = CreateMinimalCloudEventProto();
-            var cloudEvent = new ProtobufEventFormatter().ConvertFromProto(proto, null);
-            Assert.Null(cloudEvent.Data);
-        }
-
-        [Fact]
-        public void ConvertFromProto_TextData()
-        {
-            var proto = CreateMinimalCloudEventProto();
-            proto.TextData = "text";
-            var cloudEvent = new ProtobufEventFormatter().ConvertFromProto(proto, null);
-            Assert.Equal("text", cloudEvent.Data);
-        }
-
-        [Fact]
-        public void ConvertFromProto_BinaryData()
-        {
-            var proto = CreateMinimalCloudEventProto();
-            proto.BinaryData = ByteString.CopyFrom(SampleBinaryData);
-            var cloudEvent = new ProtobufEventFormatter().ConvertFromProto(proto, null);
-            Assert.Equal(SampleBinaryData, cloudEvent.Data);
-        }
-
-        [Fact]
-        public void ConvertFromProto_MessageData()
-        {
-            var message = new PayloadData1 { Name = "testing" };
-            var proto = CreateMinimalCloudEventProto();
-            proto.ProtoData = Any.Pack(message);
-            var cloudEvent = new ProtobufEventFormatter().ConvertFromProto(proto, null);
-            // Note: this isn't unpacked automatically.
-            Assert.Equal(Any.Pack(message), cloudEvent.Data);
-        }
-
-        [Fact]
-        public void ConvertFromProto_UnspecifiedExtensionAttributes()
-        {
-            var proto = CreateMinimalCloudEventProto();
-            proto.Attributes.Add("xyz", StringAttribute("abc"));
-            var cloudEvent = new ProtobufEventFormatter().ConvertFromProto(proto, null);
-            Assert.Equal("abc", cloudEvent["xyz"]);
-        }
-
-        [Fact]
-        public void ConvertFromProto_SpecifiedExtensionAttributes_Valid()
-        {
-            var attribute = CloudEventAttribute.CreateExtension("xyz", CloudEventAttributeType.String);
-            var proto = CreateMinimalCloudEventProto();
-            proto.Attributes.Add(attribute.Name, StringAttribute("abc"));
-            var cloudEvent = new ProtobufEventFormatter().ConvertFromProto(proto, new[] { attribute });
-            Assert.Equal("abc", cloudEvent[attribute]);
-        }
-
-        [Fact]
-        public void ConvertFromProto_SpecifiedExtensionAttributes_UnexpectedType()
-        {
-            var attribute = CloudEventAttribute.CreateExtension("xyz", CloudEventAttributeType.UriReference);
-            var proto = CreateMinimalCloudEventProto();
-            proto.Attributes.Add(attribute.Name, UriAttribute("https://xyz"));
-            // Even though the value would be valid as a URI reference, we fail because
-            // the type in the proto message is not the same as the type we've specified in the method argument.
-            Assert.Throws<ArgumentException>(() => new ProtobufEventFormatter().ConvertFromProto(proto, new[] { attribute }));
-        }
-
-        [Fact]
-        public void ConvertFromProto_SpecifiedExtensionAttributes_InvalidValue()
-        {
-            var attribute = CloudEventAttribute.CreateExtension("xyz", CloudEventAttributeType.Integer, ValidateValue);
-            var proto = CreateMinimalCloudEventProto();
-            proto.Attributes.Add(attribute.Name, IntegerAttribute(1000));
-            var exception = Assert.Throws<ArgumentException>(() => new ProtobufEventFormatter().ConvertFromProto(proto, new[] { attribute }));
-            Assert.Equal("Boom!", exception!.InnerException!.Message);
-
-            void ValidateValue(object value)
+            if ((int) value > 100)
             {
-                if ((int) value > 100)
-                {
-                    throw new Exception("Boom!");
-                }
+                throw new Exception("Boom!");
             }
         }
+    }
 
-        [Fact]
-        public void ConvertFromProto_Invalid_NoSpecVersion()
-        {
-            var proto = CreateMinimalCloudEventProto();
-            proto.SpecVersion = "";
-            var exception = Assert.Throws<ArgumentException>(() => new ProtobufEventFormatter().ConvertFromProto(proto, null));
-        }
+    [Fact]
+    public void ConvertFromProto_Invalid_NoSpecVersion()
+    {
+        var proto = CreateMinimalCloudEventProto();
+        proto.SpecVersion = "";
+        var exception = Assert.Throws<ArgumentException>(() => new ProtobufEventFormatter().ConvertFromProto(proto, null));
+    }
 
-        [Fact]
-        public void ConvertFromProto_Invalid_NoType()
-        {
-            var proto = CreateMinimalCloudEventProto();
-            proto.SpecVersion = "";
-            var exception = Assert.Throws<ArgumentException>(() => new ProtobufEventFormatter().ConvertFromProto(proto, null));
-        }
+    [Fact]
+    public void ConvertFromProto_Invalid_NoType()
+    {
+        var proto = CreateMinimalCloudEventProto();
+        proto.SpecVersion = "";
+        var exception = Assert.Throws<ArgumentException>(() => new ProtobufEventFormatter().ConvertFromProto(proto, null));
+    }
 
-        [Fact]
-        public void ConvertFromProto_Invalid_NoId()
-        {
-            var proto = CreateMinimalCloudEventProto();
-            proto.Id = "";
-            var exception = Assert.Throws<ArgumentException>(() => new ProtobufEventFormatter().ConvertFromProto(proto, null));
-        }
+    [Fact]
+    public void ConvertFromProto_Invalid_NoId()
+    {
+        var proto = CreateMinimalCloudEventProto();
+        proto.Id = "";
+        var exception = Assert.Throws<ArgumentException>(() => new ProtobufEventFormatter().ConvertFromProto(proto, null));
+    }
 
-        [Fact]
-        public void ConvertFromProto_Invalid_NoSource()
-        {
-            var proto = CreateMinimalCloudEventProto();
-            proto.Source = "";
-            var exception = Assert.Throws<ArgumentException>(() => new ProtobufEventFormatter().ConvertFromProto(proto, null));
-        }
+    [Fact]
+    public void ConvertFromProto_Invalid_NoSource()
+    {
+        var proto = CreateMinimalCloudEventProto();
+        proto.Source = "";
+        var exception = Assert.Throws<ArgumentException>(() => new ProtobufEventFormatter().ConvertFromProto(proto, null));
+    }
 
-        [Theory]
-        [InlineData("utf-8")]
-        [InlineData("iso-8859-1")]
-        [InlineData(null)]
-        public void DecodeBinaryModeEventData_Text(string? charset)
-        {
-            string text = "caf\u00e9"; // Valid in both UTF-8 and ISO-8859-1, but with different representations
-            var encoding = charset is null ? Encoding.UTF8 : Encoding.GetEncoding(charset);
-            var bytes = encoding.GetBytes(text);
-            string contentType = charset is null ? "text/plain" : $"text/plain; charset={charset}";
-            var data = DecodeBinaryModeEventData(bytes, contentType);
-            string actualText = Assert.IsType<string>(data);
-            Assert.Equal(text, actualText);
-        }
+    [Theory]
+    [InlineData("utf-8")]
+    [InlineData("iso-8859-1")]
+    [InlineData(null)]
+    public void DecodeBinaryModeEventData_Text(string? charset)
+    {
+        string text = "caf\u00e9"; // Valid in both UTF-8 and ISO-8859-1, but with different representations
+        var encoding = charset is null ? Encoding.UTF8 : Encoding.GetEncoding(charset);
+        var bytes = encoding.GetBytes(text);
+        string contentType = charset is null ? "text/plain" : $"text/plain; charset={charset}";
+        var data = DecodeBinaryModeEventData(bytes, contentType);
+        string actualText = Assert.IsType<string>(data);
+        Assert.Equal(text, actualText);
+    }
 
-        [Theory]
-        [InlineData("application/json")]
-        [InlineData(null)]
-        public void DecodeBinaryModeData_NonTextContentType(string? contentType)
-        {
-            var bytes = Encoding.UTF8.GetBytes("{}");
-            var data = DecodeBinaryModeEventData(bytes, contentType);
-            byte[] actualBytes = Assert.IsType<byte[]>(data);
-            Assert.Equal(bytes, actualBytes);
-        }
+    [Theory]
+    [InlineData("application/json")]
+    [InlineData(null)]
+    public void DecodeBinaryModeData_NonTextContentType(string? contentType)
+    {
+        var bytes = Encoding.UTF8.GetBytes("{}");
+        var data = DecodeBinaryModeEventData(bytes, contentType);
+        byte[] actualBytes = Assert.IsType<byte[]>(data);
+        Assert.Equal(bytes, actualBytes);
+    }
 
-        [Fact]
-        public void DecodeBatchMode_Minimal()
+    [Fact]
+    public void DecodeBatchMode_Minimal()
+    {
+        var batchProto = new V1.CloudEventBatch
         {
-            var batchProto = new V1.CloudEventBatch
-            {
-                Events = { CreateMinimalCloudEventProto() }
-            };
-            byte[] bytes = batchProto.ToByteArray();
-            var stream = new MemoryStream(bytes);
-            var formatter = new ProtobufEventFormatter();
-            var cloudEvents = formatter.DecodeBatchModeMessage(stream, s_protobufCloudEventBatchContentType, null);
-            var cloudEvent = Assert.Single(cloudEvents);
-            Assert.Equal("test-type", cloudEvent.Type);
-            Assert.Equal("test-id", cloudEvent.Id);
-            Assert.Equal(SampleUri, cloudEvent.Source);
-        }
+            Events = { CreateMinimalCloudEventProto() }
+        };
+        byte[] bytes = batchProto.ToByteArray();
+        var stream = new MemoryStream(bytes);
+        var formatter = new ProtobufEventFormatter();
+        var cloudEvents = formatter.DecodeBatchModeMessage(stream, s_protobufCloudEventBatchContentType, null);
+        var cloudEvent = Assert.Single(cloudEvents);
+        Assert.Equal("test-type", cloudEvent.Type);
+        Assert.Equal("test-id", cloudEvent.Id);
+        Assert.Equal(SampleUri, cloudEvent.Source);
+    }
 
-        // Just a single test for the code that parses asynchronously... the guts are all the same.
-        [Fact]
-        public async Task DecodeBatchModeMessageAsync_Minimal()
+    // Just a single test for the code that parses asynchronously... the guts are all the same.
+    [Fact]
+    public async Task DecodeBatchModeMessageAsync_Minimal()
+    {
+        var batchProto = new V1.CloudEventBatch
         {
-            var batchProto = new V1.CloudEventBatch
-            {
-                Events = { CreateMinimalCloudEventProto() }
-            };
-            byte[] bytes = batchProto.ToByteArray();
-            var stream = new MemoryStream(bytes);
-            var formatter = new ProtobufEventFormatter();
-            var cloudEvents = await formatter.DecodeBatchModeMessageAsync(stream, s_protobufCloudEventBatchContentType, null);
-            var cloudEvent = Assert.Single(cloudEvents);
-            Assert.Equal("test-type", cloudEvent.Type);
-            Assert.Equal("test-id", cloudEvent.Id);
-            Assert.Equal(SampleUri, cloudEvent.Source);
-        }
+            Events = { CreateMinimalCloudEventProto() }
+        };
+        byte[] bytes = batchProto.ToByteArray();
+        var stream = new MemoryStream(bytes);
+        var formatter = new ProtobufEventFormatter();
+        var cloudEvents = await formatter.DecodeBatchModeMessageAsync(stream, s_protobufCloudEventBatchContentType, null);
+        var cloudEvent = Assert.Single(cloudEvents);
+        Assert.Equal("test-type", cloudEvent.Type);
+        Assert.Equal("test-id", cloudEvent.Id);
+        Assert.Equal(SampleUri, cloudEvent.Source);
+    }
 
-        [Fact]
-        public void DecodeBatchMode_Empty()
-        {
-            var batchProto = new V1.CloudEventBatch();
-            byte[] bytes = batchProto.ToByteArray();
-            var stream = new MemoryStream(bytes);
-            var formatter = new ProtobufEventFormatter();
-            var cloudEvents = formatter.DecodeBatchModeMessage(stream, s_protobufCloudEventBatchContentType, null);
-            Assert.Empty(cloudEvents);
-        }
+    [Fact]
+    public void DecodeBatchMode_Empty()
+    {
+        var batchProto = new V1.CloudEventBatch();
+        byte[] bytes = batchProto.ToByteArray();
+        var stream = new MemoryStream(bytes);
+        var formatter = new ProtobufEventFormatter();
+        var cloudEvents = formatter.DecodeBatchModeMessage(stream, s_protobufCloudEventBatchContentType, null);
+        Assert.Empty(cloudEvents);
+    }
 
-        [Fact]
-        public void DecodeBatchMode_Multiple()
+    [Fact]
+    public void DecodeBatchMode_Multiple()
+    {
+        var batchProto = new V1.CloudEventBatch
         {
-            var batchProto = new V1.CloudEventBatch
-            {
-                Events =
+            Events =
                 {
                     new V1.CloudEvent
                     {
@@ -644,70 +644,69 @@ namespace CloudNative.CloudEvents.Protobuf.UnitTests
                         Source = "//event-source2"
                     }
                 }
-            };
-
-
-            byte[] bytes = batchProto.ToByteArray();
-            var stream = new MemoryStream(bytes);
-            var formatter = new ProtobufEventFormatter();
-            var cloudEvents = formatter.DecodeBatchModeMessage(stream, s_protobufCloudEventBatchContentType, null);
-            Assert.Equal(2, cloudEvents.Count);
-
-            var event1 = cloudEvents[0];
-            Assert.Equal("type1", event1.Type);
-            Assert.Equal("event1", event1.Id);
-            Assert.Equal(new Uri("//event-source1", UriKind.RelativeOrAbsolute), event1.Source);
-            Assert.Equal("simple text", event1.Data);
-            Assert.Equal("text/plain", event1.DataContentType);
-
-            var event2 = cloudEvents[1];
-            Assert.Equal("type2", event2.Type);
-            Assert.Equal("event2", event2.Id);
-            Assert.Equal(new Uri("//event-source2", UriKind.RelativeOrAbsolute), event2.Source);
-            Assert.Null(event2.Data);
-            Assert.Null(event2.DataContentType);
-        }
-
-        // Utility methods
-
-        private static object? DecodeBinaryModeEventData(byte[] bytes, string? contentType)
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.DataContentType = contentType;
-            new ProtobufEventFormatter().DecodeBinaryModeEventData(bytes, cloudEvent);
-            return cloudEvent.Data;
-        }
-
-        private static CloudEventAttributeValue StringAttribute(string value) =>
-            new CloudEventAttributeValue { CeString = value };
-
-        private static CloudEventAttributeValue BinaryAttribute(byte[] value) =>
-            new CloudEventAttributeValue { CeBytes = ByteString.CopyFrom(value) };
-
-        private static CloudEventAttributeValue BooleanAttribute(bool value) =>
-            new CloudEventAttributeValue { CeBoolean = value };
-
-        private static CloudEventAttributeValue IntegerAttribute(int value) =>
-            new CloudEventAttributeValue { CeInteger = value };
-
-        private static CloudEventAttributeValue UriAttribute(string value) =>
-            new CloudEventAttributeValue { CeUri = value };
-
-        private static CloudEventAttributeValue UriRefAttribute(string value) =>
-            new CloudEventAttributeValue { CeUriRef = value };
-
-        private static CloudEventAttributeValue TimestampAttribute(Timestamp value) =>
-            new CloudEventAttributeValue { CeTimestamp = value };
-
-        private static CloudEventAttributeValue TimestampAttribute(DateTimeOffset value) =>
-            TimestampAttribute(Timestamp.FromDateTimeOffset(value));
-
-        private static V1.CloudEvent CreateMinimalCloudEventProto() => new V1.CloudEvent
-        {
-            SpecVersion = "1.0",
-            Type = "test-type",
-            Id = "test-id",
-            Source = SampleUriText
         };
+
+
+        byte[] bytes = batchProto.ToByteArray();
+        var stream = new MemoryStream(bytes);
+        var formatter = new ProtobufEventFormatter();
+        var cloudEvents = formatter.DecodeBatchModeMessage(stream, s_protobufCloudEventBatchContentType, null);
+        Assert.Equal(2, cloudEvents.Count);
+
+        var event1 = cloudEvents[0];
+        Assert.Equal("type1", event1.Type);
+        Assert.Equal("event1", event1.Id);
+        Assert.Equal(new Uri("//event-source1", UriKind.RelativeOrAbsolute), event1.Source);
+        Assert.Equal("simple text", event1.Data);
+        Assert.Equal("text/plain", event1.DataContentType);
+
+        var event2 = cloudEvents[1];
+        Assert.Equal("type2", event2.Type);
+        Assert.Equal("event2", event2.Id);
+        Assert.Equal(new Uri("//event-source2", UriKind.RelativeOrAbsolute), event2.Source);
+        Assert.Null(event2.Data);
+        Assert.Null(event2.DataContentType);
     }
+
+    // Utility methods
+
+    private static object? DecodeBinaryModeEventData(byte[] bytes, string? contentType)
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.DataContentType = contentType;
+        new ProtobufEventFormatter().DecodeBinaryModeEventData(bytes, cloudEvent);
+        return cloudEvent.Data;
+    }
+
+    private static CloudEventAttributeValue StringAttribute(string value) =>
+        new CloudEventAttributeValue { CeString = value };
+
+    private static CloudEventAttributeValue BinaryAttribute(byte[] value) =>
+        new CloudEventAttributeValue { CeBytes = ByteString.CopyFrom(value) };
+
+    private static CloudEventAttributeValue BooleanAttribute(bool value) =>
+        new CloudEventAttributeValue { CeBoolean = value };
+
+    private static CloudEventAttributeValue IntegerAttribute(int value) =>
+        new CloudEventAttributeValue { CeInteger = value };
+
+    private static CloudEventAttributeValue UriAttribute(string value) =>
+        new CloudEventAttributeValue { CeUri = value };
+
+    private static CloudEventAttributeValue UriRefAttribute(string value) =>
+        new CloudEventAttributeValue { CeUriRef = value };
+
+    private static CloudEventAttributeValue TimestampAttribute(Timestamp value) =>
+        new CloudEventAttributeValue { CeTimestamp = value };
+
+    private static CloudEventAttributeValue TimestampAttribute(DateTimeOffset value) =>
+        TimestampAttribute(Timestamp.FromDateTimeOffset(value));
+
+    private static V1.CloudEvent CreateMinimalCloudEventProto() => new V1.CloudEvent
+    {
+        SpecVersion = "1.0",
+        Type = "test-type",
+        Id = "test-id",
+        Source = SampleUriText
+    };
 }

--- a/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/AttributedModel.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/AttributedModel.cs
@@ -4,14 +4,13 @@
 
 using System.Text.Json.Serialization;
 
-namespace CloudNative.CloudEvents.SystemTextJson.UnitTests
-{
-    [CloudEventFormatter(typeof(JsonEventFormatter<AttributedModel>))]
-    internal class AttributedModel
-    {
-        public const string JsonPropertyName = "customattribute";
+namespace CloudNative.CloudEvents.SystemTextJson.UnitTests;
 
-        [JsonPropertyName(JsonPropertyName)]
-        public string? AttributedProperty { get; set; }
-    }
+[CloudEventFormatter(typeof(JsonEventFormatter<AttributedModel>))]
+internal class AttributedModel
+{
+    public const string JsonPropertyName = "customattribute";
+
+    [JsonPropertyName(JsonPropertyName)]
+    public string? AttributedProperty { get; set; }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/GenericJsonEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/GenericJsonEventFormatterTest.cs
@@ -10,166 +10,165 @@ using System.Text;
 using System.Text.Json;
 using Xunit;
 
-namespace CloudNative.CloudEvents.SystemTextJson.UnitTests
+namespace CloudNative.CloudEvents.SystemTextJson.UnitTests;
+
+/// <summary>
+/// Tests for <see cref="JsonEventFormatter{T}"/>
+/// </summary>
+public class GenericJsonEventFormatterTest
 {
-    /// <summary>
-    /// Tests for <see cref="JsonEventFormatter{T}"/>
-    /// </summary>
-    public class GenericJsonEventFormatterTest
+    [Fact]
+    public void DecodeStructuredMode()
     {
-        [Fact]
-        public void DecodeStructuredMode()
-        {
-            var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
-            obj["data"] = new JObject { [AttributedModel.JsonPropertyName] = "test" };
-            byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
+        var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
+        obj["data"] = new JObject { [AttributedModel.JsonPropertyName] = "test" };
+        byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
 
-            var formatter = CreateFormatter<AttributedModel>();
-            var cloudEvent = formatter.DecodeStructuredModeMessage(bytes, null, null);
+        var formatter = CreateFormatter<AttributedModel>();
+        var cloudEvent = formatter.DecodeStructuredModeMessage(bytes, null, null);
 
-            var model = (AttributedModel) cloudEvent.Data!;
-            Assert.Equal("test", model.AttributedProperty);
-        }
+        var model = (AttributedModel) cloudEvent.Data!;
+        Assert.Equal("test", model.AttributedProperty);
+    }
 
-        [Fact]
-        public void DecodeStructuredMode_ContentTypeIgnored()
-        {
-            var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
-            obj["data"] = new JObject { [AttributedModel.JsonPropertyName] = "test" };
-            byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
+    [Fact]
+    public void DecodeStructuredMode_ContentTypeIgnored()
+    {
+        var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
+        obj["data"] = new JObject { [AttributedModel.JsonPropertyName] = "test" };
+        byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
 
-            var formatter = CreateFormatter<AttributedModel>();
-            var cloudEvent = formatter.DecodeStructuredModeMessage(bytes, new ContentType("text/plain"), null);
+        var formatter = CreateFormatter<AttributedModel>();
+        var cloudEvent = formatter.DecodeStructuredModeMessage(bytes, new ContentType("text/plain"), null);
 
-            var model = (AttributedModel) cloudEvent.Data!;
-            Assert.Equal("test", model.AttributedProperty);
-        }
+        var model = (AttributedModel) cloudEvent.Data!;
+        Assert.Equal("test", model.AttributedProperty);
+    }
 
-        [Fact]
-        public void DecodeStructuredMode_NoData()
-        {
-            var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
-            byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
+    [Fact]
+    public void DecodeStructuredMode_NoData()
+    {
+        var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
+        byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
 
-            var formatter = CreateFormatter<AttributedModel>();
-            var cloudEvent = formatter.DecodeStructuredModeMessage(bytes, null, null);
-            Assert.Null(cloudEvent.Data);
-        }
+        var formatter = CreateFormatter<AttributedModel>();
+        var cloudEvent = formatter.DecodeStructuredModeMessage(bytes, null, null);
+        Assert.Null(cloudEvent.Data);
+    }
 
-        [Fact]
-        public void DecodeStructuredMode_Base64Data()
-        {
-            var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
-            obj["data_base64"] = Convert.ToBase64String(Encoding.UTF8.GetBytes("{}"));
-            byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
+    [Fact]
+    public void DecodeStructuredMode_Base64Data()
+    {
+        var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
+        obj["data_base64"] = Convert.ToBase64String(Encoding.UTF8.GetBytes("{}"));
+        byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
 
-            var formatter = CreateFormatter<AttributedModel>();
-            Assert.Throws<ArgumentException>(() => formatter.DecodeStructuredModeMessage(bytes, null, null));
-        }
+        var formatter = CreateFormatter<AttributedModel>();
+        Assert.Throws<ArgumentException>(() => formatter.DecodeStructuredModeMessage(bytes, null, null));
+    }
 
-        [Fact]
-        public void DecodeBinaryEventModeData()
-        {
-            var obj = new JObject { [AttributedModel.JsonPropertyName] = "test" };
-            byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
+    [Fact]
+    public void DecodeBinaryEventModeData()
+    {
+        var obj = new JObject { [AttributedModel.JsonPropertyName] = "test" };
+        byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
 
-            var formatter = CreateFormatter<AttributedModel>();
-            var cloudEvent = new CloudEvent();
-            formatter.DecodeBinaryModeEventData(bytes, cloudEvent);
+        var formatter = CreateFormatter<AttributedModel>();
+        var cloudEvent = new CloudEvent();
+        formatter.DecodeBinaryModeEventData(bytes, cloudEvent);
 
-            var model = (AttributedModel) cloudEvent.Data!;
-            Assert.Equal("test", model.AttributedProperty);
-        }
+        var model = (AttributedModel) cloudEvent.Data!;
+        Assert.Equal("test", model.AttributedProperty);
+    }
 
-        [Fact]
-        public void DecodeBinaryEventModeData_NoData()
-        {
-            var formatter = CreateFormatter<AttributedModel>();
-            var cloudEvent = new CloudEvent { Data = "original" };
-            formatter.DecodeBinaryModeEventData(new byte[0], cloudEvent);
-            Assert.Null(cloudEvent.Data);
-        }
+    [Fact]
+    public void DecodeBinaryEventModeData_NoData()
+    {
+        var formatter = CreateFormatter<AttributedModel>();
+        var cloudEvent = new CloudEvent { Data = "original" };
+        formatter.DecodeBinaryModeEventData(new byte[0], cloudEvent);
+        Assert.Null(cloudEvent.Data);
+    }
 
-        [Fact]
-        public void EncodeStructuredMode()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new AttributedModel { AttributedProperty = "test" };
-            var formatter = CreateFormatter<AttributedModel>();
-            var body = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
-            var element = JsonEventFormatterTest.ParseJson(body);
-            Assert.False(element.TryGetProperty("data_base64", out _));
-            var data = element.GetProperty("data");
+    [Fact]
+    public void EncodeStructuredMode()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new AttributedModel { AttributedProperty = "test" };
+        var formatter = CreateFormatter<AttributedModel>();
+        var body = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
+        var element = JsonEventFormatterTest.ParseJson(body);
+        Assert.False(element.TryGetProperty("data_base64", out _));
+        var data = element.GetProperty("data");
 
-            new JsonElementAsserter
+        new JsonElementAsserter
             {
                 { AttributedModel.JsonPropertyName, JsonValueKind.String, "test" }
             }.AssertProperties(data, assertCount: true);
-        }
+    }
 
-        [Fact]
-        public void EncodeStructuredMode_NoData()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+    [Fact]
+    public void EncodeStructuredMode_NoData()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
 
-            var formatter = CreateFormatter<AttributedModel>();
-            var body = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
-            var element = JsonEventFormatterTest.ParseJson(body);
-            Assert.False(element.TryGetProperty("data", out _));
-            Assert.False(element.TryGetProperty("data_base64", out _));
-        }
+        var formatter = CreateFormatter<AttributedModel>();
+        var body = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
+        var element = JsonEventFormatterTest.ParseJson(body);
+        Assert.False(element.TryGetProperty("data", out _));
+        Assert.False(element.TryGetProperty("data_base64", out _));
+    }
 
-        [Fact]
-        public void EncodeStructuredMode_WrongType()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new OtherModelClass { Text = "Wrong type" };
-            var formatter = CreateFormatter<AttributedModel>();
-            Assert.Throws<InvalidCastException>(() => formatter.EncodeStructuredModeMessage(cloudEvent, out _));
-        }
+    [Fact]
+    public void EncodeStructuredMode_WrongType()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new OtherModelClass { Text = "Wrong type" };
+        var formatter = CreateFormatter<AttributedModel>();
+        Assert.Throws<InvalidCastException>(() => formatter.EncodeStructuredModeMessage(cloudEvent, out _));
+    }
 
-        [Fact]
-        public void EncodeBinaryModeEventData()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new AttributedModel { AttributedProperty = "test" };
-            var formatter = CreateFormatter<AttributedModel>();
-            var body = formatter.EncodeBinaryModeEventData(cloudEvent);
-            var jobject = JsonEventFormatterTest.ParseJson(body);
+    [Fact]
+    public void EncodeBinaryModeEventData()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new AttributedModel { AttributedProperty = "test" };
+        var formatter = CreateFormatter<AttributedModel>();
+        var body = formatter.EncodeBinaryModeEventData(cloudEvent);
+        var jobject = JsonEventFormatterTest.ParseJson(body);
 
-            new JsonElementAsserter
+        new JsonElementAsserter
             {
                 { AttributedModel.JsonPropertyName, JsonValueKind.String, "test" }
             }.AssertProperties(jobject, assertCount: true);
-        }
+    }
 
-        [Fact]
-        public void EncodeBinaryModeEventData_NoData()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            var formatter = CreateFormatter<AttributedModel>();
-            Assert.True(formatter.EncodeBinaryModeEventData(cloudEvent).IsEmpty);
-        }
+    [Fact]
+    public void EncodeBinaryModeEventData_NoData()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        var formatter = CreateFormatter<AttributedModel>();
+        Assert.True(formatter.EncodeBinaryModeEventData(cloudEvent).IsEmpty);
+    }
 
-        [Fact]
-        public void EncodeBinaryModeEventData_WrongType()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new OtherModelClass { Text = "Wrong type" };
-            var formatter = CreateFormatter<AttributedModel>();
-            Assert.Throws<InvalidCastException>(() => formatter.EncodeBinaryModeEventData(cloudEvent));
-        }
+    [Fact]
+    public void EncodeBinaryModeEventData_WrongType()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new OtherModelClass { Text = "Wrong type" };
+        var formatter = CreateFormatter<AttributedModel>();
+        Assert.Throws<InvalidCastException>(() => formatter.EncodeBinaryModeEventData(cloudEvent));
+    }
 
-        private static CloudEventFormatter CreateFormatter<T>()
-        {
-            var formatter = CloudEventFormatterAttribute.CreateFormatter(typeof(T));
-            Assert.NotNull(formatter);
-            return formatter!;
-        }
+    private static CloudEventFormatter CreateFormatter<T>()
+    {
+        var formatter = CloudEventFormatterAttribute.CreateFormatter(typeof(T));
+        Assert.NotNull(formatter);
+        return formatter!;
+    }
 
-        private class OtherModelClass
-        {
-            public string? Text { get; set; }
-        }
+    private class OtherModelClass
+    {
+        public string? Text { get; set; }
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/JsonElementAsserter.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/JsonElementAsserter.cs
@@ -9,47 +9,46 @@ using System.Linq;
 using System.Text.Json;
 using Xunit;
 
-namespace CloudNative.CloudEvents.SystemTextJson.UnitTests
+namespace CloudNative.CloudEvents.SystemTextJson.UnitTests;
+
+internal class JsonElementAsserter : IEnumerable
 {
-    internal class JsonElementAsserter : IEnumerable
+    private readonly List<(string name, JsonValueKind type, object? value)> expectations = new List<(string, JsonValueKind, object?)>();
+
+    // Just for collection initializers
+    public IEnumerator GetEnumerator() => throw new NotImplementedException();
+
+    public void Add<T>(string name, JsonValueKind type, T value) =>
+        expectations.Add((name, type, value));
+
+    public void AssertProperties(JsonElement obj, bool assertCount)
     {
-        private readonly List<(string name, JsonValueKind type, object? value)> expectations = new List<(string, JsonValueKind, object?)>();
-
-        // Just for collection initializers
-        public IEnumerator GetEnumerator() => throw new NotImplementedException();
-
-        public void Add<T>(string name, JsonValueKind type, T value) =>
-            expectations.Add((name, type, value));
-
-        public void AssertProperties(JsonElement obj, bool assertCount)
+        foreach (var expectation in expectations)
         {
-            foreach (var expectation in expectations)
+            Assert.True(
+                obj.TryGetProperty(expectation.name, out var property),
+                $"Expected property '{expectation.name}' to be present");
+            Assert.Equal(expectation.type, property.ValueKind);
+            // No need to check null values, as they'll have a null token type.
+            if (expectation.value is object)
             {
-                Assert.True(
-                    obj.TryGetProperty(expectation.name, out var property),
-                    $"Expected property '{expectation.name}' to be present");
-                Assert.Equal(expectation.type, property.ValueKind);
-                // No need to check null values, as they'll have a null token type.
-                if (expectation.value is object)
+                var value = property.ValueKind switch
                 {
-                    var value = property.ValueKind switch
-                    {
-                        JsonValueKind.True => true,
-                        JsonValueKind.False => false,
-                        JsonValueKind.String => property.GetString(),
-                        JsonValueKind.Number => property.GetInt32(),
-                        JsonValueKind.Null => (object?) null,
-                        JsonValueKind.Object => JsonSerializer.Deserialize(property.GetRawText(), expectation.value.GetType()),
-                        _ => throw new Exception($"Unhandled value kind: {property.ValueKind}")
-                    };
+                    JsonValueKind.True => true,
+                    JsonValueKind.False => false,
+                    JsonValueKind.String => property.GetString(),
+                    JsonValueKind.Number => property.GetInt32(),
+                    JsonValueKind.Null => (object?) null,
+                    JsonValueKind.Object => JsonSerializer.Deserialize(property.GetRawText(), expectation.value.GetType()),
+                    _ => throw new Exception($"Unhandled value kind: {property.ValueKind}")
+                };
 
-                    Assert.Equal(expectation.value, value);
-                }
+                Assert.Equal(expectation.value, value);
             }
-            if (assertCount)
-            {
-                Assert.Equal(expectations.Count, obj.EnumerateObject().Count());
-            }
+        }
+        if (assertCount)
+        {
+            Assert.Equal(expectations.Count, obj.EnumerateObject().Count());
         }
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/JsonEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/JsonEventFormatterTest.cs
@@ -20,37 +20,37 @@ using JArray = Newtonsoft.Json.Linq.JArray;
 // JObject is a really handy way of creating JSON which we can then parse with System.Text.Json
 using JObject = Newtonsoft.Json.Linq.JObject;
 
-namespace CloudNative.CloudEvents.SystemTextJson.UnitTests
+namespace CloudNative.CloudEvents.SystemTextJson.UnitTests;
+
+public class JsonEventFormatterTest
 {
-    public class JsonEventFormatterTest
+    private static readonly ContentType s_jsonCloudEventContentType = new ContentType("application/cloudevents+json; charset=utf-8");
+    private static readonly ContentType s_jsonCloudEventBatchContentType = new ContentType("application/cloudevents-batch+json; charset=utf-8");
+    private const string NonAsciiValue = "GBP=\u00a3";
+
+    /// <summary>
+    /// A simple test that populates all known v1.0 attributes, so we don't need to test that
+    /// aspect in the future.
+    /// </summary>
+    [Fact]
+    public void EncodeStructuredModeMessage_V1Attributes()
     {
-        private static readonly ContentType s_jsonCloudEventContentType = new ContentType("application/cloudevents+json; charset=utf-8");
-        private static readonly ContentType s_jsonCloudEventBatchContentType = new ContentType("application/cloudevents-batch+json; charset=utf-8");
-        private const string NonAsciiValue = "GBP=\u00a3";
-
-        /// <summary>
-        /// A simple test that populates all known v1.0 attributes, so we don't need to test that
-        /// aspect in the future.
-        /// </summary>
-        [Fact]
-        public void EncodeStructuredModeMessage_V1Attributes()
+        var cloudEvent = new CloudEvent(CloudEventsSpecVersion.V1_0)
         {
-            var cloudEvent = new CloudEvent(CloudEventsSpecVersion.V1_0)
-            {
-                Data = "text", // Just so that it's reasonable to have a DataContentType
-                DataContentType = "text/plain",
-                DataSchema = new Uri("https://data-schema"),
-                Id = "event-id",
-                Source = new Uri("https://event-source"),
-                Subject = "event-subject",
-                Time = new DateTimeOffset(2021, 2, 19, 12, 34, 56, 789, TimeSpan.FromHours(1)),
-                Type = "event-type"
-            };
+            Data = "text", // Just so that it's reasonable to have a DataContentType
+            DataContentType = "text/plain",
+            DataSchema = new Uri("https://data-schema"),
+            Id = "event-id",
+            Source = new Uri("https://event-source"),
+            Subject = "event-subject",
+            Time = new DateTimeOffset(2021, 2, 19, 12, 34, 56, 789, TimeSpan.FromHours(1)),
+            Type = "event-type"
+        };
 
-            var encoded = new JsonEventFormatter().EncodeStructuredModeMessage(cloudEvent, out var contentType);
-            Assert.Equal("application/cloudevents+json; charset=utf-8", contentType.ToString());
-            JsonElement obj = ParseJson(encoded);
-            var asserter = new JsonElementAsserter
+        var encoded = new JsonEventFormatter().EncodeStructuredModeMessage(cloudEvent, out var contentType);
+        Assert.Equal("application/cloudevents+json; charset=utf-8", contentType.ToString());
+        JsonElement obj = ParseJson(encoded);
+        var asserter = new JsonElementAsserter
             {
                 { "data", JsonValueKind.String, "text" },
                 { "datacontenttype", JsonValueKind.String, "text/plain" },
@@ -62,27 +62,27 @@ namespace CloudNative.CloudEvents.SystemTextJson.UnitTests
                 { "time", JsonValueKind.String, "2021-02-19T12:34:56.789+01:00" },
                 { "type", JsonValueKind.String, "event-type" },
             };
-            asserter.AssertProperties(obj, assertCount: true);
-        }
+        asserter.AssertProperties(obj, assertCount: true);
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_AllAttributeTypes()
+    [Fact]
+    public void EncodeStructuredModeMessage_AllAttributeTypes()
+    {
+        var cloudEvent = new CloudEvent(AllTypesExtensions)
         {
-            var cloudEvent = new CloudEvent(AllTypesExtensions)
-            {
-                ["binary"] = SampleBinaryData,
-                ["boolean"] = true,
-                ["integer"] = 10,
-                ["string"] = "text",
-                ["timestamp"] = SampleTimestamp,
-                ["uri"] = SampleUri,
-                ["urireference"] = SampleUriReference
-            };
-            // We're not going to check these.
-            cloudEvent.PopulateRequiredAttributes();
+            ["binary"] = SampleBinaryData,
+            ["boolean"] = true,
+            ["integer"] = 10,
+            ["string"] = "text",
+            ["timestamp"] = SampleTimestamp,
+            ["uri"] = SampleUri,
+            ["urireference"] = SampleUriReference
+        };
+        // We're not going to check these.
+        cloudEvent.PopulateRequiredAttributes();
 
-            JsonElement element = EncodeAndParseStructured(cloudEvent);
-            var asserter = new JsonElementAsserter
+        JsonElement element = EncodeAndParseStructured(cloudEvent);
+        var asserter = new JsonElementAsserter
             {
                 { "binary", JsonValueKind.String, SampleBinaryDataBase64 },
                 { "boolean", JsonValueKind.True, true },
@@ -92,385 +92,385 @@ namespace CloudNative.CloudEvents.SystemTextJson.UnitTests
                 { "uri", JsonValueKind.String, SampleUriText },
                 { "urireference", JsonValueKind.String, SampleUriReferenceText },
             };
-            asserter.AssertProperties(element, assertCount: false);
-        }
+        asserter.AssertProperties(element, assertCount: false);
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_JsonDataType_ObjectSerialization()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new { Text = "simple text" };
-            cloudEvent.DataContentType = "application/json";
-            JsonElement element = EncodeAndParseStructured(cloudEvent);
-            JsonElement dataProperty = element.GetProperty("data");
-            var asserter = new JsonElementAsserter
+    [Fact]
+    public void EncodeStructuredModeMessage_JsonDataType_ObjectSerialization()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new { Text = "simple text" };
+        cloudEvent.DataContentType = "application/json";
+        JsonElement element = EncodeAndParseStructured(cloudEvent);
+        JsonElement dataProperty = element.GetProperty("data");
+        var asserter = new JsonElementAsserter
             {
                 { "Text", JsonValueKind.String, "simple text" }
             };
-            asserter.AssertProperties(dataProperty, assertCount: true);
-        }
+        asserter.AssertProperties(dataProperty, assertCount: true);
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_JsonDataType_NumberSerialization()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = 10;
-            cloudEvent.DataContentType = "application/json";
-            JsonElement element = EncodeAndParseStructured(cloudEvent);
-            var asserter = new JsonElementAsserter
+    [Fact]
+    public void EncodeStructuredModeMessage_JsonDataType_NumberSerialization()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = 10;
+        cloudEvent.DataContentType = "application/json";
+        JsonElement element = EncodeAndParseStructured(cloudEvent);
+        var asserter = new JsonElementAsserter
             {
                 { "data", JsonValueKind.Number, 10 }
             };
-            asserter.AssertProperties(element, assertCount: false);
-        }
+        asserter.AssertProperties(element, assertCount: false);
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_JsonDataType_CustomSerializerOptions()
+    [Fact]
+    public void EncodeStructuredModeMessage_JsonDataType_CustomSerializerOptions()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new { DateValue = new DateTime(2021, 2, 19, 12, 49, 34, DateTimeKind.Utc) };
+        cloudEvent.DataContentType = "application/json";
+
+        var serializerOptions = new JsonSerializerOptions
         {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new { DateValue = new DateTime(2021, 2, 19, 12, 49, 34, DateTimeKind.Utc) };
-            cloudEvent.DataContentType = "application/json";
-
-            var serializerOptions = new JsonSerializerOptions
-            {
-                Converters = { new YearMonthDayConverter() },
-            };
-            var formatter = new JsonEventFormatter(serializerOptions, default);
-            var encoded = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
-            JsonElement element = ParseJson(encoded);
-            JsonElement dataProperty = element.GetProperty("data");
-            var asserter = new JsonElementAsserter
+            Converters = { new YearMonthDayConverter() },
+        };
+        var formatter = new JsonEventFormatter(serializerOptions, default);
+        var encoded = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
+        JsonElement element = ParseJson(encoded);
+        JsonElement dataProperty = element.GetProperty("data");
+        var asserter = new JsonElementAsserter
             {
                 { "DateValue", JsonValueKind.String, "2021-02-19" }
             };
-            asserter.AssertProperties(dataProperty, assertCount: true);
-        }
+        asserter.AssertProperties(dataProperty, assertCount: true);
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_JsonDataType_AttributedModel()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new AttributedModel { AttributedProperty = "simple text" };
-            cloudEvent.DataContentType = "application/json";
-            JsonElement element = EncodeAndParseStructured(cloudEvent);
-            JsonElement dataProperty = element.GetProperty("data");
-            var asserter = new JsonElementAsserter
+    [Fact]
+    public void EncodeStructuredModeMessage_JsonDataType_AttributedModel()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new AttributedModel { AttributedProperty = "simple text" };
+        cloudEvent.DataContentType = "application/json";
+        JsonElement element = EncodeAndParseStructured(cloudEvent);
+        JsonElement dataProperty = element.GetProperty("data");
+        var asserter = new JsonElementAsserter
             {
                 { AttributedModel.JsonPropertyName, JsonValueKind.String, "simple text" }
             };
-            asserter.AssertProperties(dataProperty, assertCount: true);
-        }
+        asserter.AssertProperties(dataProperty, assertCount: true);
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_JsonDataType_JsonElementObject()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = ParseJson("{ \"value\": { \"Key\": \"value\" } }").GetProperty("value");
-            cloudEvent.DataContentType = "application/json";
-            JsonElement element = EncodeAndParseStructured(cloudEvent);
-            JsonElement data = element.GetProperty("data");
-            var asserter = new JsonElementAsserter
+    [Fact]
+    public void EncodeStructuredModeMessage_JsonDataType_JsonElementObject()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = ParseJson("{ \"value\": { \"Key\": \"value\" } }").GetProperty("value");
+        cloudEvent.DataContentType = "application/json";
+        JsonElement element = EncodeAndParseStructured(cloudEvent);
+        JsonElement data = element.GetProperty("data");
+        var asserter = new JsonElementAsserter
             {
                 { "Key", JsonValueKind.String, "value" }
             };
-            asserter.AssertProperties(data, assertCount: true);
-        }
+        asserter.AssertProperties(data, assertCount: true);
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_JsonDataType_JsonElementString()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = ParseJson("{ \"value\": \"text\" }").GetProperty("value");
-            cloudEvent.DataContentType = "application/json";
-            JsonElement element = EncodeAndParseStructured(cloudEvent);
-            JsonElement data = element.GetProperty("data");
-            Assert.Equal(JsonValueKind.String, data.ValueKind);
-            Assert.Equal("text", data.GetString());
-        }
+    [Fact]
+    public void EncodeStructuredModeMessage_JsonDataType_JsonElementString()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = ParseJson("{ \"value\": \"text\" }").GetProperty("value");
+        cloudEvent.DataContentType = "application/json";
+        JsonElement element = EncodeAndParseStructured(cloudEvent);
+        JsonElement data = element.GetProperty("data");
+        Assert.Equal(JsonValueKind.String, data.ValueKind);
+        Assert.Equal("text", data.GetString());
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_JsonDataType_JsonElementNull()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = ParseJson("{ \"value\": null }").GetProperty("value");
-            cloudEvent.DataContentType = "application/json";
-            JsonElement element = EncodeAndParseStructured(cloudEvent);
-            JsonElement data = element.GetProperty("data");
-            Assert.Equal(JsonValueKind.Null, data.ValueKind);
-        }
+    [Fact]
+    public void EncodeStructuredModeMessage_JsonDataType_JsonElementNull()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = ParseJson("{ \"value\": null }").GetProperty("value");
+        cloudEvent.DataContentType = "application/json";
+        JsonElement element = EncodeAndParseStructured(cloudEvent);
+        JsonElement data = element.GetProperty("data");
+        Assert.Equal(JsonValueKind.Null, data.ValueKind);
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_JsonDataType_JsonElementNumeric()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = ParseJson("{ \"value\": 100 }").GetProperty("value");
-            cloudEvent.DataContentType = "application/json";
-            JsonElement element = EncodeAndParseStructured(cloudEvent);
-            JsonElement data = element.GetProperty("data");
-            Assert.Equal(JsonValueKind.Number, data.ValueKind);
-            Assert.Equal(100, data.GetInt32());
-        }
+    [Fact]
+    public void EncodeStructuredModeMessage_JsonDataType_JsonElementNumeric()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = ParseJson("{ \"value\": 100 }").GetProperty("value");
+        cloudEvent.DataContentType = "application/json";
+        JsonElement element = EncodeAndParseStructured(cloudEvent);
+        JsonElement data = element.GetProperty("data");
+        Assert.Equal(JsonValueKind.Number, data.ValueKind);
+        Assert.Equal(100, data.GetInt32());
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_JsonDataType_NullValue()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = null;
-            cloudEvent.DataContentType = "application/json";
-            JsonElement element = EncodeAndParseStructured(cloudEvent);
-            Assert.False(element.TryGetProperty("data", out _));
-        }
+    [Fact]
+    public void EncodeStructuredModeMessage_JsonDataType_NullValue()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = null;
+        cloudEvent.DataContentType = "application/json";
+        JsonElement element = EncodeAndParseStructured(cloudEvent);
+        Assert.False(element.TryGetProperty("data", out _));
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_TextType_String()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = "some text";
-            cloudEvent.DataContentType = "text/anything";
-            JsonElement element = EncodeAndParseStructured(cloudEvent);
-            var dataProperty = element.GetProperty("data");
-            Assert.Equal(JsonValueKind.String, dataProperty.ValueKind);
-            Assert.Equal("some text", dataProperty.GetString());
-        }
+    [Fact]
+    public void EncodeStructuredModeMessage_TextType_String()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = "some text";
+        cloudEvent.DataContentType = "text/anything";
+        JsonElement element = EncodeAndParseStructured(cloudEvent);
+        var dataProperty = element.GetProperty("data");
+        Assert.Equal(JsonValueKind.String, dataProperty.ValueKind);
+        Assert.Equal("some text", dataProperty.GetString());
+    }
 
-        // A text content type with bytes as data is serialized like any other bytes.
-        [Fact]
-        public void EncodeStructuredModeMessage_TextType_Bytes()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = SampleBinaryData;
-            cloudEvent.DataContentType = "text/anything";
-            JsonElement element = EncodeAndParseStructured(cloudEvent);
-            Assert.False(element.TryGetProperty("data", out _));
-            var dataBase64 = element.GetProperty("data_base64");
-            Assert.Equal(JsonValueKind.String, dataBase64.ValueKind);
-            Assert.Equal(SampleBinaryDataBase64, dataBase64.GetString());
-        }
+    // A text content type with bytes as data is serialized like any other bytes.
+    [Fact]
+    public void EncodeStructuredModeMessage_TextType_Bytes()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = SampleBinaryData;
+        cloudEvent.DataContentType = "text/anything";
+        JsonElement element = EncodeAndParseStructured(cloudEvent);
+        Assert.False(element.TryGetProperty("data", out _));
+        var dataBase64 = element.GetProperty("data_base64");
+        Assert.Equal(JsonValueKind.String, dataBase64.ValueKind);
+        Assert.Equal(SampleBinaryDataBase64, dataBase64.GetString());
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_TextType_NotStringOrBytes()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new object();
-            cloudEvent.DataContentType = "text/anything";
-            var formatter = new JsonEventFormatter();
-            Assert.Throws<ArgumentException>(() => formatter.EncodeStructuredModeMessage(cloudEvent, out _));
-        }
+    [Fact]
+    public void EncodeStructuredModeMessage_TextType_NotStringOrBytes()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new object();
+        cloudEvent.DataContentType = "text/anything";
+        var formatter = new JsonEventFormatter();
+        Assert.Throws<ArgumentException>(() => formatter.EncodeStructuredModeMessage(cloudEvent, out _));
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_ArbitraryType_Bytes()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = SampleBinaryData;
-            cloudEvent.DataContentType = "not_text/or_json";
-            JsonElement element = EncodeAndParseStructured(cloudEvent);
-            Assert.False(element.TryGetProperty("data", out _));
-            var dataBase64 = element.GetProperty("data_base64");
-            Assert.Equal(JsonValueKind.String, dataBase64.ValueKind);
-            Assert.Equal(SampleBinaryDataBase64, dataBase64.GetString());
-        }
+    [Fact]
+    public void EncodeStructuredModeMessage_ArbitraryType_Bytes()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = SampleBinaryData;
+        cloudEvent.DataContentType = "not_text/or_json";
+        JsonElement element = EncodeAndParseStructured(cloudEvent);
+        Assert.False(element.TryGetProperty("data", out _));
+        var dataBase64 = element.GetProperty("data_base64");
+        Assert.Equal(JsonValueKind.String, dataBase64.ValueKind);
+        Assert.Equal(SampleBinaryDataBase64, dataBase64.GetString());
+    }
 
-        [Fact]
-        public void EncodeStructuredModeMessage_ArbitraryType_NotBytes()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new object();
-            cloudEvent.DataContentType = "not_text/or_json";
-            var formatter = new JsonEventFormatter();
-            Assert.Throws<ArgumentException>(() => formatter.EncodeStructuredModeMessage(cloudEvent, out _));
-        }
+    [Fact]
+    public void EncodeStructuredModeMessage_ArbitraryType_NotBytes()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new object();
+        cloudEvent.DataContentType = "not_text/or_json";
+        var formatter = new JsonEventFormatter();
+        Assert.Throws<ArgumentException>(() => formatter.EncodeStructuredModeMessage(cloudEvent, out _));
+    }
 
-        [Fact]
-        public void EncodeBinaryModeEventData_JsonDataType_ObjectSerialization()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new { Text = "simple text" };
-            cloudEvent.DataContentType = "application/json";
-            var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
-            JsonElement data = ParseJson(bytes);
-            var asserter = new JsonElementAsserter
+    [Fact]
+    public void EncodeBinaryModeEventData_JsonDataType_ObjectSerialization()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new { Text = "simple text" };
+        cloudEvent.DataContentType = "application/json";
+        var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
+        JsonElement data = ParseJson(bytes);
+        var asserter = new JsonElementAsserter
             {
                 { "Text", JsonValueKind.String, "simple text" }
             };
-            asserter.AssertProperties(data, assertCount: true);
-        }
+        asserter.AssertProperties(data, assertCount: true);
+    }
 
-        [Fact]
-        public void EncodeBinaryModeEventData_JsonDataType_CustomSerializer()
+    [Fact]
+    public void EncodeBinaryModeEventData_JsonDataType_CustomSerializer()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new { DateValue = new DateTime(2021, 2, 19, 12, 49, 34, DateTimeKind.Utc) };
+        cloudEvent.DataContentType = "application/json";
+
+        var serializerOptions = new JsonSerializerOptions
         {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new { DateValue = new DateTime(2021, 2, 19, 12, 49, 34, DateTimeKind.Utc) };
-            cloudEvent.DataContentType = "application/json";
-
-            var serializerOptions = new JsonSerializerOptions
-            {
-                Converters = { new YearMonthDayConverter() },
-            };
-            var formatter = new JsonEventFormatter(serializerOptions, default);
-            var bytes = formatter.EncodeBinaryModeEventData(cloudEvent);
-            JsonElement data = ParseJson(bytes);
-            var asserter = new JsonElementAsserter
+            Converters = { new YearMonthDayConverter() },
+        };
+        var formatter = new JsonEventFormatter(serializerOptions, default);
+        var bytes = formatter.EncodeBinaryModeEventData(cloudEvent);
+        JsonElement data = ParseJson(bytes);
+        var asserter = new JsonElementAsserter
             {
                 { "DateValue", JsonValueKind.String, "2021-02-19" }
             };
-            asserter.AssertProperties(data, assertCount: true);
-        }
+        asserter.AssertProperties(data, assertCount: true);
+    }
 
-        [Fact]
-        public void EncodeBinaryModeEventData_JsonDataType_AttributedModel()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new AttributedModel { AttributedProperty = "simple text" };
-            cloudEvent.DataContentType = "application/json";
-            var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
-            JsonElement data = ParseJson(bytes);
-            var asserter = new JsonElementAsserter
+    [Fact]
+    public void EncodeBinaryModeEventData_JsonDataType_AttributedModel()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new AttributedModel { AttributedProperty = "simple text" };
+        cloudEvent.DataContentType = "application/json";
+        var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
+        JsonElement data = ParseJson(bytes);
+        var asserter = new JsonElementAsserter
             {
                 { AttributedModel.JsonPropertyName, JsonValueKind.String, "simple text" }
             };
-            asserter.AssertProperties(data, assertCount: true);
-        }
+        asserter.AssertProperties(data, assertCount: true);
+    }
 
-        [Theory]
-        [InlineData("utf-8")]
-        [InlineData("utf-16")]
-        public void EncodeBinaryModeEventData_JsonDataType_JsonElement(string charset)
+    [Theory]
+    [InlineData("utf-8")]
+    [InlineData("utf-16")]
+    public void EncodeBinaryModeEventData_JsonDataType_JsonElement(string charset)
+    {
+        // This would definitely be an odd thing to do, admittedly...
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = ParseJson($"{{ \"value\": \"some text\" }}").GetProperty("value");
+        cloudEvent.DataContentType = $"application/json; charset={charset}";
+        var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
+        Assert.Equal("\"some text\"", BinaryDataUtilities.GetString(bytes, Encoding.GetEncoding(charset)));
+    }
+
+    [Fact]
+    public void EncodeBinaryModeEventData_JsonDataType_NullValue()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = null;
+        cloudEvent.DataContentType = "application/json";
+        var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
+        Assert.True(bytes.IsEmpty);
+    }
+
+    [Theory]
+    [InlineData("utf-8")]
+    [InlineData("iso-8859-1")]
+    public void EncodeBinaryModeEventData_TextType_String(string charset)
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = "some text";
+        cloudEvent.DataContentType = $"text/anything; charset={charset}";
+        var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
+        Assert.Equal("some text", BinaryDataUtilities.GetString(bytes, Encoding.GetEncoding(charset)));
+    }
+
+    // A text content type with bytes as data is serialized like any other bytes.
+    [Fact]
+    public void EncodeBinaryModeEventData_TextType_Bytes()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = SampleBinaryData;
+        cloudEvent.DataContentType = "text/anything";
+        var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
+        Assert.Equal(SampleBinaryData, bytes);
+    }
+
+    [Fact]
+    public void EncodeBinaryModeEventData_TextType_NotStringOrBytes()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new object();
+        cloudEvent.DataContentType = "text/anything";
+        var formatter = new JsonEventFormatter();
+        Assert.Throws<ArgumentException>(() => formatter.EncodeBinaryModeEventData(cloudEvent));
+    }
+
+    [Fact]
+    public void EncodeBinaryModeEventData_ArbitraryType_Bytes()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = SampleBinaryData;
+        cloudEvent.DataContentType = "not_text/or_json";
+        var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
+        Assert.Equal(SampleBinaryData, bytes);
+    }
+
+    [Fact]
+    public void EncodeBinaryModeEventData_ArbitraryType_NotBytes()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.Data = new object();
+        cloudEvent.DataContentType = "not_text/or_json";
+        var formatter = new JsonEventFormatter();
+        Assert.Throws<ArgumentException>(() => formatter.EncodeBinaryModeEventData(cloudEvent));
+    }
+
+    [Fact]
+    public void EncodeBinaryModeEventData_NoContentType_ConvertsStringToJson()
+    {
+        var cloudEvent = new CloudEvent
         {
-            // This would definitely be an odd thing to do, admittedly...
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = ParseJson($"{{ \"value\": \"some text\" }}").GetProperty("value");
-            cloudEvent.DataContentType = $"application/json; charset={charset}";
-            var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
-            Assert.Equal("\"some text\"", BinaryDataUtilities.GetString(bytes, Encoding.GetEncoding(charset)));
-        }
+            Data = "some text"
+        }.PopulateRequiredAttributes();
 
-        [Fact]
-        public void EncodeBinaryModeEventData_JsonDataType_NullValue()
+        // EncodeBinaryModeEventData doesn't actually populate the content type of the CloudEvent,
+        // but treat the data as if we'd explicitly specified application/json.
+        var data = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
+        string text = BinaryDataUtilities.GetString(data, Encoding.UTF8);
+        Assert.Equal("\"some text\"", text);
+    }
+
+    [Fact]
+    public void EncodeBinaryModeEventData_NoContentType_LeavesBinaryData()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = null;
-            cloudEvent.DataContentType = "application/json";
-            var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
-            Assert.True(bytes.IsEmpty);
-        }
+            Data = SampleBinaryData
+        }.PopulateRequiredAttributes();
 
-        [Theory]
-        [InlineData("utf-8")]
-        [InlineData("iso-8859-1")]
-        public void EncodeBinaryModeEventData_TextType_String(string charset)
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = "some text";
-            cloudEvent.DataContentType = $"text/anything; charset={charset}";
-            var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
-            Assert.Equal("some text", BinaryDataUtilities.GetString(bytes, Encoding.GetEncoding(charset)));
-        }
+        // EncodeBinaryModeEventData does *not* implicitly encode binary data as JSON.
+        var data = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
+        var array = BinaryDataUtilities.AsArray(data);
+        Assert.Equal(array, SampleBinaryData);
+    }
 
-        // A text content type with bytes as data is serialized like any other bytes.
-        [Fact]
-        public void EncodeBinaryModeEventData_TextType_Bytes()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = SampleBinaryData;
-            cloudEvent.DataContentType = "text/anything";
-            var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
-            Assert.Equal(SampleBinaryData, bytes);
-        }
+    // Note: batch mode testing is restricted to the batch aspects; we assume that the
+    // per-CloudEvent implementation is shared with structured mode, so we rely on
+    // structured mode testing for things like custom serialization.
 
-        [Fact]
-        public void EncodeBinaryModeEventData_TextType_NotStringOrBytes()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new object();
-            cloudEvent.DataContentType = "text/anything";
-            var formatter = new JsonEventFormatter();
-            Assert.Throws<ArgumentException>(() => formatter.EncodeBinaryModeEventData(cloudEvent));
-        }
+    [Fact]
+    public void EncodeBatchModeMessage_Empty()
+    {
+        var cloudEvents = new CloudEvent[0];
+        var formatter = new JsonEventFormatter();
+        var bytes = formatter.EncodeBatchModeMessage(cloudEvents, out var contentType);
+        Assert.Equal("application/cloudevents-batch+json; charset=utf-8", contentType.ToString());
+        var array = ParseJson(bytes);
+        Assert.Equal(JsonValueKind.Array, array.ValueKind);
+        Assert.Equal(0, array.GetArrayLength());
+    }
 
-        [Fact]
-        public void EncodeBinaryModeEventData_ArbitraryType_Bytes()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = SampleBinaryData;
-            cloudEvent.DataContentType = "not_text/or_json";
-            var bytes = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
-            Assert.Equal(SampleBinaryData, bytes);
-        }
+    [Fact]
+    public void EncodeBatchModeMessage_TwoEvents()
+    {
+        var event1 = new CloudEvent().PopulateRequiredAttributes();
+        event1.Id = "event1";
+        event1.Data = "simple text";
+        event1.DataContentType = "text/plain";
 
-        [Fact]
-        public void EncodeBinaryModeEventData_ArbitraryType_NotBytes()
-        {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.Data = new object();
-            cloudEvent.DataContentType = "not_text/or_json";
-            var formatter = new JsonEventFormatter();
-            Assert.Throws<ArgumentException>(() => formatter.EncodeBinaryModeEventData(cloudEvent));
-        }
+        var event2 = new CloudEvent().PopulateRequiredAttributes();
+        event2.Id = "event2";
 
-        [Fact]
-        public void EncodeBinaryModeEventData_NoContentType_ConvertsStringToJson()
-        {
-            var cloudEvent = new CloudEvent
-            {
-                Data = "some text"
-            }.PopulateRequiredAttributes();
+        var cloudEvents = new[] { event1, event2 };
+        var formatter = new JsonEventFormatter();
+        var bytes = formatter.EncodeBatchModeMessage(cloudEvents, out var contentType);
+        Assert.Equal("application/cloudevents-batch+json; charset=utf-8", contentType.ToString());
+        var array = ParseJson(bytes).EnumerateArray().ToList();
+        Assert.Equal(2, array.Count);
 
-            // EncodeBinaryModeEventData doesn't actually populate the content type of the CloudEvent,
-            // but treat the data as if we'd explicitly specified application/json.
-            var data = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
-            string text = BinaryDataUtilities.GetString(data, Encoding.UTF8);
-            Assert.Equal("\"some text\"", text);
-        }
-
-        [Fact]
-        public void EncodeBinaryModeEventData_NoContentType_LeavesBinaryData()
-        {
-            var cloudEvent = new CloudEvent
-            {
-                Data = SampleBinaryData
-            }.PopulateRequiredAttributes();
-
-            // EncodeBinaryModeEventData does *not* implicitly encode binary data as JSON.
-            var data = new JsonEventFormatter().EncodeBinaryModeEventData(cloudEvent);
-            var array = BinaryDataUtilities.AsArray(data);
-            Assert.Equal(array, SampleBinaryData);
-        }
-
-        // Note: batch mode testing is restricted to the batch aspects; we assume that the
-        // per-CloudEvent implementation is shared with structured mode, so we rely on
-        // structured mode testing for things like custom serialization.
-
-        [Fact]
-        public void EncodeBatchModeMessage_Empty()
-        {
-            var cloudEvents = new CloudEvent[0];
-            var formatter = new JsonEventFormatter();
-            var bytes = formatter.EncodeBatchModeMessage(cloudEvents, out var contentType);
-            Assert.Equal("application/cloudevents-batch+json; charset=utf-8", contentType.ToString());
-            var array = ParseJson(bytes);
-            Assert.Equal(JsonValueKind.Array, array.ValueKind);
-            Assert.Equal(0, array.GetArrayLength());
-        }
-
-        [Fact]
-        public void EncodeBatchModeMessage_TwoEvents()
-        {
-            var event1 = new CloudEvent().PopulateRequiredAttributes();
-            event1.Id = "event1";
-            event1.Data = "simple text";
-            event1.DataContentType = "text/plain";
-
-            var event2 = new CloudEvent().PopulateRequiredAttributes();
-            event2.Id = "event2";
-
-            var cloudEvents = new[] { event1, event2 };
-            var formatter = new JsonEventFormatter();
-            var bytes = formatter.EncodeBatchModeMessage(cloudEvents, out var contentType);
-            Assert.Equal("application/cloudevents-batch+json; charset=utf-8", contentType.ToString());
-            var array = ParseJson(bytes).EnumerateArray().ToList();
-            Assert.Equal(2, array.Count);
-
-            var asserter1 = new JsonElementAsserter
+        var asserter1 = new JsonElementAsserter
             {
                 { "specversion", JsonValueKind.String, "1.0" },
                 { "id", JsonValueKind.String, event1.Id },
@@ -479,511 +479,511 @@ namespace CloudNative.CloudEvents.SystemTextJson.UnitTests
                 { "data", JsonValueKind.String, "simple text" },
                 { "datacontenttype", JsonValueKind.String, event1.DataContentType }
             };
-            asserter1.AssertProperties(array[0], assertCount: true);
+        asserter1.AssertProperties(array[0], assertCount: true);
 
-            var asserter2 = new JsonElementAsserter
+        var asserter2 = new JsonElementAsserter
             {
                 { "specversion", JsonValueKind.String, "1.0" },
                 { "id", JsonValueKind.String, event2.Id },
                 { "type", JsonValueKind.String, event2.Type },
                 { "source", JsonValueKind.String, "//test" },
             };
-            asserter2.AssertProperties(array[1], assertCount: true);
-        }
+        asserter2.AssertProperties(array[1], assertCount: true);
+    }
 
-        [Fact]
-        public void EncodeBatchModeMessage_Invalid()
+    [Fact]
+    public void EncodeBatchModeMessage_Invalid()
+    {
+        var formatter = new JsonEventFormatter();
+        // Invalid CloudEvent
+        Assert.Throws<ArgumentException>(() => formatter.EncodeBatchModeMessage(new[] { new CloudEvent() }, out _));
+        // Null argument
+        Assert.Throws<ArgumentNullException>(() => formatter.EncodeBatchModeMessage(null!, out _));
+        // Null value within the argument. Arguably this should throw ArgumentException instead of
+        // ArgumentNullException, but it's unlikely to cause confusion.
+        Assert.Throws<ArgumentNullException>(() => formatter.EncodeBatchModeMessage(new CloudEvent[1], out _));
+    }
+
+    [Fact]
+    public void DecodeStructuredModeMessage_NotJson()
+    {
+        var formatter = new JsonEventFormatter();
+        Assert.ThrowsAny<JsonException>(() => formatter.DecodeStructuredModeMessage(new byte[10], new ContentType("application/json"), null));
+    }
+
+    // Just a single test for the code that parses asynchronously... the guts are all the same.
+    [Theory]
+    [InlineData("utf-8")]
+    [InlineData("iso-8859-1")]
+    public async Task DecodeStructuredModeMessageAsync_Minimal(string charset)
+    {
+        // Note: just using Json.NET to get the JSON in a simple way...
+        var obj = new JObject
         {
-            var formatter = new JsonEventFormatter();
-            // Invalid CloudEvent
-            Assert.Throws<ArgumentException>(() => formatter.EncodeBatchModeMessage(new[] { new CloudEvent() }, out _));
-            // Null argument
-            Assert.Throws<ArgumentNullException>(() => formatter.EncodeBatchModeMessage(null!, out _));
-            // Null value within the argument. Arguably this should throw ArgumentException instead of
-            // ArgumentNullException, but it's unlikely to cause confusion.
-            Assert.Throws<ArgumentNullException>(() => formatter.EncodeBatchModeMessage(new CloudEvent[1], out _));
-        }
+            ["specversion"] = "1.0",
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["source"] = SampleUriText,
+            ["text"] = NonAsciiValue
+        };
+        var bytes = Encoding.GetEncoding(charset).GetBytes(obj.ToString());
+        var stream = new MemoryStream(bytes);
+        var formatter = new JsonEventFormatter();
+        var cloudEvent = await formatter.DecodeStructuredModeMessageAsync(stream, new ContentType($"application/cloudevents+json; charset={charset}"), null);
+        Assert.Equal("test-type", cloudEvent.Type);
+        Assert.Equal("test-id", cloudEvent.Id);
+        Assert.Equal(SampleUri, cloudEvent.Source);
+        Assert.Equal(NonAsciiValue, cloudEvent["text"]);
+    }
 
-        [Fact]
-        public void DecodeStructuredModeMessage_NotJson()
+    [Theory]
+    [InlineData("utf-8")]
+    [InlineData("iso-8859-1")]
+    public void DecodeStructuredModeMessage_Minimal(string charset)
+    {
+        var obj = new JObject
         {
-            var formatter = new JsonEventFormatter();
-            Assert.ThrowsAny<JsonException>(() => formatter.DecodeStructuredModeMessage(new byte[10], new ContentType("application/json"), null));
-        }
+            ["specversion"] = "1.0",
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["source"] = SampleUriText,
+            ["text"] = NonAsciiValue
+        };
+        var bytes = Encoding.GetEncoding(charset).GetBytes(obj.ToString());
+        var stream = new MemoryStream(bytes);
+        var formatter = new JsonEventFormatter();
+        var cloudEvent = formatter.DecodeStructuredModeMessage(stream, new ContentType($"application/cloudevents+json; charset={charset}"), null);
+        Assert.Equal("test-type", cloudEvent.Type);
+        Assert.Equal("test-id", cloudEvent.Id);
+        Assert.Equal(SampleUri, cloudEvent.Source);
+    }
 
-        // Just a single test for the code that parses asynchronously... the guts are all the same.
-        [Theory]
-        [InlineData("utf-8")]
-        [InlineData("iso-8859-1")]
-        public async Task DecodeStructuredModeMessageAsync_Minimal(string charset)
+    [Fact]
+    public void DecodeStructuredModeMessage_NoSpecVersion()
+    {
+        var obj = new JObject
         {
-            // Note: just using Json.NET to get the JSON in a simple way...
-            var obj = new JObject
-            {
-                ["specversion"] = "1.0",
-                ["type"] = "test-type",
-                ["id"] = "test-id",
-                ["source"] = SampleUriText,
-                ["text"] = NonAsciiValue
-            };
-            var bytes = Encoding.GetEncoding(charset).GetBytes(obj.ToString());
-            var stream = new MemoryStream(bytes);
-            var formatter = new JsonEventFormatter();
-            var cloudEvent = await formatter.DecodeStructuredModeMessageAsync(stream, new ContentType($"application/cloudevents+json; charset={charset}"), null);
-            Assert.Equal("test-type", cloudEvent.Type);
-            Assert.Equal("test-id", cloudEvent.Id);
-            Assert.Equal(SampleUri, cloudEvent.Source);
-            Assert.Equal(NonAsciiValue, cloudEvent["text"]);
-        }
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["source"] = SampleUriText,
+        };
+        Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
+    }
 
-        [Theory]
-        [InlineData("utf-8")]
-        [InlineData("iso-8859-1")]
-        public void DecodeStructuredModeMessage_Minimal(string charset)
+    [Fact]
+    public void DecodeStructuredModeMessage_UnknownSpecVersion()
+    {
+        var obj = new JObject
         {
-            var obj = new JObject
-            {
-                ["specversion"] = "1.0",
-                ["type"] = "test-type",
-                ["id"] = "test-id",
-                ["source"] = SampleUriText,
-                ["text"] = NonAsciiValue
-            };
-            var bytes = Encoding.GetEncoding(charset).GetBytes(obj.ToString());
-            var stream = new MemoryStream(bytes);
-            var formatter = new JsonEventFormatter();
-            var cloudEvent = formatter.DecodeStructuredModeMessage(stream, new ContentType($"application/cloudevents+json; charset={charset}"), null);
-            Assert.Equal("test-type", cloudEvent.Type);
-            Assert.Equal("test-id", cloudEvent.Id);
-            Assert.Equal(SampleUri, cloudEvent.Source);
-        }
+            ["specversion"] = "0.5",
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["source"] = SampleUriText,
+        };
+        Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
+    }
 
-        [Fact]
-        public void DecodeStructuredModeMessage_NoSpecVersion()
+    [Fact]
+    public void DecodeStructuredModeMessage_MissingRequiredAttributes()
+    {
+        var obj = new JObject
         {
-            var obj = new JObject
-            {
-                ["type"] = "test-type",
-                ["id"] = "test-id",
-                ["source"] = SampleUriText,
-            };
-            Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
-        }
+            ["specversion"] = "1.0",
+            ["type"] = "test-type",
+            ["id"] = "test-id"
+            // Source is missing
+        };
+        Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
+    }
 
-        [Fact]
-        public void DecodeStructuredModeMessage_UnknownSpecVersion()
+    [Fact]
+    public void DecodeStructuredModeMessage_SpecVersionNotString()
+    {
+        var obj = new JObject
         {
-            var obj = new JObject
-            {
-                ["specversion"] = "0.5",
-                ["type"] = "test-type",
-                ["id"] = "test-id",
-                ["source"] = SampleUriText,
-            };
-            Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
-        }
+            ["specversion"] = 1,
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["source"] = SampleUriText,
+        };
+        Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
+    }
 
-        [Fact]
-        public void DecodeStructuredModeMessage_MissingRequiredAttributes()
+    [Fact]
+    public void DecodeStructuredModeMessage_TypeNotString()
+    {
+        var obj = new JObject
         {
-            var obj = new JObject
-            {
-                ["specversion"] = "1.0",
-                ["type"] = "test-type",
-                ["id"] = "test-id"
-                // Source is missing
-            };
-            Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
-        }
+            ["specversion"] = "1.0",
+            ["type"] = 1,
+            ["id"] = "test-id",
+            ["source"] = SampleUriText,
+        };
+        Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
+    }
 
-        [Fact]
-        public void DecodeStructuredModeMessage_SpecVersionNotString()
+    [Fact]
+    public void DecodeStructuredModeMessage_V1Attributes()
+    {
+        var obj = new JObject
         {
-            var obj = new JObject
-            {
-                ["specversion"] = 1,
-                ["type"] = "test-type",
-                ["id"] = "test-id",
-                ["source"] = SampleUriText,
-            };
-            Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
-        }
+            ["specversion"] = "1.0",
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["data"] = "text", // Just so that it's reasonable to have a DataContentType,
+            ["datacontenttype"] = "text/plain",
+            ["dataschema"] = "https://data-schema",
+            ["subject"] = "event-subject",
+            ["source"] = "//event-source",
+            ["time"] = SampleTimestampText
+        };
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
+        Assert.Equal("test-type", cloudEvent.Type);
+        Assert.Equal("test-id", cloudEvent.Id);
+        Assert.Equal("text/plain", cloudEvent.DataContentType);
+        Assert.Equal(new Uri("https://data-schema"), cloudEvent.DataSchema);
+        Assert.Equal("event-subject", cloudEvent.Subject);
+        Assert.Equal(new Uri("//event-source", UriKind.RelativeOrAbsolute), cloudEvent.Source);
+        AssertTimestampsEqual(SampleTimestamp, cloudEvent.Time);
+    }
 
-        [Fact]
-        public void DecodeStructuredModeMessage_TypeNotString()
+    [Fact]
+    public void DecodeStructuredModeMessage_AllAttributeTypes()
+    {
+        var obj = new JObject
         {
-            var obj = new JObject
-            {
-                ["specversion"] = "1.0",
-                ["type"] = 1,
-                ["id"] = "test-id",
-                ["source"] = SampleUriText,
-            };
-            Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
-        }
+            // Required attributes
+            ["specversion"] = "1.0",
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["source"] = "//source",
+            // Extension attributes
+            ["binary"] = SampleBinaryDataBase64,
+            ["boolean"] = true,
+            ["integer"] = 10,
+            ["string"] = "text",
+            ["timestamp"] = SampleTimestampText,
+            ["uri"] = SampleUriText,
+            ["urireference"] = SampleUriReferenceText
+        };
 
-        [Fact]
-        public void DecodeStructuredModeMessage_V1Attributes()
+        var bytes = Encoding.UTF8.GetBytes(obj.ToString());
+        var formatter = new JsonEventFormatter();
+        var cloudEvent = formatter.DecodeStructuredModeMessage(bytes, s_jsonCloudEventContentType, AllTypesExtensions);
+        Assert.Equal(SampleBinaryData, cloudEvent["binary"]);
+        Assert.True((bool) cloudEvent["boolean"]!);
+        Assert.Equal(10, cloudEvent["integer"]);
+        Assert.Equal("text", cloudEvent["string"]);
+        AssertTimestampsEqual(SampleTimestamp, (DateTimeOffset) cloudEvent["timestamp"]!);
+        Assert.Equal(SampleUri, cloudEvent["uri"]);
+        Assert.Equal(SampleUriReference, cloudEvent["urireference"]);
+    }
+
+    [Fact]
+    public void DecodeStructuredModeMessage_IncorrectExtensionTypeWithValidValue()
+    {
+        var obj = new JObject
         {
-            var obj = new JObject
-            {
-                ["specversion"] = "1.0",
-                ["type"] = "test-type",
-                ["id"] = "test-id",
-                ["data"] = "text", // Just so that it's reasonable to have a DataContentType,
-                ["datacontenttype"] = "text/plain",
-                ["dataschema"] = "https://data-schema",
-                ["subject"] = "event-subject",
-                ["source"] = "//event-source",
-                ["time"] = SampleTimestampText
-            };
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
-            Assert.Equal("test-type", cloudEvent.Type);
-            Assert.Equal("test-id", cloudEvent.Id);
-            Assert.Equal("text/plain", cloudEvent.DataContentType);
-            Assert.Equal(new Uri("https://data-schema"), cloudEvent.DataSchema);
-            Assert.Equal("event-subject", cloudEvent.Subject);
-            Assert.Equal(new Uri("//event-source", UriKind.RelativeOrAbsolute), cloudEvent.Source);
-            AssertTimestampsEqual(SampleTimestamp, cloudEvent.Time);
-        }
+            ["specversion"] = "1.0",
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["source"] = "//source",
+            // Incorrect type, but is a valid value for the extension
+            ["integer"] = "10",
+        };
+        // Decode the event, providing the extension with the correct type.
+        var bytes = Encoding.UTF8.GetBytes(obj.ToString());
+        var formatter = new JsonEventFormatter();
+        var cloudEvent = formatter.DecodeStructuredModeMessage(bytes, s_jsonCloudEventContentType, AllTypesExtensions);
 
-        [Fact]
-        public void DecodeStructuredModeMessage_AllAttributeTypes()
+        // The value will have been decoded according to the extension.
+        Assert.Equal(10, cloudEvent["integer"]);
+    }
+
+    // There are other invalid token types as well; this is just one of them.
+    [Fact]
+    public void DecodeStructuredModeMessage_AttributeValueAsArrayToken()
+    {
+        var obj = CreateMinimalValidJObject();
+        obj["attr"] = new Newtonsoft.Json.Linq.JArray();
+        Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
+    }
+
+    [Fact]
+    public void DecodeStructuredModeMessage_Null()
+    {
+        var obj = CreateMinimalValidJObject();
+        obj["attr"] = Newtonsoft.Json.Linq.JValue.CreateNull();
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        // The JSON event format spec demands that we ignore null values, so we shouldn't
+        // have created an extension attribute.
+        Assert.Null(cloudEvent.GetAttribute("attr"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("application/json")]
+    [InlineData("text/plain")]
+    [InlineData("application/binary")]
+    public void DecodeStructuredModeMessage_NoData(string? contentType)
+    {
+        var obj = CreateMinimalValidJObject();
+        if (contentType is object)
         {
-            var obj = new JObject
-            {
-                // Required attributes
-                ["specversion"] = "1.0",
-                ["type"] = "test-type",
-                ["id"] = "test-id",
-                ["source"] = "//source",
-                // Extension attributes
-                ["binary"] = SampleBinaryDataBase64,
-                ["boolean"] = true,
-                ["integer"] = 10,
-                ["string"] = "text",
-                ["timestamp"] = SampleTimestampText,
-                ["uri"] = SampleUriText,
-                ["urireference"] = SampleUriReferenceText
-            };
-
-            var bytes = Encoding.UTF8.GetBytes(obj.ToString());
-            var formatter = new JsonEventFormatter();
-            var cloudEvent = formatter.DecodeStructuredModeMessage(bytes, s_jsonCloudEventContentType, AllTypesExtensions);
-            Assert.Equal(SampleBinaryData, cloudEvent["binary"]);
-            Assert.True((bool) cloudEvent["boolean"]!);
-            Assert.Equal(10, cloudEvent["integer"]);
-            Assert.Equal("text", cloudEvent["string"]);
-            AssertTimestampsEqual(SampleTimestamp, (DateTimeOffset) cloudEvent["timestamp"]!);
-            Assert.Equal(SampleUri, cloudEvent["uri"]);
-            Assert.Equal(SampleUriReference, cloudEvent["urireference"]);
-        }
-
-        [Fact]
-        public void DecodeStructuredModeMessage_IncorrectExtensionTypeWithValidValue()
-        {
-            var obj = new JObject
-            {
-                ["specversion"] = "1.0",
-                ["type"] = "test-type",
-                ["id"] = "test-id",
-                ["source"] = "//source",
-                // Incorrect type, but is a valid value for the extension
-                ["integer"] = "10",
-            };
-            // Decode the event, providing the extension with the correct type.
-            var bytes = Encoding.UTF8.GetBytes(obj.ToString());
-            var formatter = new JsonEventFormatter();
-            var cloudEvent = formatter.DecodeStructuredModeMessage(bytes, s_jsonCloudEventContentType, AllTypesExtensions);
-
-            // The value will have been decoded according to the extension.
-            Assert.Equal(10, cloudEvent["integer"]);
-        }
-
-        // There are other invalid token types as well; this is just one of them.
-        [Fact]
-        public void DecodeStructuredModeMessage_AttributeValueAsArrayToken()
-        {
-            var obj = CreateMinimalValidJObject();
-            obj["attr"] = new Newtonsoft.Json.Linq.JArray();
-            Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
-        }
-
-        [Fact]
-        public void DecodeStructuredModeMessage_Null()
-        {
-            var obj = CreateMinimalValidJObject();
-            obj["attr"] = Newtonsoft.Json.Linq.JValue.CreateNull();
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            // The JSON event format spec demands that we ignore null values, so we shouldn't
-            // have created an extension attribute.
-            Assert.Null(cloudEvent.GetAttribute("attr"));
-        }
-
-        [Theory]
-        [InlineData(null)]
-        [InlineData("application/json")]
-        [InlineData("text/plain")]
-        [InlineData("application/binary")]
-        public void DecodeStructuredModeMessage_NoData(string? contentType)
-        {
-            var obj = CreateMinimalValidJObject();
-            if (contentType is object)
-            {
-                obj["datacontenttype"] = contentType;
-            }
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Null(cloudEvent.Data);
-        }
-
-        [Fact]
-        public void DecodeStructuredModeMessage_BothDataAndDataBase64()
-        {
-            var obj = CreateMinimalValidJObject();
-            obj["data"] = "text";
-            obj["data_base64"] = SampleBinaryDataBase64;
-            Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
-        }
-
-        [Fact]
-        public void DecodeStructuredModeMessage_DataBase64NonString()
-        {
-            var obj = CreateMinimalValidJObject();
-            obj["data_base64"] = 10;
-            Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
-        }
-
-        // data_base64 always ends up as bytes, regardless of content type.
-        [Theory]
-        [InlineData(null)]
-        [InlineData("application/json")]
-        [InlineData("text/plain")]
-        [InlineData("application/binary")]
-        public void DecodeStructuredModeMessage_Base64(string? contentType)
-        {
-            var obj = CreateMinimalValidJObject();
-            if (contentType is object)
-            {
-                obj["datacontenttype"] = contentType;
-            }
-            obj["data_base64"] = SampleBinaryDataBase64;
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Equal(SampleBinaryData, cloudEvent.Data);
-        }
-
-        [Theory]
-        [InlineData("text/plain")]
-        [InlineData("image/png")]
-        public void DecodeStructuredModeMessage_NonJsonContentType_JsonStringToken(string contentType)
-        {
-            var obj = CreateMinimalValidJObject();
             obj["datacontenttype"] = contentType;
-            obj["data"] = "some text";
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Equal("some text", cloudEvent.Data);
         }
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Null(cloudEvent.Data);
+    }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("application/json")]
-        [InlineData("application/json; charset=utf-8")]
-        public void DecodeStructuredModeMessage_JsonContentType_JsonStringToken(string? contentType)
+    [Fact]
+    public void DecodeStructuredModeMessage_BothDataAndDataBase64()
+    {
+        var obj = CreateMinimalValidJObject();
+        obj["data"] = "text";
+        obj["data_base64"] = SampleBinaryDataBase64;
+        Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
+    }
+
+    [Fact]
+    public void DecodeStructuredModeMessage_DataBase64NonString()
+    {
+        var obj = CreateMinimalValidJObject();
+        obj["data_base64"] = 10;
+        Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
+    }
+
+    // data_base64 always ends up as bytes, regardless of content type.
+    [Theory]
+    [InlineData(null)]
+    [InlineData("application/json")]
+    [InlineData("text/plain")]
+    [InlineData("application/binary")]
+    public void DecodeStructuredModeMessage_Base64(string? contentType)
+    {
+        var obj = CreateMinimalValidJObject();
+        if (contentType is object)
         {
-            var obj = CreateMinimalValidJObject();
-            if (contentType is object)
-            {
-                obj["datacontenttype"] = contentType;
-            }
-            obj["data"] = "text";
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            var element = (JsonElement) cloudEvent.Data!;
-            Assert.Equal(JsonValueKind.String, element.ValueKind);
-            Assert.Equal("text", element.GetString());
+            obj["datacontenttype"] = contentType;
         }
+        obj["data_base64"] = SampleBinaryDataBase64;
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Equal(SampleBinaryData, cloudEvent.Data);
+    }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("application/json")]
-        [InlineData("application/xyz+json")]
-        [InlineData("application/xyz+json; charset=utf-8")]
-        public void DecodeStructuredModeMessage_JsonContentType_NonStringValue(string? contentType)
+    [Theory]
+    [InlineData("text/plain")]
+    [InlineData("image/png")]
+    public void DecodeStructuredModeMessage_NonJsonContentType_JsonStringToken(string contentType)
+    {
+        var obj = CreateMinimalValidJObject();
+        obj["datacontenttype"] = contentType;
+        obj["data"] = "some text";
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Equal("some text", cloudEvent.Data);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("application/json")]
+    [InlineData("application/json; charset=utf-8")]
+    public void DecodeStructuredModeMessage_JsonContentType_JsonStringToken(string? contentType)
+    {
+        var obj = CreateMinimalValidJObject();
+        if (contentType is object)
         {
-            var obj = CreateMinimalValidJObject();
-            if (contentType is object)
-            {
-                obj["datacontenttype"] = contentType;
-            }
-            obj["data"] = 10;
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            var element = (JsonElement) cloudEvent.Data!;
-            Assert.Equal(JsonValueKind.Number, element.ValueKind);
-            Assert.Equal(10, element.GetInt32());
+            obj["datacontenttype"] = contentType;
         }
+        obj["data"] = "text";
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        var element = (JsonElement) cloudEvent.Data!;
+        Assert.Equal(JsonValueKind.String, element.ValueKind);
+        Assert.Equal("text", element.GetString());
+    }
 
-        [Fact]
-        public void DecodeStructuredModeMessage_NonJsonContentType_NonStringValue()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("application/json")]
+    [InlineData("application/xyz+json")]
+    [InlineData("application/xyz+json; charset=utf-8")]
+    public void DecodeStructuredModeMessage_JsonContentType_NonStringValue(string? contentType)
+    {
+        var obj = CreateMinimalValidJObject();
+        if (contentType is object)
         {
-            var obj = CreateMinimalValidJObject();
-            obj["datacontenttype"] = "text/plain";
-            obj["data"] = 10;
-            Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
+            obj["datacontenttype"] = contentType;
         }
+        obj["data"] = 10;
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        var element = (JsonElement) cloudEvent.Data!;
+        Assert.Equal(JsonValueKind.Number, element.ValueKind);
+        Assert.Equal(10, element.GetInt32());
+    }
 
-        [Fact]
-        public void DecodeStructuredModeMessage_NullDataBase64Ignored()
-        {
-            var obj = CreateMinimalValidJObject();
-            obj["data_base64"] = Newtonsoft.Json.Linq.JValue.CreateNull();
-            obj["data"] = "some text";
-            obj["datacontenttype"] = "text/plain";
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Equal("some text", cloudEvent.Data);
-        }
+    [Fact]
+    public void DecodeStructuredModeMessage_NonJsonContentType_NonStringValue()
+    {
+        var obj = CreateMinimalValidJObject();
+        obj["datacontenttype"] = "text/plain";
+        obj["data"] = 10;
+        Assert.Throws<ArgumentException>(() => DecodeStructuredModeMessage(obj));
+    }
 
-        [Fact]
-        public void DecodeStructuredModeMessage_NullDataIgnored()
-        {
-            var obj = CreateMinimalValidJObject();
-            obj["data_base64"] = SampleBinaryDataBase64;
-            obj["data"] = Newtonsoft.Json.Linq.JValue.CreateNull();
-            obj["datacontenttype"] = "application/binary";
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Equal(SampleBinaryData, cloudEvent.Data);
-        }
+    [Fact]
+    public void DecodeStructuredModeMessage_NullDataBase64Ignored()
+    {
+        var obj = CreateMinimalValidJObject();
+        obj["data_base64"] = Newtonsoft.Json.Linq.JValue.CreateNull();
+        obj["data"] = "some text";
+        obj["datacontenttype"] = "text/plain";
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Equal("some text", cloudEvent.Data);
+    }
 
-        [Fact]
-        public void DecodeBinaryModeEventData_EmptyData_JsonContentType()
-        {
-            var data = DecodeBinaryModeEventData(new byte[0], "application/json");
-            Assert.Null(data);
-        }
+    [Fact]
+    public void DecodeStructuredModeMessage_NullDataIgnored()
+    {
+        var obj = CreateMinimalValidJObject();
+        obj["data_base64"] = SampleBinaryDataBase64;
+        obj["data"] = Newtonsoft.Json.Linq.JValue.CreateNull();
+        obj["datacontenttype"] = "application/binary";
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Equal(SampleBinaryData, cloudEvent.Data);
+    }
 
-        [Fact]
-        public void DecodeBinaryModeEventData_EmptyData_TextContentType()
-        {
-            var data = DecodeBinaryModeEventData(new byte[0], "text/plain");
-            var text = Assert.IsType<string>(data);
-            Assert.Equal("", text);
-        }
+    [Fact]
+    public void DecodeBinaryModeEventData_EmptyData_JsonContentType()
+    {
+        var data = DecodeBinaryModeEventData(new byte[0], "application/json");
+        Assert.Null(data);
+    }
 
-        [Fact]
-        public void DecodeBinaryModeEventData_EmptyData_OtherContentType()
-        {
-            var data = DecodeBinaryModeEventData(new byte[0], "application/binary");
-            var byteArray = Assert.IsType<byte[]>(data);
-            Assert.Empty(byteArray);
-        }
+    [Fact]
+    public void DecodeBinaryModeEventData_EmptyData_TextContentType()
+    {
+        var data = DecodeBinaryModeEventData(new byte[0], "text/plain");
+        var text = Assert.IsType<string>(data);
+        Assert.Equal("", text);
+    }
 
-        [Theory]
-        [InlineData("utf-8")]
-        [InlineData("utf-16")]
-        public void DecodeBinaryModeEventData_Json(string charset)
-        {
-            var encoding = Encoding.GetEncoding(charset);
-            var bytes = encoding.GetBytes(new JObject { ["test"] = "some text" }.ToString());
-            var data = DecodeBinaryModeEventData(bytes, $"application/json; charset={charset}");
-            var element = Assert.IsType<JsonElement>(data);
-            var asserter = new JsonElementAsserter
+    [Fact]
+    public void DecodeBinaryModeEventData_EmptyData_OtherContentType()
+    {
+        var data = DecodeBinaryModeEventData(new byte[0], "application/binary");
+        var byteArray = Assert.IsType<byte[]>(data);
+        Assert.Empty(byteArray);
+    }
+
+    [Theory]
+    [InlineData("utf-8")]
+    [InlineData("utf-16")]
+    public void DecodeBinaryModeEventData_Json(string charset)
+    {
+        var encoding = Encoding.GetEncoding(charset);
+        var bytes = encoding.GetBytes(new JObject { ["test"] = "some text" }.ToString());
+        var data = DecodeBinaryModeEventData(bytes, $"application/json; charset={charset}");
+        var element = Assert.IsType<JsonElement>(data);
+        var asserter = new JsonElementAsserter
             {
                 { "test", JsonValueKind.String, "some text"}
             };
-            asserter.AssertProperties(element, assertCount: true);
-        }
+        asserter.AssertProperties(element, assertCount: true);
+    }
 
-        [Theory]
-        [InlineData("utf-8")]
-        [InlineData("iso-8859-1")]
-        public void DecodeBinaryModeEventData_Text(string charset)
+    [Theory]
+    [InlineData("utf-8")]
+    [InlineData("iso-8859-1")]
+    public void DecodeBinaryModeEventData_Text(string charset)
+    {
+        var encoding = Encoding.GetEncoding(charset);
+        var bytes = encoding.GetBytes(NonAsciiValue);
+        var data = DecodeBinaryModeEventData(bytes, $"text/plain; charset={charset}");
+        var text = Assert.IsType<string>(data);
+        Assert.Equal(NonAsciiValue, text);
+    }
+
+    [Fact]
+    public void DecodeBinaryModeEventData_Binary()
+    {
+        byte[] bytes = { 0, 1, 2, 3 };
+        var data = DecodeBinaryModeEventData(bytes, "application/binary");
+        Assert.Equal(bytes, data);
+    }
+
+    [Fact]
+    public void DecodeBatchMode_NotArray()
+    {
+        var formatter = new JsonEventFormatter();
+        var data = Encoding.UTF8.GetBytes(CreateMinimalValidJObject().ToString());
+        Assert.Throws<ArgumentException>(() => formatter.DecodeBatchModeMessage(data, s_jsonCloudEventBatchContentType, extensionAttributes: null));
+    }
+
+    [Fact]
+    public void DecodeBatchMode_ArrayContainingNonObject()
+    {
+        var formatter = new JsonEventFormatter();
+        var array = new JArray { CreateMinimalValidJObject(), "text" };
+        var data = Encoding.UTF8.GetBytes(array.ToString());
+        Assert.Throws<ArgumentException>(() => formatter.DecodeBatchModeMessage(data, s_jsonCloudEventBatchContentType, extensionAttributes: null));
+    }
+
+    [Fact]
+    public void DecodeBatchMode_Empty()
+    {
+        var cloudEvents = DecodeBatchModeMessage(new JArray());
+        Assert.Empty(cloudEvents);
+    }
+
+    [Fact]
+    public void DecodeBatchMode_Minimal()
+    {
+        var cloudEvents = DecodeBatchModeMessage(new JArray { CreateMinimalValidJObject() });
+        var cloudEvent = Assert.Single(cloudEvents);
+        Assert.Equal("event-type", cloudEvent.Type);
+        Assert.Equal("event-id", cloudEvent.Id);
+        Assert.Equal(new Uri("//event-source", UriKind.RelativeOrAbsolute), cloudEvent.Source);
+    }
+
+    [Fact]
+    public void DecodeBatchMode_Minimal_WithStream()
+    {
+        var array = new JArray { CreateMinimalValidJObject() };
+        var bytes = Encoding.UTF8.GetBytes(array.ToString());
+        var formatter = new JsonEventFormatter();
+        var cloudEvents = formatter.DecodeBatchModeMessage(new MemoryStream(bytes), s_jsonCloudEventBatchContentType, null);
+        var cloudEvent = Assert.Single(cloudEvents);
+        Assert.Equal("event-type", cloudEvent.Type);
+        Assert.Equal("event-id", cloudEvent.Id);
+        Assert.Equal(new Uri("//event-source", UriKind.RelativeOrAbsolute), cloudEvent.Source);
+    }
+
+    // Just a single test for the code that parses asynchronously... the guts are all the same.
+    [Fact]
+    public async Task DecodeBatchModeMessageAsync_Minimal()
+    {
+        var obj = new JObject
         {
-            var encoding = Encoding.GetEncoding(charset);
-            var bytes = encoding.GetBytes(NonAsciiValue);
-            var data = DecodeBinaryModeEventData(bytes, $"text/plain; charset={charset}");
-            var text = Assert.IsType<string>(data);
-            Assert.Equal(NonAsciiValue, text);
-        }
-
-        [Fact]
-        public void DecodeBinaryModeEventData_Binary()
-        {
-            byte[] bytes = { 0, 1, 2, 3 };
-            var data = DecodeBinaryModeEventData(bytes, "application/binary");
-            Assert.Equal(bytes, data);
-        }
-
-        [Fact]
-        public void DecodeBatchMode_NotArray()
-        {
-            var formatter = new JsonEventFormatter();
-            var data = Encoding.UTF8.GetBytes(CreateMinimalValidJObject().ToString());
-            Assert.Throws<ArgumentException>(() => formatter.DecodeBatchModeMessage(data, s_jsonCloudEventBatchContentType, extensionAttributes: null));
-        }
-
-        [Fact]
-        public void DecodeBatchMode_ArrayContainingNonObject()
-        {
-            var formatter = new JsonEventFormatter();
-            var array = new JArray { CreateMinimalValidJObject(), "text" };
-            var data = Encoding.UTF8.GetBytes(array.ToString());
-            Assert.Throws<ArgumentException>(() => formatter.DecodeBatchModeMessage(data, s_jsonCloudEventBatchContentType, extensionAttributes: null));
-        }
-
-        [Fact]
-        public void DecodeBatchMode_Empty()
-        {
-            var cloudEvents = DecodeBatchModeMessage(new JArray());
-            Assert.Empty(cloudEvents);
-        }
-
-        [Fact]
-        public void DecodeBatchMode_Minimal()
-        {
-            var cloudEvents = DecodeBatchModeMessage(new JArray { CreateMinimalValidJObject() });
-            var cloudEvent = Assert.Single(cloudEvents);
-            Assert.Equal("event-type", cloudEvent.Type);
-            Assert.Equal("event-id", cloudEvent.Id);
-            Assert.Equal(new Uri("//event-source", UriKind.RelativeOrAbsolute), cloudEvent.Source);
-        }
-
-        [Fact]
-        public void DecodeBatchMode_Minimal_WithStream()
-        {
-            var array = new JArray { CreateMinimalValidJObject() };
-            var bytes = Encoding.UTF8.GetBytes(array.ToString());
-            var formatter = new JsonEventFormatter();
-            var cloudEvents = formatter.DecodeBatchModeMessage(new MemoryStream(bytes), s_jsonCloudEventBatchContentType, null);
-            var cloudEvent = Assert.Single(cloudEvents);
-            Assert.Equal("event-type", cloudEvent.Type);
-            Assert.Equal("event-id", cloudEvent.Id);
-            Assert.Equal(new Uri("//event-source", UriKind.RelativeOrAbsolute), cloudEvent.Source);
-        }
-
-        // Just a single test for the code that parses asynchronously... the guts are all the same.
-        [Fact]
-        public async Task DecodeBatchModeMessageAsync_Minimal()
-        {
-            var obj = new JObject
-            {
-                ["specversion"] = "1.0",
-                ["type"] = "test-type",
-                ["id"] = "test-id",
-                ["source"] = SampleUriText,
-            };
-            var bytes = Encoding.UTF8.GetBytes(new JArray { obj }.ToString());
-            var stream = new MemoryStream(bytes);
-            var formatter = new JsonEventFormatter();
-            var cloudEvents = await formatter.DecodeBatchModeMessageAsync(stream, s_jsonCloudEventBatchContentType, null);
-            var cloudEvent = Assert.Single(cloudEvents);
-            Assert.Equal("test-type", cloudEvent.Type);
-            Assert.Equal("test-id", cloudEvent.Id);
-            Assert.Equal(SampleUri, cloudEvent.Source);
-        }
+            ["specversion"] = "1.0",
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["source"] = SampleUriText,
+        };
+        var bytes = Encoding.UTF8.GetBytes(new JArray { obj }.ToString());
+        var stream = new MemoryStream(bytes);
+        var formatter = new JsonEventFormatter();
+        var cloudEvents = await formatter.DecodeBatchModeMessageAsync(stream, s_jsonCloudEventBatchContentType, null);
+        var cloudEvent = Assert.Single(cloudEvents);
+        Assert.Equal("test-type", cloudEvent.Type);
+        Assert.Equal("test-id", cloudEvent.Id);
+        Assert.Equal(SampleUri, cloudEvent.Source);
+    }
 
 
-        [Fact]
-        public void DecodeBatchMode_Multiple()
-        {
-            var array = new JArray
+    [Fact]
+    public void DecodeBatchMode_Multiple()
+    {
+        var array = new JArray
             {
                 new JObject
                 {
@@ -1002,37 +1002,37 @@ namespace CloudNative.CloudEvents.SystemTextJson.UnitTests
                     ["source"] = "//event-source2"
                 },
             };
-            var cloudEvents = DecodeBatchModeMessage(array);
-            Assert.Equal(2, cloudEvents.Count);
+        var cloudEvents = DecodeBatchModeMessage(array);
+        Assert.Equal(2, cloudEvents.Count);
 
-            var event1 = cloudEvents[0];
-            Assert.Equal("type1", event1.Type);
-            Assert.Equal("event1", event1.Id);
-            Assert.Equal(new Uri("//event-source1", UriKind.RelativeOrAbsolute), event1.Source);
-            Assert.Equal("simple text", event1.Data);
-            Assert.Equal("text/plain", event1.DataContentType);
+        var event1 = cloudEvents[0];
+        Assert.Equal("type1", event1.Type);
+        Assert.Equal("event1", event1.Id);
+        Assert.Equal(new Uri("//event-source1", UriKind.RelativeOrAbsolute), event1.Source);
+        Assert.Equal("simple text", event1.Data);
+        Assert.Equal("text/plain", event1.DataContentType);
 
-            var event2 = cloudEvents[1];
-            Assert.Equal("type2", event2.Type);
-            Assert.Equal("event2", event2.Id);
-            Assert.Equal(new Uri("//event-source2", UriKind.RelativeOrAbsolute), event2.Source);
-            Assert.Null(event2.Data);
-            Assert.Null(event2.DataContentType);
-        }
+        var event2 = cloudEvents[1];
+        Assert.Equal("type2", event2.Type);
+        Assert.Equal("event2", event2.Id);
+        Assert.Equal(new Uri("//event-source2", UriKind.RelativeOrAbsolute), event2.Source);
+        Assert.Null(event2.Data);
+        Assert.Null(event2.DataContentType);
+    }
 
-        // Additional tests for the changes/clarifications in https://github.com/cloudevents/spec/pull/861
-        [Fact]
-        public void EncodeStructured_DefaultContentTypeToApplicationJson()
+    // Additional tests for the changes/clarifications in https://github.com/cloudevents/spec/pull/861
+    [Fact]
+    public void EncodeStructured_DefaultContentTypeToApplicationJson()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent
-            {
-                Data = new { Key = "value" }
-            }.PopulateRequiredAttributes();
+            Data = new { Key = "value" }
+        }.PopulateRequiredAttributes();
 
-            var encoded = new JsonEventFormatter().EncodeStructuredModeMessage(cloudEvent, out var contentType);
-            Assert.Equal("application/cloudevents+json; charset=utf-8", contentType.ToString());
-            JsonElement obj = ParseJson(encoded);
-            var asserter = new JsonElementAsserter
+        var encoded = new JsonEventFormatter().EncodeStructuredModeMessage(cloudEvent, out var contentType);
+        Assert.Equal("application/cloudevents+json; charset=utf-8", contentType.ToString());
+        JsonElement obj = ParseJson(encoded);
+        var asserter = new JsonElementAsserter
             {
                 { "data", JsonValueKind.Object, cloudEvent.Data },
                 { "datacontenttype", JsonValueKind.String, "application/json" },
@@ -1041,24 +1041,24 @@ namespace CloudNative.CloudEvents.SystemTextJson.UnitTests
                 { "specversion", JsonValueKind.String, "1.0" },
                 { "type", JsonValueKind.String, "test-type" },
             };
-            asserter.AssertProperties(obj, assertCount: true);
-        }
+        asserter.AssertProperties(obj, assertCount: true);
+    }
 
-        [Fact]
-        public void EncodeStructured_BinaryData_DefaultContentTypeIsNotImplied()
+    [Fact]
+    public void EncodeStructured_BinaryData_DefaultContentTypeIsNotImplied()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent
-            {
-                Data = SampleBinaryData
-            }.PopulateRequiredAttributes();
+            Data = SampleBinaryData
+        }.PopulateRequiredAttributes();
 
-            // If a CloudEvent to have binary data but no data content type,
-            // the spec says the data should be placed in data_base64, but the content type
-            // should *not* be defaulted to application/json, as clarified in https://github.com/cloudevents/spec/issues/933
-            var encoded = new JsonEventFormatter().EncodeStructuredModeMessage(cloudEvent, out var contentType);
-            Assert.Equal("application/cloudevents+json; charset=utf-8", contentType.ToString());
-            JsonElement obj = ParseJson(encoded);
-            var asserter = new JsonElementAsserter
+        // If a CloudEvent to have binary data but no data content type,
+        // the spec says the data should be placed in data_base64, but the content type
+        // should *not* be defaulted to application/json, as clarified in https://github.com/cloudevents/spec/issues/933
+        var encoded = new JsonEventFormatter().EncodeStructuredModeMessage(cloudEvent, out var contentType);
+        Assert.Equal("application/cloudevents+json; charset=utf-8", contentType.ToString());
+        JsonElement obj = ParseJson(encoded);
+        var asserter = new JsonElementAsserter
             {
                 { "data_base64", JsonValueKind.String, SampleBinaryDataBase64 },
                 { "id", JsonValueKind.String, "test-id" },
@@ -1066,52 +1066,52 @@ namespace CloudNative.CloudEvents.SystemTextJson.UnitTests
                 { "specversion", JsonValueKind.String, "1.0" },
                 { "type", JsonValueKind.String, "test-type" },
             };
-            asserter.AssertProperties(obj, assertCount: true);
-        }
+        asserter.AssertProperties(obj, assertCount: true);
+    }
 
-        [Fact]
-        public void DecodeStructured_DefaultContentTypeToApplicationJson()
+    [Fact]
+    public void DecodeStructured_DefaultContentTypeToApplicationJson()
+    {
+        var obj = new JObject
         {
-            var obj = new JObject
-            {
-                ["specversion"] = "1.0",
-                ["type"] = "test-type",
-                ["id"] = "test-id",
-                ["source"] = SampleUriText,
-                ["data"] = "some text"
-            };
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Equal("application/json", cloudEvent.DataContentType);
-            var jsonData = Assert.IsType<JsonElement>(cloudEvent.Data);
-            Assert.Equal(JsonValueKind.String, jsonData.ValueKind);
-            Assert.Equal("some text", jsonData.GetString());
-        }
+            ["specversion"] = "1.0",
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["source"] = SampleUriText,
+            ["data"] = "some text"
+        };
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Equal("application/json", cloudEvent.DataContentType);
+        var jsonData = Assert.IsType<JsonElement>(cloudEvent.Data);
+        Assert.Equal(JsonValueKind.String, jsonData.ValueKind);
+        Assert.Equal("some text", jsonData.GetString());
+    }
 
-        [Fact]
-        public void EncodeStructured_IndentationSettings()
+    [Fact]
+    public void EncodeStructured_IndentationSettings()
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        var formatter = new JsonEventFormatter(new JsonSerializerOptions
         {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            var formatter = new JsonEventFormatter(new JsonSerializerOptions
-            {
-                WriteIndented = true
-            }, new JsonDocumentOptions());
-            var encoded = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
-            // Normalize the result to LF line endings.
-            var json = BinaryDataUtilities.GetString(encoded, Encoding.UTF8).Replace("\r\n", "\n").Replace("\r", "\n");
-            var expected = "{\n  \"specversion\": \"1.0\",\n  \"id\": \"test-id\",\n  \"source\": \"//test\",\n  \"type\": \"test-type\"\n}";
-            Assert.Equal(expected, json);
-        }
+            WriteIndented = true
+        }, new JsonDocumentOptions());
+        var encoded = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
+        // Normalize the result to LF line endings.
+        var json = BinaryDataUtilities.GetString(encoded, Encoding.UTF8).Replace("\r\n", "\n").Replace("\r", "\n");
+        var expected = "{\n  \"specversion\": \"1.0\",\n  \"id\": \"test-id\",\n  \"source\": \"//test\",\n  \"type\": \"test-type\"\n}";
+        Assert.Equal(expected, json);
+    }
 
-        [Fact]
-        public void ConvertToJsonElement()
+    [Fact]
+    public void ConvertToJsonElement()
+    {
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent
-            {
-                Data = SampleBinaryData
-            }.PopulateRequiredAttributes();
+            Data = SampleBinaryData
+        }.PopulateRequiredAttributes();
 
-            JsonElement element = new JsonEventFormatter().ConvertToJsonElement(cloudEvent);
-            var asserter = new JsonElementAsserter
+        JsonElement element = new JsonEventFormatter().ConvertToJsonElement(cloudEvent);
+        var asserter = new JsonElementAsserter
             {
                 { "data_base64", JsonValueKind.String, SampleBinaryDataBase64 },
                 { "id", JsonValueKind.String, "test-id" },
@@ -1119,112 +1119,111 @@ namespace CloudNative.CloudEvents.SystemTextJson.UnitTests
                 { "specversion", JsonValueKind.String, "1.0" },
                 { "type", JsonValueKind.String, "test-type" }
             };
-            asserter.AssertProperties(element, assertCount: true);
-        }
+        asserter.AssertProperties(element, assertCount: true);
+    }
 
-        [Fact]
-        public void ConvertFromJsonElement()
+    [Fact]
+    public void ConvertFromJsonElement()
+    {
+        var obj = new JObject
         {
-            var obj = new JObject
-            {
-                ["specversion"] = "1.0",
-                ["type"] = "test-type",
-                ["id"] = "test-id",
-                ["data"] = "text", // Just so that it's reasonable to have a DataContentType,
-                ["datacontenttype"] = "text/plain",
-                ["dataschema"] = "https://data-schema",
-                ["subject"] = "event-subject",
-                ["source"] = "//event-source",
-                ["time"] = SampleTimestampText
-            };
-            using var document = JsonDocument.Parse(obj.ToString());
-            var cloudEvent = new JsonEventFormatter().ConvertFromJsonElement(document.RootElement, extensionAttributes: null);
-            Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
-            Assert.Equal("test-type", cloudEvent.Type);
-            Assert.Equal("test-id", cloudEvent.Id);
-            Assert.Equal("text/plain", cloudEvent.DataContentType);
-            Assert.Equal(new Uri("https://data-schema"), cloudEvent.DataSchema);
-            Assert.Equal("event-subject", cloudEvent.Subject);
-            Assert.Equal(new Uri("//event-source", UriKind.RelativeOrAbsolute), cloudEvent.Source);
-            AssertTimestampsEqual(SampleTimestamp, cloudEvent.Time);
-        }
+            ["specversion"] = "1.0",
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["data"] = "text", // Just so that it's reasonable to have a DataContentType,
+            ["datacontenttype"] = "text/plain",
+            ["dataschema"] = "https://data-schema",
+            ["subject"] = "event-subject",
+            ["source"] = "//event-source",
+            ["time"] = SampleTimestampText
+        };
+        using var document = JsonDocument.Parse(obj.ToString());
+        var cloudEvent = new JsonEventFormatter().ConvertFromJsonElement(document.RootElement, extensionAttributes: null);
+        Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
+        Assert.Equal("test-type", cloudEvent.Type);
+        Assert.Equal("test-id", cloudEvent.Id);
+        Assert.Equal("text/plain", cloudEvent.DataContentType);
+        Assert.Equal(new Uri("https://data-schema"), cloudEvent.DataSchema);
+        Assert.Equal("event-subject", cloudEvent.Subject);
+        Assert.Equal(new Uri("//event-source", UriKind.RelativeOrAbsolute), cloudEvent.Source);
+        AssertTimestampsEqual(SampleTimestamp, cloudEvent.Time);
+    }
 
-        // Utility methods
-        private static object DecodeBinaryModeEventData(byte[] bytes, string contentType)
+    // Utility methods
+    private static object DecodeBinaryModeEventData(byte[] bytes, string contentType)
+    {
+        var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
+        cloudEvent.DataContentType = contentType;
+        new JsonEventFormatter().DecodeBinaryModeEventData(bytes, cloudEvent);
+        return cloudEvent.Data!;
+    }
+
+    internal static JObject CreateMinimalValidJObject() =>
+        new JObject
         {
-            var cloudEvent = new CloudEvent().PopulateRequiredAttributes();
-            cloudEvent.DataContentType = contentType;
-            new JsonEventFormatter().DecodeBinaryModeEventData(bytes, cloudEvent);
-            return cloudEvent.Data!;
-        }
+            ["specversion"] = "1.0",
+            ["type"] = "event-type",
+            ["id"] = "event-id",
+            ["source"] = "//event-source"
+        };
 
-        internal static JObject CreateMinimalValidJObject() =>
-            new JObject
-            {
-                ["specversion"] = "1.0",
-                ["type"] = "event-type",
-                ["id"] = "event-id",
-                ["source"] = "//event-source"
-            };
+    /// <summary>
+    /// Parses JSON as a JsonElement.
+    /// </summary>
+    internal static JsonElement ParseJson(string text)
+    {
+        using var document = JsonDocument.Parse(text);
+        return document.RootElement.Clone();
+    }
 
-        /// <summary>
-        /// Parses JSON as a JsonElement.
-        /// </summary>
-        internal static JsonElement ParseJson(string text)
-        {
-            using var document = JsonDocument.Parse(text);
-            return document.RootElement.Clone();
-        }
+    /// <summary>
+    /// Parses JSON as a JsonElement.
+    /// </summary>
+    internal static JsonElement ParseJson(ReadOnlyMemory<byte> data)
+    {
+        using var document = JsonDocument.Parse(data);
+        return document.RootElement.Clone();
+    }
 
-        /// <summary>
-        /// Parses JSON as a JsonElement.
-        /// </summary>
-        internal static JsonElement ParseJson(ReadOnlyMemory<byte> data)
-        {
-            using var document = JsonDocument.Parse(data);
-            return document.RootElement.Clone();
-        }
+    /// <summary>
+    /// Convenience method to format a CloudEvent with the default JsonEventFormatter in
+    /// structured mode, then parse the result as a JObject.
+    /// </summary>
+    private static JsonElement EncodeAndParseStructured(CloudEvent cloudEvent)
+    {
+        var formatter = new JsonEventFormatter();
+        var encoded = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
+        return ParseJson(encoded);
+    }
 
-        /// <summary>
-        /// Convenience method to format a CloudEvent with the default JsonEventFormatter in
-        /// structured mode, then parse the result as a JObject.
-        /// </summary>
-        private static JsonElement EncodeAndParseStructured(CloudEvent cloudEvent)
-        {
-            var formatter = new JsonEventFormatter();
-            var encoded = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
-            return ParseJson(encoded);
-        }
+    /// <summary>
+    /// Convenience method to serialize a JObject to bytes, then
+    /// decode it as a structured event with the default (System.Text.Json) JsonEventFormatter and no extension attributes.
+    /// </summary>
+    private static CloudEvent DecodeStructuredModeMessage(Newtonsoft.Json.Linq.JObject obj)
+    {
+        var bytes = Encoding.UTF8.GetBytes(obj.ToString());
+        var formatter = new JsonEventFormatter();
+        return formatter.DecodeStructuredModeMessage(bytes, s_jsonCloudEventContentType, null);
+    }
 
-        /// <summary>
-        /// Convenience method to serialize a JObject to bytes, then
-        /// decode it as a structured event with the default (System.Text.Json) JsonEventFormatter and no extension attributes.
-        /// </summary>
-        private static CloudEvent DecodeStructuredModeMessage(Newtonsoft.Json.Linq.JObject obj)
-        {
-            var bytes = Encoding.UTF8.GetBytes(obj.ToString());
-            var formatter = new JsonEventFormatter();
-            return formatter.DecodeStructuredModeMessage(bytes, s_jsonCloudEventContentType, null);
-        }
+    /// <summary>
+    /// Convenience method to serialize a JArray to bytes, then
+    /// decode it as a structured event with the default (System.Text.Json) JsonEventFormatter and no extension attributes.
+    /// </summary>
+    private static IReadOnlyList<CloudEvent> DecodeBatchModeMessage(Newtonsoft.Json.Linq.JArray array)
+    {
+        var bytes = Encoding.UTF8.GetBytes(array.ToString());
+        var formatter = new JsonEventFormatter();
+        return formatter.DecodeBatchModeMessage(bytes, s_jsonCloudEventBatchContentType, null);
+    }
 
-        /// <summary>
-        /// Convenience method to serialize a JArray to bytes, then
-        /// decode it as a structured event with the default (System.Text.Json) JsonEventFormatter and no extension attributes.
-        /// </summary>
-        private static IReadOnlyList<CloudEvent> DecodeBatchModeMessage(Newtonsoft.Json.Linq.JArray array)
-        {
-            var bytes = Encoding.UTF8.GetBytes(array.ToString());
-            var formatter = new JsonEventFormatter();
-            return formatter.DecodeBatchModeMessage(bytes, s_jsonCloudEventBatchContentType, null);
-        }
+    private class YearMonthDayConverter : JsonConverter<DateTime>
+    {
+        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+            DateTime.ParseExact(reader.GetString()!, "yyyy-MM-dd", CultureInfo.InvariantCulture);
 
-        private class YearMonthDayConverter : JsonConverter<DateTime>
-        {
-            public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
-                DateTime.ParseExact(reader.GetString()!, "yyyy-MM-dd", CultureInfo.InvariantCulture);
-
-            public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options) =>
-                writer.WriteStringValue(value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
-        }
+        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options) =>
+            writer.WriteStringValue(value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/SpecializedFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/SpecializedFormatterTest.cs
@@ -11,195 +11,194 @@ using static CloudNative.CloudEvents.UnitTests.TestHelpers;
 // JObject is a really handy way of creating JSON which we can then parse with System.Text.Json
 using JObject = Newtonsoft.Json.Linq.JObject;
 
-namespace CloudNative.CloudEvents.SystemTextJson.UnitTests
+namespace CloudNative.CloudEvents.SystemTextJson.UnitTests;
+
+/// <summary>
+/// Tests for encoding/decoding using a subclass of <see cref="JsonEventFormatter"/>.
+/// This is effectively testing when the virtual methods are invoked.
+/// </summary>
+public class SpecializedFormatterTest
 {
-    /// <summary>
-    /// Tests for encoding/decoding using a subclass of <see cref="JsonEventFormatter"/>.
-    /// This is effectively testing when the virtual methods are invoked.
-    /// </summary>
-    public class SpecializedFormatterTest
+    private const string GuidPrefix = "guid:";
+    private const string TextBinaryContentType = "text/binary";
+    private const string GuidContentType = "application/guid";
+
+    // Just to validate delegation to base methods
+    [Fact]
+    public void EncodePlainText()
     {
-        private const string GuidPrefix = "guid:";
-        private const string TextBinaryContentType = "text/binary";
-        private const string GuidContentType = "application/guid";
-
-        // Just to validate delegation to base methods
-        [Fact]
-        public void EncodePlainText()
+        var cloudEvent = new CloudEvent
         {
-            var cloudEvent = new CloudEvent
+            Data = "some text",
+            DataContentType = "text/plain"
+        }.PopulateRequiredAttributes();
+        var obj = EncodeAndParseStructured(cloudEvent);
+        AssertStringElement("some text", obj.GetProperty("data"));
+    }
+
+    // Just to validate delegation to base methods
+    [Fact]
+    public void EncodeByteArray()
+    {
+        var cloudEvent = new CloudEvent
+        {
+            Data = SampleBinaryData,
+            DataContentType = "application/binary"
+        }.PopulateRequiredAttributes();
+        var obj = EncodeAndParseStructured(cloudEvent);
+        AssertStringElement(SampleBinaryDataBase64, obj.GetProperty("data_base64"));
+    }
+
+    [Fact]
+    public void EncodeGuid()
+    {
+        Guid guid = Guid.NewGuid();
+        var cloudEvent = new CloudEvent
+        {
+            Data = guid,
+            DataContentType = GuidContentType
+        }.PopulateRequiredAttributes();
+        var obj = EncodeAndParseStructured(cloudEvent);
+        string expectedText = GuidPrefix + Convert.ToBase64String(guid.ToByteArray());
+        AssertStringElement(expectedText, obj.GetProperty("data"));
+    }
+
+    [Fact]
+    public void EncodeTextBinary()
+    {
+        var cloudEvent = new CloudEvent
+        {
+            Data = "some text",
+            DataContentType = TextBinaryContentType
+        }.PopulateRequiredAttributes();
+        var obj = EncodeAndParseStructured(cloudEvent);
+        string expectedText = Convert.ToBase64String(Encoding.UTF8.GetBytes("some text"));
+        AssertStringElement(expectedText, obj.GetProperty("data_base64"));
+    }
+
+    // Just to validate delegation to base methods
+    [Fact]
+    public void DecodePlainText()
+    {
+        var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
+        obj["data"] = "some text";
+        obj["datacontenttype"] = "text/plain";
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Equal("some text", cloudEvent.Data);
+    }
+
+    // Just to validate delegation to base methods
+    [Fact]
+    public void DecodeByteArray()
+    {
+        var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
+        obj["data_base64"] = SampleBinaryDataBase64;
+        obj["datacontenttype"] = "application/binary";
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Equal(SampleBinaryData, cloudEvent.Data);
+    }
+
+    [Fact]
+    public void DecodeGuid()
+    {
+        Guid guid = Guid.NewGuid();
+        var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
+        obj["data"] = GuidPrefix + Convert.ToBase64String(guid.ToByteArray());
+        obj["datacontenttype"] = GuidContentType;
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Equal(guid, cloudEvent.Data);
+    }
+
+    [Fact]
+    public void DecodeTextBinary()
+    {
+        var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
+        obj["data_base64"] = Convert.ToBase64String(Encoding.UTF8.GetBytes("some text"));
+        obj["datacontenttype"] = TextBinaryContentType;
+        var cloudEvent = DecodeStructuredModeMessage(obj);
+        Assert.Equal("some text", cloudEvent.Data);
+    }
+
+    private static void AssertStringElement(string expectedValue, JsonElement element)
+    {
+        Assert.Equal(JsonValueKind.String, element.ValueKind);
+        Assert.Equal(expectedValue, element.GetString());
+    }
+
+    /// <summary>
+    /// Convenience method to format a CloudEvent with a specialized formatter in
+    /// structured mode, then parse the result as a JObject.
+    /// </summary>
+    private static JsonElement EncodeAndParseStructured(CloudEvent cloudEvent)
+    {
+        var formatter = new SpecializedFormatter();
+        var encoded = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
+        return JsonEventFormatterTest.ParseJson(encoded);
+    }
+
+    /// <summary>
+    /// Convenience method to serialize a JObject to bytes, then
+    /// decode it as a structured event with a specialized formatter and no extension attributes.
+    /// </summary>
+    private static CloudEvent DecodeStructuredModeMessage(JObject obj)
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
+        var formatter = new SpecializedFormatter();
+        return formatter.DecodeStructuredModeMessage(bytes, null, null);
+    }
+
+    /// <summary>
+    /// Specialized formatter:
+    /// - Content type of "text/binary" is encoded in base64
+    /// - Guid with a content type of "application/guid" is encoded as a string with content "guid:base64-data"
+    /// </summary>
+    private class SpecializedFormatter : JsonEventFormatter
+    {
+        protected override void DecodeStructuredModeDataBase64Property(JsonElement dataBase64Element, CloudEvent cloudEvent)
+        {
+            if (cloudEvent.DataContentType == TextBinaryContentType && dataBase64Element.ValueKind == JsonValueKind.String)
             {
-                Data = "some text",
-                DataContentType = "text/plain"
-            }.PopulateRequiredAttributes();
-            var obj = EncodeAndParseStructured(cloudEvent);
-            AssertStringElement("some text", obj.GetProperty("data"));
-        }
-
-        // Just to validate delegation to base methods
-        [Fact]
-        public void EncodeByteArray()
-        {
-            var cloudEvent = new CloudEvent
-            {
-                Data = SampleBinaryData,
-                DataContentType = "application/binary"
-            }.PopulateRequiredAttributes();
-            var obj = EncodeAndParseStructured(cloudEvent);
-            AssertStringElement(SampleBinaryDataBase64, obj.GetProperty("data_base64"));
-        }
-
-        [Fact]
-        public void EncodeGuid()
-        {
-            Guid guid = Guid.NewGuid();
-            var cloudEvent = new CloudEvent
-            {
-                Data = guid,
-                DataContentType = GuidContentType
-            }.PopulateRequiredAttributes();
-            var obj = EncodeAndParseStructured(cloudEvent);
-            string expectedText = GuidPrefix + Convert.ToBase64String(guid.ToByteArray());
-            AssertStringElement(expectedText, obj.GetProperty("data"));
-        }
-
-        [Fact]
-        public void EncodeTextBinary()
-        {
-            var cloudEvent = new CloudEvent
-            {
-                Data = "some text",
-                DataContentType = TextBinaryContentType
-            }.PopulateRequiredAttributes();
-            var obj = EncodeAndParseStructured(cloudEvent);
-            string expectedText = Convert.ToBase64String(Encoding.UTF8.GetBytes("some text"));
-            AssertStringElement(expectedText, obj.GetProperty("data_base64"));
-        }
-
-        // Just to validate delegation to base methods
-        [Fact]
-        public void DecodePlainText()
-        {
-            var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
-            obj["data"] = "some text";
-            obj["datacontenttype"] = "text/plain";
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Equal("some text", cloudEvent.Data);
-        }
-
-        // Just to validate delegation to base methods
-        [Fact]
-        public void DecodeByteArray()
-        {
-            var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
-            obj["data_base64"] = SampleBinaryDataBase64;
-            obj["datacontenttype"] = "application/binary";
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Equal(SampleBinaryData, cloudEvent.Data);
-        }
-
-        [Fact]
-        public void DecodeGuid()
-        {
-            Guid guid = Guid.NewGuid();
-            var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
-            obj["data"] = GuidPrefix + Convert.ToBase64String(guid.ToByteArray());
-            obj["datacontenttype"] = GuidContentType;
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Equal(guid, cloudEvent.Data);
-        }
-
-        [Fact]
-        public void DecodeTextBinary()
-        {
-            var obj = JsonEventFormatterTest.CreateMinimalValidJObject();
-            obj["data_base64"] = Convert.ToBase64String(Encoding.UTF8.GetBytes("some text"));
-            obj["datacontenttype"] = TextBinaryContentType;
-            var cloudEvent = DecodeStructuredModeMessage(obj);
-            Assert.Equal("some text", cloudEvent.Data);
-        }
-
-        private static void AssertStringElement(string expectedValue, JsonElement element)
-        {
-            Assert.Equal(JsonValueKind.String, element.ValueKind);
-            Assert.Equal(expectedValue, element.GetString());
-        }
-
-        /// <summary>
-        /// Convenience method to format a CloudEvent with a specialized formatter in
-        /// structured mode, then parse the result as a JObject.
-        /// </summary>
-        private static JsonElement EncodeAndParseStructured(CloudEvent cloudEvent)
-        {
-            var formatter = new SpecializedFormatter();
-            var encoded = formatter.EncodeStructuredModeMessage(cloudEvent, out _);
-            return JsonEventFormatterTest.ParseJson(encoded);
-        }
-
-        /// <summary>
-        /// Convenience method to serialize a JObject to bytes, then
-        /// decode it as a structured event with a specialized formatter and no extension attributes.
-        /// </summary>
-        private static CloudEvent DecodeStructuredModeMessage(JObject obj)
-        {
-            byte[] bytes = Encoding.UTF8.GetBytes(obj.ToString());
-            var formatter = new SpecializedFormatter();
-            return formatter.DecodeStructuredModeMessage(bytes, null, null);
-        }
-
-        /// <summary>
-        /// Specialized formatter:
-        /// - Content type of "text/binary" is encoded in base64
-        /// - Guid with a content type of "application/guid" is encoded as a string with content "guid:base64-data"
-        /// </summary>
-        private class SpecializedFormatter : JsonEventFormatter
-        {
-            protected override void DecodeStructuredModeDataBase64Property(JsonElement dataBase64Element, CloudEvent cloudEvent)
-            {
-                if (cloudEvent.DataContentType == TextBinaryContentType && dataBase64Element.ValueKind == JsonValueKind.String)
-                {
-                    cloudEvent.Data = Encoding.UTF8.GetString(dataBase64Element.GetBytesFromBase64());
-                }
-                else
-                {
-                    base.DecodeStructuredModeDataBase64Property(dataBase64Element, cloudEvent);
-                }
+                cloudEvent.Data = Encoding.UTF8.GetString(dataBase64Element.GetBytesFromBase64());
             }
-
-            protected override void DecodeStructuredModeDataProperty(JsonElement dataElement, CloudEvent cloudEvent)
+            else
             {
-                if (cloudEvent.DataContentType == GuidContentType && dataElement.ValueKind == JsonValueKind.String)
-                {
-                    string text = dataElement.GetString()!;
-                    if (!text.StartsWith(GuidPrefix))
-                    {
-                        throw new ArgumentException("Invalid GUID text data");
-                    }
-                    cloudEvent.Data = new Guid(Convert.FromBase64String(text.Substring(GuidPrefix.Length)));
-                }
-                else
-                {
-                    base.DecodeStructuredModeDataProperty(dataElement, cloudEvent);
-                }
+                base.DecodeStructuredModeDataBase64Property(dataBase64Element, cloudEvent);
             }
+        }
 
-            protected override void EncodeStructuredModeData(CloudEvent cloudEvent, Utf8JsonWriter writer)
+        protected override void DecodeStructuredModeDataProperty(JsonElement dataElement, CloudEvent cloudEvent)
+        {
+            if (cloudEvent.DataContentType == GuidContentType && dataElement.ValueKind == JsonValueKind.String)
             {
-                var data = cloudEvent.Data;
-                if (data is Guid guid && cloudEvent.DataContentType == GuidContentType)
+                string text = dataElement.GetString()!;
+                if (!text.StartsWith(GuidPrefix))
                 {
-                    writer.WritePropertyName(DataPropertyName);
-                    writer.WriteStringValue(GuidPrefix + Convert.ToBase64String(guid.ToByteArray()));
+                    throw new ArgumentException("Invalid GUID text data");
                 }
-                else if (data is string text && cloudEvent.DataContentType == TextBinaryContentType)
-                {
-                    writer.WritePropertyName(DataBase64PropertyName);
-                    writer.WriteBase64StringValue(Encoding.UTF8.GetBytes(text));
-                }
-                else
-                {
-                    base.EncodeStructuredModeData(cloudEvent, writer);
-                }
+                cloudEvent.Data = new Guid(Convert.FromBase64String(text.Substring(GuidPrefix.Length)));
+            }
+            else
+            {
+                base.DecodeStructuredModeDataProperty(dataElement, cloudEvent);
+            }
+        }
+
+        protected override void EncodeStructuredModeData(CloudEvent cloudEvent, Utf8JsonWriter writer)
+        {
+            var data = cloudEvent.Data;
+            if (data is Guid guid && cloudEvent.DataContentType == GuidContentType)
+            {
+                writer.WritePropertyName(DataPropertyName);
+                writer.WriteStringValue(GuidPrefix + Convert.ToBase64String(guid.ToByteArray()));
+            }
+            else if (data is string text && cloudEvent.DataContentType == TextBinaryContentType)
+            {
+                writer.WritePropertyName(DataBase64PropertyName);
+                writer.WriteBase64StringValue(Encoding.UTF8.GetBytes(text));
+            }
+            else
+            {
+                base.EncodeStructuredModeData(cloudEvent, writer);
             }
         }
     }

--- a/test/CloudNative.CloudEvents.UnitTests/TestHelpers.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/TestHelpers.cs
@@ -10,26 +10,26 @@ using System.IO;
 using System.Linq;
 using Xunit;
 
-namespace CloudNative.CloudEvents.UnitTests
+namespace CloudNative.CloudEvents.UnitTests;
+
+/// <summary>
+/// Helpers for test code, e.g. common non-trivial assertions.
+/// </summary>
+internal static class TestHelpers
 {
+    internal static IEqualityComparer<DateTimeOffset> InstantOnlyTimestampComparer => EqualityComparer<DateTimeOffset>.Default;
+    internal static IEqualityComparer<DateTimeOffset> StrictTimestampComparer => StrictTimestampComparerImpl.Instance;
+
+    internal static CloudEventAttribute[] EmptyExtensionArray { get; } = new CloudEventAttribute[0];
+    internal static IEnumerable<CloudEventAttribute> EmptyExtensionSequence { get; } = new List<CloudEventAttribute>().AsReadOnly();
+
     /// <summary>
-    /// Helpers for test code, e.g. common non-trivial assertions.
+    /// A set of extension attributes covering all attributes types.
+    /// The name of each attribute is the lower-cased form of the attribute type
+    /// name, with all punctuation removed (e.g. "urireference").
+    /// The attributes do not have any extra validation.
     /// </summary>
-    internal static class TestHelpers
-    {
-        internal static IEqualityComparer<DateTimeOffset> InstantOnlyTimestampComparer => EqualityComparer<DateTimeOffset>.Default;
-        internal static IEqualityComparer<DateTimeOffset> StrictTimestampComparer => StrictTimestampComparerImpl.Instance;
-
-        internal static CloudEventAttribute[] EmptyExtensionArray { get; } = new CloudEventAttribute[0];
-        internal static IEnumerable<CloudEventAttribute> EmptyExtensionSequence { get; } = new List<CloudEventAttribute>().AsReadOnly();
-
-        /// <summary>
-        /// A set of extension attributes covering all attributes types.
-        /// The name of each attribute is the lower-cased form of the attribute type
-        /// name, with all punctuation removed (e.g. "urireference").
-        /// The attributes do not have any extra validation.
-        /// </summary>
-        internal static IEnumerable<CloudEventAttribute> AllTypesExtensions { get; } = new List<CloudEventAttribute>
+    internal static IEnumerable<CloudEventAttribute> AllTypesExtensions { get; } = new List<CloudEventAttribute>
         {
             CloudEventAttribute.CreateExtension("binary", CloudEventAttributeType.Binary),
             CloudEventAttribute.CreateExtension("boolean", CloudEventAttributeType.Boolean),
@@ -40,197 +40,196 @@ namespace CloudNative.CloudEvents.UnitTests
             CloudEventAttribute.CreateExtension("urireference", CloudEventAttributeType.UriReference)
         }.AsReadOnly();
 
-        /// <summary>
-        /// Arbitrary binary data to be used for testing.
-        /// Calling code should not rely on the exact value.
-        /// </summary>
-        internal static byte[] SampleBinaryData { get; } = new byte[] { 1, 2, 3 };
+    /// <summary>
+    /// Arbitrary binary data to be used for testing.
+    /// Calling code should not rely on the exact value.
+    /// </summary>
+    internal static byte[] SampleBinaryData { get; } = new byte[] { 1, 2, 3 };
 
-        /// <summary>
-        /// The base64 representation of <see cref="SampleBinaryData"/>.
-        /// </summary>
-        internal static string SampleBinaryDataBase64 { get; } = Convert.ToBase64String(SampleBinaryData); // AQID
+    /// <summary>
+    /// The base64 representation of <see cref="SampleBinaryData"/>.
+    /// </summary>
+    internal static string SampleBinaryDataBase64 { get; } = Convert.ToBase64String(SampleBinaryData); // AQID
 
-        /// <summary>
-        /// Arbitrary timestamp to be used for testing.
-        /// Calling code should not rely on the exact value.
-        /// </summary>
-        internal static DateTimeOffset SampleTimestamp { get; } = new DateTimeOffset(2021, 2, 19, 12, 34, 56, 789, TimeSpan.FromHours(1));
+    /// <summary>
+    /// Arbitrary timestamp to be used for testing.
+    /// Calling code should not rely on the exact value.
+    /// </summary>
+    internal static DateTimeOffset SampleTimestamp { get; } = new DateTimeOffset(2021, 2, 19, 12, 34, 56, 789, TimeSpan.FromHours(1));
 
-        /// <summary>
-        /// The RFC 3339 text representation of <see cref="SampleTimestamp"/>.
-        /// </summary>
-        internal static string SampleTimestampText { get; } = "2021-02-19T12:34:56.789+01:00";
+    /// <summary>
+    /// The RFC 3339 text representation of <see cref="SampleTimestamp"/>.
+    /// </summary>
+    internal static string SampleTimestampText { get; } = "2021-02-19T12:34:56.789+01:00";
 
-        /// <summary>
-        /// Arbitrary absolute URI to be used for testing.
-        /// Calling code should not rely on the exact value.
-        /// </summary>
-        internal static Uri SampleUri { get; } = new Uri("https://absoluteuri/path");
+    /// <summary>
+    /// Arbitrary absolute URI to be used for testing.
+    /// Calling code should not rely on the exact value.
+    /// </summary>
+    internal static Uri SampleUri { get; } = new Uri("https://absoluteuri/path");
 
-        /// <summary>
-        /// The textual representation of <see cref="SampleUri"/>.
-        /// </summary>
-        internal static string SampleUriText { get; } = "https://absoluteuri/path";
+    /// <summary>
+    /// The textual representation of <see cref="SampleUri"/>.
+    /// </summary>
+    internal static string SampleUriText { get; } = "https://absoluteuri/path";
 
-        /// <summary>
-        /// Arbitrary absolute URI to be used for testing.
-        /// Calling code should not rely on the exact value.
-        /// </summary>
-        internal static Uri SampleUriReference { get; } = new Uri("//urireference/path", UriKind.RelativeOrAbsolute);
+    /// <summary>
+    /// Arbitrary absolute URI to be used for testing.
+    /// Calling code should not rely on the exact value.
+    /// </summary>
+    internal static Uri SampleUriReference { get; } = new Uri("//urireference/path", UriKind.RelativeOrAbsolute);
 
-        /// <summary>
-        /// The textual representation of <see cref="SampleUriReference"/>.
-        /// </summary>
-        internal static string SampleUriReferenceText { get; } = "//urireference/path";
+    /// <summary>
+    /// The textual representation of <see cref="SampleUriReference"/>.
+    /// </summary>
+    internal static string SampleUriReferenceText { get; } = "//urireference/path";
 
-        /// <summary>
-        /// Populates a CloudEvent with minimal valid attribute values.
-        /// Calling code should not take a dependency on the exact values used.
-        /// </summary>
-        /// <returns>The original CloudEvent reference, for method chaining purposes.</returns>
-        internal static CloudEvent PopulateRequiredAttributes(this CloudEvent cloudEvent)
+    /// <summary>
+    /// Populates a CloudEvent with minimal valid attribute values.
+    /// Calling code should not take a dependency on the exact values used.
+    /// </summary>
+    /// <returns>The original CloudEvent reference, for method chaining purposes.</returns>
+    internal static CloudEvent PopulateRequiredAttributes(this CloudEvent cloudEvent)
+    {
+        cloudEvent.Id = "test-id";
+        cloudEvent.Source = new Uri("//test", UriKind.RelativeOrAbsolute);
+        cloudEvent.Type = "test-type";
+        return cloudEvent;
+    }
+
+    /// <summary>
+    /// Creates a batch of two CloudEvents, one of which has (plain text) content.
+    /// </summary>
+    internal static List<CloudEvent> CreateSampleBatch()
+    {
+        var event1 = new CloudEvent().PopulateRequiredAttributes();
+        event1.Id = "event1";
+        event1.Data = "simple text";
+        event1.DataContentType = "text/plain";
+
+        var event2 = new CloudEvent().PopulateRequiredAttributes();
+        event2.Id = "event2";
+
+        return new List<CloudEvent> { event1, event2 };
+    }
+
+    /// <summary>
+    /// Asserts that two timestamp values are equal, expressing the expected value as a
+    /// string for compact testing.
+    /// </summary>
+    /// <param name="expected">The expected value, as a string</param>
+    /// <param name="actual">The value to test against</param>
+    internal static void AssertTimestampsEqual(string expected, DateTimeOffset actual)
+    {
+        // TODO: Use common RFC-3339 parsing code when we have it.
+        DateTimeOffset expectedDto = DateTimeOffset.ParseExact(expected, "yyyy-MM-dd'T'HH:mm:ss.FFFFFFFK", CultureInfo.InvariantCulture);
+        AssertTimestampsEqual(expectedDto, actual);
+    }
+
+    /// <summary>
+    /// Asserts that two timestamp values are equal, in both "instant being represented"
+    /// and "UTC offset".
+    /// </summary>
+    /// <param name="expected">The expected value</param>
+    /// <param name="actual">The value to test against</param>
+    internal static void AssertTimestampsEqual(DateTimeOffset expected, DateTimeOffset actual)
+    {
+        Assert.Equal(expected.UtcDateTime, actual.UtcDateTime);
+        Assert.Equal(expected.Offset, actual.Offset);
+    }
+
+    /// <summary>
+    /// Asserts that two timestamp values are equal, in both "instant being represented"
+    /// and "UTC offset". This overload accepts nullable values, and requires that both
+    /// values are null or neither is.
+    /// </summary>
+    /// <param name="expected">The expected value</param>
+    /// <param name="actual">The value to test against</param>
+    internal static void AssertTimestampsEqual(DateTimeOffset? expected, DateTimeOffset? actual)
+    {
+        if (expected is null && actual is null)
         {
-            cloudEvent.Id = "test-id";
-            cloudEvent.Source = new Uri("//test", UriKind.RelativeOrAbsolute);
-            cloudEvent.Type = "test-type";
-            return cloudEvent;
+            return;
         }
-
-        /// <summary>
-        /// Creates a batch of two CloudEvents, one of which has (plain text) content.
-        /// </summary>
-        internal static List<CloudEvent> CreateSampleBatch()
+        if (expected is null || actual is null)
         {
-            var event1 = new CloudEvent().PopulateRequiredAttributes();
-            event1.Id = "event1";
-            event1.Data = "simple text";
-            event1.DataContentType = "text/plain";
-
-            var event2 = new CloudEvent().PopulateRequiredAttributes();
-            event2.Id = "event2";
-
-            return new List<CloudEvent> { event1, event2 };
+            Assert.Fail("Expected both values to be null, or neither to be null");
         }
+        AssertTimestampsEqual(expected!.Value, actual!.Value);
+    }
 
-        /// <summary>
-        /// Asserts that two timestamp values are equal, expressing the expected value as a
-        /// string for compact testing.
-        /// </summary>
-        /// <param name="expected">The expected value, as a string</param>
-        /// <param name="actual">The value to test against</param>
-        internal static void AssertTimestampsEqual(string expected, DateTimeOffset actual)
-        {
-            // TODO: Use common RFC-3339 parsing code when we have it.
-            DateTimeOffset expectedDto = DateTimeOffset.ParseExact(expected, "yyyy-MM-dd'T'HH:mm:ss.FFFFFFFK", CultureInfo.InvariantCulture);
-            AssertTimestampsEqual(expectedDto, actual);
-        }
+    // TODO: Use this more widely
+    // TODO: Document handling of timestamps, and potentially parameterize it.
+    internal static void AssertCloudEventsEqual(CloudEvent expected, CloudEvent actual,
+        IEqualityComparer<DateTimeOffset>? timestampComparer = null,
+        IEqualityComparer<object?>? dataComparer = null)
+    {
+        timestampComparer ??= StrictTimestampComparer;
+        Assert.Equal(expected.SpecVersion, actual.SpecVersion);
+        var expectedAttributes = expected.GetPopulatedAttributes().ToList();
+        var actualAttributes = actual.GetPopulatedAttributes().ToList();
 
-        /// <summary>
-        /// Asserts that two timestamp values are equal, in both "instant being represented"
-        /// and "UTC offset".
-        /// </summary>
-        /// <param name="expected">The expected value</param>
-        /// <param name="actual">The value to test against</param>
-        internal static void AssertTimestampsEqual(DateTimeOffset expected, DateTimeOffset actual)
+        Assert.Equal(expectedAttributes.Count, actualAttributes.Count);
+        foreach (var expectedAttribute in expectedAttributes)
         {
-            Assert.Equal(expected.UtcDateTime, actual.UtcDateTime);
-            Assert.Equal(expected.Offset, actual.Offset);
-        }
+            var actualAttribute = actualAttributes.FirstOrDefault(actual => actual.Key.Name == expectedAttribute.Key.Name);
+            Assert.NotNull(actualAttribute.Key);
 
-        /// <summary>
-        /// Asserts that two timestamp values are equal, in both "instant being represented"
-        /// and "UTC offset". This overload accepts nullable values, and requires that both
-        /// values are null or neither is.
-        /// </summary>
-        /// <param name="expected">The expected value</param>
-        /// <param name="actual">The value to test against</param>
-        internal static void AssertTimestampsEqual(DateTimeOffset? expected, DateTimeOffset? actual)
-        {
-            if (expected is null && actual is null)
+            Assert.Equal(expectedAttribute.Key.Type, actualAttribute.Key.Type);
+            if (expectedAttribute.Value is DateTimeOffset expectedDto &&
+                actualAttribute.Value is DateTimeOffset actualDto)
             {
-                return;
+                Assert.Equal(expectedDto, actualDto, timestampComparer);
             }
-            if (expected is null || actual is null)
+            else
             {
-                Assert.Fail("Expected both values to be null, or neither to be null");
-            }
-            AssertTimestampsEqual(expected!.Value, actual!.Value);
-        }
-
-        // TODO: Use this more widely
-        // TODO: Document handling of timestamps, and potentially parameterize it.
-        internal static void AssertCloudEventsEqual(CloudEvent expected, CloudEvent actual,
-            IEqualityComparer<DateTimeOffset>? timestampComparer = null,
-            IEqualityComparer<object?>? dataComparer = null)
-        {
-            timestampComparer ??= StrictTimestampComparer;
-            Assert.Equal(expected.SpecVersion, actual.SpecVersion);
-            var expectedAttributes = expected.GetPopulatedAttributes().ToList();
-            var actualAttributes = actual.GetPopulatedAttributes().ToList();
-
-            Assert.Equal(expectedAttributes.Count, actualAttributes.Count);
-            foreach (var expectedAttribute in expectedAttributes)
-            {
-                var actualAttribute = actualAttributes.FirstOrDefault(actual => actual.Key.Name == expectedAttribute.Key.Name);
-                Assert.NotNull(actualAttribute.Key);
-
-                Assert.Equal(expectedAttribute.Key.Type, actualAttribute.Key.Type);
-                if (expectedAttribute.Value is DateTimeOffset expectedDto &&
-                    actualAttribute.Value is DateTimeOffset actualDto)
-                {
-                    Assert.Equal(expectedDto, actualDto, timestampComparer);
-                }
-                else
-                {
-                    Assert.Equal(expectedAttribute.Value, actualAttribute.Value);
-                }
-            }
-            Assert.Equal(expected.Data, actual.Data, dataComparer ?? EqualityComparer<object?>.Default);
-        }
-
-        internal static void AssertBatchesEqual(IReadOnlyList<CloudEvent> expectedBatch, IReadOnlyList<CloudEvent> actualBatch,
-            IEqualityComparer<DateTimeOffset>? timestampComparer = null,
-            IEqualityComparer<object?>? dataComparer = null)
-        {
-            Assert.Equal(expectedBatch.Count, actualBatch.Count);
-            foreach (var pair in expectedBatch.Zip(actualBatch, (x, y) => (x, y)))
-            {
-                AssertCloudEventsEqual(pair.x, pair.y, timestampComparer, dataComparer);
+                Assert.Equal(expectedAttribute.Value, actualAttribute.Value);
             }
         }
+        Assert.Equal(expected.Data, actual.Data, dataComparer ?? EqualityComparer<object?>.Default);
+    }
 
-        /// <summary>
-        /// Loads the resource with the given name, copying it into a MemoryStream.
-        /// (That's often easier to work with when debugging.)
-        /// </summary>
-        internal static MemoryStream LoadResource(string resource)
+    internal static void AssertBatchesEqual(IReadOnlyList<CloudEvent> expectedBatch, IReadOnlyList<CloudEvent> actualBatch,
+        IEqualityComparer<DateTimeOffset>? timestampComparer = null,
+        IEqualityComparer<object?>? dataComparer = null)
+    {
+        Assert.Equal(expectedBatch.Count, actualBatch.Count);
+        foreach (var pair in expectedBatch.Zip(actualBatch, (x, y) => (x, y)))
         {
-            using var stream = typeof(TestHelpers).Assembly.GetManifestResourceStream(resource);
-            if (stream is null)
-            {
-                throw new ArgumentException($"Resource {resource} is missing. Known resources: {string.Join(", ", typeof(TestHelpers).Assembly.GetManifestResourceNames())}");
-            }
-            var output = new MemoryStream();
-            stream.CopyTo(output);
-            output.Position = 0;
-            return output;
+            AssertCloudEventsEqual(pair.x, pair.y, timestampComparer, dataComparer);
+        }
+    }
+
+    /// <summary>
+    /// Loads the resource with the given name, copying it into a MemoryStream.
+    /// (That's often easier to work with when debugging.)
+    /// </summary>
+    internal static MemoryStream LoadResource(string resource)
+    {
+        using var stream = typeof(TestHelpers).Assembly.GetManifestResourceStream(resource);
+        if (stream is null)
+        {
+            throw new ArgumentException($"Resource {resource} is missing. Known resources: {string.Join(", ", typeof(TestHelpers).Assembly.GetManifestResourceNames())}");
+        }
+        var output = new MemoryStream();
+        stream.CopyTo(output);
+        output.Position = 0;
+        return output;
+    }
+
+    private class StrictTimestampComparerImpl : IEqualityComparer<DateTimeOffset>
+    {
+        internal static StrictTimestampComparerImpl Instance { get; } = new StrictTimestampComparerImpl();
+
+        private StrictTimestampComparerImpl()
+        {
         }
 
-        private class StrictTimestampComparerImpl : IEqualityComparer<DateTimeOffset>
-        {
-            internal static StrictTimestampComparerImpl Instance { get; } = new StrictTimestampComparerImpl();
+        public bool Equals(DateTimeOffset x, DateTimeOffset y) =>
+            x.UtcDateTime == y.UtcDateTime &&
+            x.Offset == y.Offset;
 
-            private StrictTimestampComparerImpl()
-            {
-            }
-
-            public bool Equals(DateTimeOffset x, DateTimeOffset y) =>
-                x.UtcDateTime == y.UtcDateTime &&
-                x.Offset == y.Offset;
-
-            public int GetHashCode([DisallowNull] DateTimeOffset obj) =>
-                obj.UtcDateTime.GetHashCode() ^ obj.Offset.GetHashCode();
-        }
+        public int GetHashCode([DisallowNull] DateTimeOffset obj) =>
+            obj.UtcDateTime.GetHashCode() ^ obj.Offset.GetHashCode();
     }
 }

--- a/test/CloudNative.CloudEvents.UnitTests/TimestampsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/TimestampsTest.cs
@@ -6,178 +6,177 @@ using System;
 using Xunit;
 using static CloudNative.CloudEvents.UnitTests.TestHelpers;
 
-namespace CloudNative.CloudEvents.UnitTests
+namespace CloudNative.CloudEvents.UnitTests;
+
+public class TimestampsTest
 {
-    public class TimestampsTest
+    // TryParse and Parse are tested together, as they're effectively alternatives for the same thing.
+
+    /// <summary>
+    /// Just a selection of simple tests; this is not trying to be exhaustive.
+    /// (The other parse tests check specific aspects more thoroughly.)
+    /// </summary>
+    [Theory]
+    [InlineData("2021-01-18T14:52:01Z", 2021, 1, 18, 14, 52, 1, 0, 0)]
+    [InlineData("2000-02-29T01:23:45.678+01:30", 2000, 2, 29, 1, 23, 45, 6_780_000, 90)]
+    [InlineData("2000-02-29T01:23:45-01:30", 2000, 2, 29, 1, 23, 45, 0, -90)]
+    public void Parse_Success_Simple(string text, int year, int month, int day, int hour, int minute, int second, int ticks, int offsetMinutes)
     {
-        // TryParse and Parse are tested together, as they're effectively alternatives for the same thing.
+        var expected = new DateTimeOffset(year, month, day, hour, minute, second, 0, TimeSpan.FromMinutes(offsetMinutes))
+            .AddTicks(ticks);
+        AssertParseSuccess(expected, text);
+    }
 
-        /// <summary>
-        /// Just a selection of simple tests; this is not trying to be exhaustive.
-        /// (The other parse tests check specific aspects more thoroughly.)
-        /// </summary>
-        [Theory]
-        [InlineData("2021-01-18T14:52:01Z", 2021, 1, 18, 14, 52, 1, 0, 0)]
-        [InlineData("2000-02-29T01:23:45.678+01:30", 2000, 2, 29, 1, 23, 45, 6_780_000, 90)]
-        [InlineData("2000-02-29T01:23:45-01:30", 2000, 2, 29, 1, 23, 45, 0, -90)]
-        public void Parse_Success_Simple(string text, int year, int month, int day, int hour, int minute, int second, int ticks, int offsetMinutes)
-        {
-            var expected = new DateTimeOffset(year, month, day, hour, minute, second, 0, TimeSpan.FromMinutes(offsetMinutes))
-                .AddTicks(ticks);
-            AssertParseSuccess(expected, text);
-        }
+    [Theory]
+    [InlineData("", 0)]
+    [InlineData(".0", 0)]
+    [InlineData(".1", 1_000_000)]
+    [InlineData(".12", 1_200_000)]
+    [InlineData(".123", 1_230_000)]
+    [InlineData(".1234", 1_234_000)]
+    [InlineData(".12345", 1_234_500)]
+    [InlineData(".123456", 1_234_560)]
+    [InlineData(".1234567", 1_234_567)]
+    // We truncate nanoseconds to the tick
+    [InlineData(".12345678", 1_234_567)]
+    [InlineData(".123456789", 1_234_567)]
+    // (Realistically we're unlikely to get any values with greater precision than nanoseconds, but
+    // we might as well test it.)
+    [InlineData(".12345678912345", 1_234_567)]
+    public void Parse_Success_VaryingFractionalSeconds(string fractionalPart, int expectedTicks)
+    {
+        string text = $"2021-01-18T14:52:01{fractionalPart}+05:00";
+        DateTimeOffset expected = new DateTimeOffset(2021, 1, 18, 14, 52, 1, 0, TimeSpan.FromHours(5))
+            .AddTicks(expectedTicks);
+        AssertParseSuccess(expected, text);
+    }
 
-        [Theory]
-        [InlineData("", 0)]
-        [InlineData(".0", 0)]
-        [InlineData(".1", 1_000_000)]
-        [InlineData(".12", 1_200_000)]
-        [InlineData(".123", 1_230_000)]
-        [InlineData(".1234", 1_234_000)]
-        [InlineData(".12345", 1_234_500)]
-        [InlineData(".123456", 1_234_560)]
-        [InlineData(".1234567", 1_234_567)]
-        // We truncate nanoseconds to the tick
-        [InlineData(".12345678", 1_234_567)]
-        [InlineData(".123456789", 1_234_567)]
-        // (Realistically we're unlikely to get any values with greater precision than nanoseconds, but
-        // we might as well test it.)
-        [InlineData(".12345678912345", 1_234_567)]
-        public void Parse_Success_VaryingFractionalSeconds(string fractionalPart, int expectedTicks)
-        {
-            string text = $"2021-01-18T14:52:01{fractionalPart}+05:00";
-            DateTimeOffset expected = new DateTimeOffset(2021, 1, 18, 14, 52, 1, 0, TimeSpan.FromHours(5))
-                .AddTicks(expectedTicks);
-            AssertParseSuccess(expected, text);
-        }
+    [Theory]
+    [InlineData("Z", 0)]
+    // Alternative way of representing UTC (this is perfectly valid).
+    [InlineData("+00:00", 0)]
+    // This is the "unknown local offset". We treat this as UTC, as there is no reasonable
+    // way to express it as a DateTimeOffset, and that's better than failing. It's unlikely
+    // we'll ever see this, and arguably it's not really a "timestamp" at that point anyway.
+    [InlineData("-00:00", 0)]
+    [InlineData("+01:00", 60)]
+    [InlineData("-01:00", -60)]
+    [InlineData("+01:30", 90)]
+    [InlineData("-01:30", -90)]
+    // Extreme values
+    [InlineData("+14:00", 14 * 60)]
+    [InlineData("-14:00", -14 * 60)]
+    public void Parse_Success_VaryingUtcOffset(string offsetPart, int expectedOffsetMinutes)
+    {
+        // No fractional seconds
+        string text = $"2021-01-18T14:52:01{offsetPart}";
+        DateTimeOffset expected = new DateTimeOffset(2021, 1, 18, 14, 52, 1, 0, TimeSpan.FromMinutes(expectedOffsetMinutes));
+        AssertParseSuccess(expected, text);
 
-        [Theory]
-        [InlineData("Z", 0)]
-        // Alternative way of representing UTC (this is perfectly valid).
-        [InlineData("+00:00", 0)]
-        // This is the "unknown local offset". We treat this as UTC, as there is no reasonable
-        // way to express it as a DateTimeOffset, and that's better than failing. It's unlikely
-        // we'll ever see this, and arguably it's not really a "timestamp" at that point anyway.
-        [InlineData("-00:00", 0)]
-        [InlineData("+01:00", 60)]
-        [InlineData("-01:00", -60)]
-        [InlineData("+01:30", 90)]
-        [InlineData("-01:30", -90)]
-        // Extreme values
-        [InlineData("+14:00", 14 * 60)]
-        [InlineData("-14:00", -14 * 60)]
-        public void Parse_Success_VaryingUtcOffset(string offsetPart, int expectedOffsetMinutes)
-        {
-            // No fractional seconds
-            string text = $"2021-01-18T14:52:01{offsetPart}";
-            DateTimeOffset expected = new DateTimeOffset(2021, 1, 18, 14, 52, 1, 0, TimeSpan.FromMinutes(expectedOffsetMinutes));
-            AssertParseSuccess(expected, text);
+        // Single check for fractional seconds
+        text = $"2021-01-18T14:52:01.500{offsetPart}";
+        expected = expected.AddMilliseconds(500);
+        AssertParseSuccess(expected, text);
+    }
 
-            // Single check for fractional seconds
-            text = $"2021-01-18T14:52:01.500{offsetPart}";
-            expected = expected.AddMilliseconds(500);
-            AssertParseSuccess(expected, text);
-        }
+    private static void AssertParseSuccess(DateTimeOffset expected, string text)
+    {
+        var parsed = Timestamps.Parse(text);
+        AssertTimestampsEqual(expected, parsed);
 
-        private static void AssertParseSuccess(DateTimeOffset expected, string text)
-        {
-            var parsed = Timestamps.Parse(text);
-            AssertTimestampsEqual(expected, parsed);
+        Assert.True(Timestamps.TryParse(text, out parsed));
+        AssertTimestampsEqual(expected, parsed);
+    }
 
-            Assert.True(Timestamps.TryParse(text, out parsed));
-            AssertTimestampsEqual(expected, parsed);
-        }
+    [Theory]
+    [InlineData("")]
+    [InlineData("garbage")]
+    [InlineData("garbage that is long enough")]
+    [InlineData("2021-01-18T14:52:01")] // No UTC offset indicator
+    [InlineData("2021-01-18T14:52:01.1234567XYZ")] // Garbage after 7 significant digits of sub-second
+    [InlineData("2021-01-18T14:52:01Z01")] // Text after UTC offset indicator
+    [InlineData("2021-01-18T14:52:01X")] // Garbage UTC offset indicator
+    [InlineData("2021-01-18T14:52:01+XX:XX")] // Garbage UTC offset indicator (but right length)
+    [InlineData("2021-01-18T14:52:01+01")] // Hour-only UTC offset indicator
+    [InlineData("2021-01-18T14:52:01+01:30:30")] // Sub-minute UTC offset indicator
+    [InlineData("2021-01-18T14:52:01+14:01")] // UTC offset indicator out of range
+    [InlineData("2021-01-18T14:52:01-14:01")] // UTC offset indicator out of range
+    [InlineData("2021-01-18T14:52:01-00:60")] // UTC offset indicator with invalid minutes
+    [InlineData("2021-01-18 14:52:01Z")] // Space instead of 'T'
+    [InlineData("2100-02-29T14:52:01Z")] // Feb 29th in non-leap-year
+    [InlineData("10000-01-01T00:00:00Z")] // Year out of range
+    [InlineData("2021-13-01T00:00:00Z")] // Month out of range
+    [InlineData("2021-01-50T00:00:00Z")] // Day out of range
+    [InlineData("2021-01-18T24:00:00Z")] // Hour out of range
+    [InlineData("2021-01-18T14:60:00Z")] // Minute out of range
+    [InlineData("2021-01-18T14:00:60Z")] // Second out of range
+    [InlineData("100-01-01T00:00:00Z")] // Non-padded year
+    [InlineData("2021-1-01T00:00:00Z")] // Non-padded month
+    [InlineData("2021-01-1T00:00:00Z")] // Non-padded day
+    [InlineData("2021-01-01T1:00:00Z")] // Non-padded hour
+    [InlineData("2021-01-01T00:1:00Z")] // Non-padded minute
+    [InlineData("2021-01-01T00:01:1Z")] // Non-padded second
+    [InlineData("2021-01-01T00:01Z")] // No second part
+    public void Parse_Failure(string text)
+    {
+        Assert.False(Timestamps.TryParse(text, out _));
+        Assert.Throws<FormatException>(() => Timestamps.Parse(text));
+    }
 
-        [Theory]
-        [InlineData("")]
-        [InlineData("garbage")]
-        [InlineData("garbage that is long enough")]
-        [InlineData("2021-01-18T14:52:01")] // No UTC offset indicator
-        [InlineData("2021-01-18T14:52:01.1234567XYZ")] // Garbage after 7 significant digits of sub-second
-        [InlineData("2021-01-18T14:52:01Z01")] // Text after UTC offset indicator
-        [InlineData("2021-01-18T14:52:01X")] // Garbage UTC offset indicator
-        [InlineData("2021-01-18T14:52:01+XX:XX")] // Garbage UTC offset indicator (but right length)
-        [InlineData("2021-01-18T14:52:01+01")] // Hour-only UTC offset indicator
-        [InlineData("2021-01-18T14:52:01+01:30:30")] // Sub-minute UTC offset indicator
-        [InlineData("2021-01-18T14:52:01+14:01")] // UTC offset indicator out of range
-        [InlineData("2021-01-18T14:52:01-14:01")] // UTC offset indicator out of range
-        [InlineData("2021-01-18T14:52:01-00:60")] // UTC offset indicator with invalid minutes
-        [InlineData("2021-01-18 14:52:01Z")] // Space instead of 'T'
-        [InlineData("2100-02-29T14:52:01Z")] // Feb 29th in non-leap-year
-        [InlineData("10000-01-01T00:00:00Z")] // Year out of range
-        [InlineData("2021-13-01T00:00:00Z")] // Month out of range
-        [InlineData("2021-01-50T00:00:00Z")] // Day out of range
-        [InlineData("2021-01-18T24:00:00Z")] // Hour out of range
-        [InlineData("2021-01-18T14:60:00Z")] // Minute out of range
-        [InlineData("2021-01-18T14:00:60Z")] // Second out of range
-        [InlineData("100-01-01T00:00:00Z")] // Non-padded year
-        [InlineData("2021-1-01T00:00:00Z")] // Non-padded month
-        [InlineData("2021-01-1T00:00:00Z")] // Non-padded day
-        [InlineData("2021-01-01T1:00:00Z")] // Non-padded hour
-        [InlineData("2021-01-01T00:1:00Z")] // Non-padded minute
-        [InlineData("2021-01-01T00:01:1Z")] // Non-padded second
-        [InlineData("2021-01-01T00:01Z")] // No second part
-        public void Parse_Failure(string text)
-        {
-            Assert.False(Timestamps.TryParse(text, out _));
-            Assert.Throws<FormatException>(() => Timestamps.Parse(text));
-        }
+    [Fact]
+    public void Parse_Null()
+    {
+        Assert.Throws<ArgumentNullException>(() => Timestamps.TryParse(null!, out _));
+        Assert.Throws<ArgumentNullException>(() => Timestamps.Parse(null!));
+    }
 
-        [Fact]
-        public void Parse_Null()
-        {
-            Assert.Throws<ArgumentNullException>(() => Timestamps.TryParse(null!, out _));
-            Assert.Throws<ArgumentNullException>(() => Timestamps.Parse(null!));
-        }
+    /// <summary>
+    /// As we're already testing parsing thoroughly, the simplest way of providing
+    /// a value to format is to parse a string. Many examples will round-trip, in which
+    /// case it's simple just to provide the information once.
+    /// <see cref="Format_NonRoundtrip(string, string)"/> tests situations which don't round-trip.
+    /// </summary>
+    /// <param name="input"></param>
+    [Theory]
+    [InlineData("2021-01-18T14:52:01Z")]
+    [InlineData("2000-02-29T01:23:45.678+01:30")]
+    [InlineData("2000-02-29T01:23:45-01:30")]
+    [InlineData("2000-02-29T01:23:45.678+10:00")]
+    [InlineData("2000-02-29T01:23:45-10:00")]
+    [InlineData("2021-01-18T14:52:01.100Z")]
+    [InlineData("2021-01-18T14:52:01.120Z")]
+    [InlineData("2021-01-18T14:52:01.123Z")]
+    [InlineData("2021-01-18T14:52:01.123400Z")]
+    [InlineData("2021-01-18T14:52:01.123450Z")]
+    [InlineData("2021-01-18T14:52:01.123456Z")]
+    [InlineData("2021-01-18T14:52:01.1234567Z")]
+    public void Format_Roundtrip(string input)
+    {
+        var parsed = Timestamps.Parse(input);
+        var formatted = Timestamps.Format(parsed);
+        Assert.Equal(input, formatted);
+    }
 
-        /// <summary>
-        /// As we're already testing parsing thoroughly, the simplest way of providing
-        /// a value to format is to parse a string. Many examples will round-trip, in which
-        /// case it's simple just to provide the information once.
-        /// <see cref="Format_NonRoundtrip(string, string)"/> tests situations which don't round-trip.
-        /// </summary>
-        /// <param name="input"></param>
-        [Theory]
-        [InlineData("2021-01-18T14:52:01Z")]
-        [InlineData("2000-02-29T01:23:45.678+01:30")]
-        [InlineData("2000-02-29T01:23:45-01:30")]
-        [InlineData("2000-02-29T01:23:45.678+10:00")]
-        [InlineData("2000-02-29T01:23:45-10:00")]
-        [InlineData("2021-01-18T14:52:01.100Z")]
-        [InlineData("2021-01-18T14:52:01.120Z")]
-        [InlineData("2021-01-18T14:52:01.123Z")]
-        [InlineData("2021-01-18T14:52:01.123400Z")]
-        [InlineData("2021-01-18T14:52:01.123450Z")]
-        [InlineData("2021-01-18T14:52:01.123456Z")]
-        [InlineData("2021-01-18T14:52:01.1234567Z")]
-        public void Format_Roundtrip(string input)
-        {
-            var parsed = Timestamps.Parse(input);
-            var formatted = Timestamps.Format(parsed);
-            Assert.Equal(input, formatted);
-        }
-
-        [Theory]
-        // Zero offset normalized to Z
-        [InlineData("2021-01-18T14:52:01+00:00", "2021-01-18T14:52:01Z")]
-        [InlineData("2021-01-18T14:52:01-00:00", "2021-01-18T14:52:01Z")]
-        // Second precision
-        [InlineData("2000-02-29T01:23:45.000-01:30", "2000-02-29T01:23:45-01:30")]
-        // Millisecond precision
-        [InlineData("2000-02-29T01:23:45.67+01:30", "2000-02-29T01:23:45.670+01:30")]
-        [InlineData("2000-02-29T01:23:45.678000+01:30", "2000-02-29T01:23:45.678+01:30")]
-        [InlineData("2000-02-29T01:23:45.6780000000+01:30", "2000-02-29T01:23:45.678+01:30")]
-        // Microssecond precision
-        [InlineData("2000-02-29T01:23:45.6781+01:30", "2000-02-29T01:23:45.678100+01:30")]
-        [InlineData("2000-02-29T01:23:45.6781000+01:30", "2000-02-29T01:23:45.678100+01:30")]
-        [InlineData("2000-02-29T01:23:45.6781000000+01:30", "2000-02-29T01:23:45.678100+01:30")]
-        // Tick precision
-        [InlineData("2021-01-18T14:52:01.123456789Z", "2021-01-18T14:52:01.1234567Z")]
-        public void Format_NonRoundtrip(string input, string expectedFormatted)
-        {
-            var parsed = Timestamps.Parse(input);
-            var formatted = Timestamps.Format(parsed);
-            Assert.Equal(expectedFormatted, formatted);
-        }
+    [Theory]
+    // Zero offset normalized to Z
+    [InlineData("2021-01-18T14:52:01+00:00", "2021-01-18T14:52:01Z")]
+    [InlineData("2021-01-18T14:52:01-00:00", "2021-01-18T14:52:01Z")]
+    // Second precision
+    [InlineData("2000-02-29T01:23:45.000-01:30", "2000-02-29T01:23:45-01:30")]
+    // Millisecond precision
+    [InlineData("2000-02-29T01:23:45.67+01:30", "2000-02-29T01:23:45.670+01:30")]
+    [InlineData("2000-02-29T01:23:45.678000+01:30", "2000-02-29T01:23:45.678+01:30")]
+    [InlineData("2000-02-29T01:23:45.6780000000+01:30", "2000-02-29T01:23:45.678+01:30")]
+    // Microssecond precision
+    [InlineData("2000-02-29T01:23:45.6781+01:30", "2000-02-29T01:23:45.678100+01:30")]
+    [InlineData("2000-02-29T01:23:45.6781000+01:30", "2000-02-29T01:23:45.678100+01:30")]
+    [InlineData("2000-02-29T01:23:45.6781000000+01:30", "2000-02-29T01:23:45.678100+01:30")]
+    // Tick precision
+    [InlineData("2021-01-18T14:52:01.123456789Z", "2021-01-18T14:52:01.1234567Z")]
+    public void Format_NonRoundtrip(string input, string expectedFormatted)
+    {
+        var parsed = Timestamps.Parse(input);
+        var formatted = Timestamps.Format(parsed);
+        Assert.Equal(expectedFormatted, formatted);
     }
 }


### PR DESCRIPTION
This PR uses file-based namespaces for all non-generated *.cs files. 

For some projects in this repo, it wasn't supported yet since `LangVersion` 8 was used. To keep that change minimal, I went with version 10, which [is supported for .NET 6 and up](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-versioning#:~:text=6.x-,C%23%2010,-.NET) and up. We can probably set them to 12 throughout the repo in a successive PR (which is supported for .NET 8 and up).

For the `EncodeStructuredModeData` methods in the `JsonEventFormatter` for both Newtonsoft and system.text.json I added the null-forgiving operator, a side effect of setting the langversion to 10. Maybe that needs proper null checking in the future? 

To compare the changes, you might want to use something like `git diff -w upstream/main...pr-single-commit-origin`, the GitHub `Files changed` view is rather hard to watch with this PR. 