### PR TITLE
Introduce `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# Ignore large mechanical/style-only commits in git blame. Sorted by oldest to newest.
+ae75b32c283cd531a7af38dd9c6fa66d2540109f
+db3feba27836691d1c85315c8fcb326d79ecc3a8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,11 @@ local development environment. Then add this repository as the upstream.
 git clone https://github.com/mygithuborg/sdk-csharp.git
 cd sdk-csharp
 git remote add upstream https://github.com/cloudevents/sdk-csharp.git
+git config blame.ignoreRevsFile .git-blame-ignore-revs
 ```
+
+The final command is optional, but recommended. It makes `git blame` ignore
+mechanical formatting/refactoring commits listed in [.git-blame-ignore-revs](.git-blame-ignore-revs).
 
 ## Branches
 


### PR DESCRIPTION
This introduces a `.git-blame-ignore-revs` file, and adds 2 commits to the file:
- https://github.com/cloudevents/sdk-csharp/commit/ae75b32c283cd531a7af38dd9c6fa66d2540109f
- https://github.com/cloudevents/sdk-csharp/commit/db3feba27836691d1c85315c8fcb326d79ecc3a8

Also adds a small revs guideline in the contributing file.