### PR TITLE
`ArrayBufferWriter` instead of `MemoryStream` for `Utf8JsonWriter`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
     <PackageVersion Include="AMQPNetLite.Serialization" Version="2.5.1" />
     <PackageVersion Include="Apache.Avro" Version="1.12.1" />
     <PackageVersion Include="Confluent.Kafka" Version="2.14.0" />
+    <PackageVersion Include="System.Buffers" Version="4.6.1" />
     <PackageVersion Include="Google.Protobuf" Version="3.34.1" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="5.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.3.9" />

--- a/src/CloudNative.CloudEvents.SystemTextJson/CloudNative.CloudEvents.SystemTextJson.csproj
+++ b/src/CloudNative.CloudEvents.SystemTextJson/CloudNative.CloudEvents.SystemTextJson.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
     <Description>JSON support for the CNCF CloudEvents SDK, based on System.Text.Json.</Description>
     <PackageTags>cncf;cloudnative;cloudevents;events;json;systemtextjson</PackageTags>
     <Nullable>enable</Nullable>

--- a/src/CloudNative.CloudEvents.SystemTextJson/JsonEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.SystemTextJson/JsonEventFormatter.cs
@@ -4,6 +4,7 @@
 
 using CloudNative.CloudEvents.Core;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Mime;
@@ -410,8 +411,8 @@ public class JsonEventFormatter : CloudEventFormatter
             CharSet = Encoding.UTF8.WebName
         };
 
-        var stream = new MemoryStream();
-        var writer = CreateUtf8JsonWriter(stream);
+        var bufferWriter = new ArrayBufferWriter<byte>();
+        var writer = CreateUtf8JsonWriter(bufferWriter);
         writer.WriteStartArray();
         foreach (var cloudEvent in cloudEvents)
         {
@@ -419,23 +420,23 @@ public class JsonEventFormatter : CloudEventFormatter
         }
         writer.WriteEndArray();
         writer.Flush();
-        return stream.ToArray();
+        return bufferWriter.WrittenMemory;
     }
 
     /// <inheritdoc />
     public override ReadOnlyMemory<byte> EncodeStructuredModeMessage(CloudEvent cloudEvent, out ContentType contentType)
     {
-        contentType = new ContentType(StructuredMediaType)
-        {
-            CharSet = Encoding.UTF8.WebName
-        };
+        contentType = new ContentType(StructuredMediaType) { CharSet = Encoding.UTF8.WebName };
 
-        var stream = new MemoryStream();
-        var writer = CreateUtf8JsonWriter(stream);
+        var bufferWriter = new ArrayBufferWriter<byte>();
+        using var writer = CreateUtf8JsonWriter(bufferWriter);
+
         WriteCloudEventForBatchOrStructuredMode(writer, cloudEvent);
         writer.Flush();
-        return stream.ToArray();
+
+        return bufferWriter.WrittenMemory;
     }
+
 
     /// <summary>
     /// Converts the given <see cref="CloudEvent"/> to a <see cref="JsonElement"/> containing the structured mode JSON format representation
@@ -468,6 +469,19 @@ public class JsonEventFormatter : CloudEventFormatter
             SkipValidation = false
         };
         return new Utf8JsonWriter(stream, options);
+    }
+
+    private Utf8JsonWriter CreateUtf8JsonWriter(IBufferWriter<byte> bufferWriter)
+    {
+        var options = new JsonWriterOptions
+        {
+            Encoder = SerializerOptions?.Encoder,
+            Indented = SerializerOptions?.WriteIndented ?? false,
+            // TODO: Consider skipping validation in the future for the sake of performance.
+            SkipValidation = false
+        };
+
+        return new Utf8JsonWriter(bufferWriter, options);
     }
 
     private void WriteCloudEventForBatchOrStructuredMode(Utf8JsonWriter writer, CloudEvent cloudEvent)

--- a/src/CloudNative.CloudEvents/CloudNative.CloudEvents.csproj
+++ b/src/CloudNative.CloudEvents/CloudNative.CloudEvents.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Buffers" />
     <PackageReference Include="System.Memory" Condition="'$(TargetFramework)'=='netstandard2.0'" />
     <!-- Source-only package with nullable reference annotations. -->
     <PackageReference Include="Nullable" PrivateAssets="All" />


### PR DESCRIPTION
Instead of doing `ToArray` we can do `WrittenMemory` to return the (readonly) memory, this should reduce allocation, memory and improve speed.

This won't work on netstandard2.0, the writer isn't included via `System.Buffers`... so if you like this setup then 3 methods will get different signatures for the old frameworks, which isn't elegant. This draft just displays the basic intention.