### PR TITLE
Tighten up analyzer categories and flatten some logic

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -29,6 +29,12 @@ indent_size = 2
 # Organize usings
 dotnet_sort_system_directives_first = false
 
+# Analyzer categories
+dotnet_analyzer_diagnostic.category-Maintainability.severity = warning
+dotnet_analyzer_diagnostic.category-Security.severity = warning
+dotnet_analyzer_diagnostic.category-Interoperability.severity = warning
+dotnet_analyzer_diagnostic.category-Performance.severity = warning
+
 # this. preferences
 dotnet_style_qualification_for_field = false:suggestion
 dotnet_style_qualification_for_property = false:suggestion
@@ -194,7 +200,7 @@ csharp_space_between_square_brackets = false
 csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
 
-csharp_style_namespace_declarations = file_scoped:suggestion
+csharp_style_namespace_declarations = file_scoped:warning
 csharp_style_prefer_null_check_over_type_check = true:suggestion
 csharp_style_prefer_local_over_anonymous_function = true:suggestion
 csharp_style_prefer_tuple_swap = true:suggestion

--- a/samples/HttpSend/Program.cs
+++ b/samples/HttpSend/Program.cs
@@ -16,7 +16,7 @@ namespace HttpSend;
 
 // This application uses the McMaster.Extensions.CommandLineUtils library for parsing the command
 // line and calling the application code. The [Option] attributes designate the parameters.
-internal class Program
+internal sealed class Program
 {
     [Option(Description = "CloudEvents 'source' (default: urn:example-com:mysource:abc)", LongName = "source", ShortName = "s")]
     private string Source { get; } = "urn:example-com:mysource:abc";

--- a/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtensions.cs
+++ b/src/CloudNative.CloudEvents.AspNetCore/HttpRequestExtensions.cs
@@ -85,11 +85,6 @@ public static class HttpRequestExtensions
             var version = CloudEventsSpecVersion.FromVersionId(versionId.FirstOrDefault())
                 ?? throw new ArgumentException($"Unknown CloudEvents spec version '{versionId}'", nameof(httpRequest));
 
-            if (version is null)
-            {
-                throw new ArgumentException($"Unsupported CloudEvents spec version '{versionId.First()}'");
-            }
-
             var cloudEvent = new CloudEvent(version, extensionAttributes);
             foreach (var header in headers)
             {

--- a/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
@@ -95,15 +95,12 @@ public class AvroEventFormatter : CloudEventFormatter
         IDictionary<string, object> recordAttributes = (IDictionary<string, object>) attrObj;
 
         if (!recordAttributes.TryGetValue(CloudEventsSpecVersion.SpecVersionAttribute.Name, out var versionId) ||
-            !(versionId is string versionIdString))
+            versionId is not string versionIdString)
         {
             throw new ArgumentException("Specification version attribute is missing");
         }
-        CloudEventsSpecVersion? version = CloudEventsSpecVersion.FromVersionId(versionIdString);
-        if (version is null)
-        {
-            throw new ArgumentException($"Unsupported CloudEvents spec version '{versionIdString}'");
-        }
+        var version = CloudEventsSpecVersion.FromVersionId(versionIdString) 
+            ?? throw new ArgumentException($"Unsupported CloudEvents spec version '{versionIdString}'");
 
         var cloudEvent = new CloudEvent(version, extensionAttributes);
         cloudEvent.Data = record.TryGetValue(DataName, out var data) ? data : null;
@@ -125,13 +122,13 @@ public class AvroEventFormatter : CloudEventFormatter
             // The Avro schema allows the value to be a Boolean, integer, string or bytes.
             // Timestamps and URIs are represented as strings, so we just use SetAttributeFromString to handle those.
             // TODO: This does mean that any extensions of these types must have been registered beforehand.
-            if (value is bool || value is int || value is byte[])
+            if (value is bool or int or byte[])
             {
                 cloudEvent[key] = value;
             }
-            else if (value is string)
+            else if (value is string v)
             {
-                cloudEvent.SetAttributeFromString(key, (string) value);
+                cloudEvent.SetAttributeFromString(key, v);
             }
             else
             {
@@ -160,7 +157,7 @@ public class AvroEventFormatter : CloudEventFormatter
             var attribute = keyValuePair.Key;
             var value = keyValuePair.Value;
             // TODO: Create a mapping method in each direction, to have this logic more clearly separated.
-            var avroValue = value is bool || value is int || value is byte[] || value is string
+            var avroValue = value is bool or int or byte[] or string
                 ? value
                 : attribute.Format(value);
             recordAttributes[attribute.Name] = avroValue;

--- a/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.Avro/AvroEventFormatter.cs
@@ -86,7 +86,7 @@ public class AvroEventFormatter : CloudEventFormatter
     public override ReadOnlyMemory<byte> EncodeBatchModeMessage(IEnumerable<CloudEvent> cloudEvent, out ContentType contentType) =>
         throw new NotSupportedException("The Avro event formatter does not support batch content mode");
 
-    private CloudEvent DecodeGenericRecord(GenericRecord record, IEnumerable<CloudEventAttribute>? extensionAttributes)
+    private static CloudEvent DecodeGenericRecord(GenericRecord record, IEnumerable<CloudEventAttribute>? extensionAttributes)
     {
         if (!record.TryGetValue(AttributeName, out var attrObj))
         {

--- a/src/CloudNative.CloudEvents.Kafka/KafkaExtensions.cs
+++ b/src/CloudNative.CloudEvents.Kafka/KafkaExtensions.cs
@@ -77,7 +77,7 @@ public static class KafkaExtensions
         else
         {
             // Binary mode
-            if (!(GetHeaderValue(message, SpecVersionKafkaHeader) is string versionId))
+            if (GetHeaderValue(message, SpecVersionKafkaHeader) is not string versionId)
             {
                 throw new ArgumentException("Request is not a CloudEvent");
             }

--- a/src/CloudNative.CloudEvents.NewtonsoftJson/GlobalSuppressions.cs
+++ b/src/CloudNative.CloudEvents.NewtonsoftJson/GlobalSuppressions.cs
@@ -1,0 +1,6 @@
+// This file is used by Code Analysis to maintain SuppressMessage attributes that are applied to this project.
+// Project-level suppressions either have no target or are given a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Performance", "CA1859: Use concrete types when possible for improved performance", Justification = "IReadOnlyList is part of the contract")]

--- a/src/CloudNative.CloudEvents.NewtonsoftJson/JsonEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.NewtonsoftJson/JsonEventFormatter.cs
@@ -219,7 +219,7 @@ public class JsonEventFormatter : CloudEventFormatter
         return Validation.CheckCloudEventArgument(cloudEvent, paramName);
     }
 
-    private void PopulateAttributesFromStructuredEvent(CloudEvent cloudEvent, JObject jObject)
+    private static void PopulateAttributesFromStructuredEvent(CloudEvent cloudEvent, JObject jObject)
     {
         foreach (var keyValuePair in jObject)
         {
@@ -264,7 +264,7 @@ public class JsonEventFormatter : CloudEventFormatter
         }
     }
 
-    private void ValidateTokenTypeForAttribute(CloudEventAttribute? attribute, JTokenType tokenType)
+    private static void ValidateTokenTypeForAttribute(CloudEventAttribute? attribute, JTokenType tokenType)
     {
         // We can't validate unknown attributes, don't check for extension attributes,
         // and null values will be ignored anyway.

--- a/src/CloudNative.CloudEvents.NewtonsoftJson/JsonEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.NewtonsoftJson/JsonEventFormatter.cs
@@ -521,33 +521,28 @@ public class JsonEventFormatter : CloudEventFormatter
         {
             writer.WritePropertyName(DataBase64PropertyName);
             writer.WriteValue(Convert.ToBase64String(binary));
+            return;
         }
-        else
+
+        // Throwing exception only happens in a derived class which overrides GetOrInferDataContentType further...
+        // This class infers application/json for anything other than byte arrays.
+        string? dataContentTypeText = GetOrInferDataContentType(cloudEvent) ?? throw new ArgumentException("Data content type cannot be inferred");
+
+        var dataContentType = new ContentType(dataContentTypeText);
+        if (IsJsonMediaType(dataContentType.MediaType))
         {
-            string? dataContentTypeText = GetOrInferDataContentType(cloudEvent);
-            // This would only happen in a derived class which overrides GetOrInferDataContentType further...
-            // This class infers application/json for anything other than byte arrays.
-            if (dataContentTypeText is null)
-            {
-                throw new ArgumentException("Data content type cannot be inferred");
-            }
-            ContentType dataContentType = new ContentType(dataContentTypeText);
-            if (IsJsonMediaType(dataContentType.MediaType))
-            {
-                writer.WritePropertyName(DataPropertyName);
-                Serializer.Serialize(writer, cloudEvent.Data);
-            }
-            else if (cloudEvent.Data is string text && dataContentType.MediaType.StartsWith("text/"))
-            {
-                writer.WritePropertyName(DataPropertyName);
-                writer.WriteValue(text);
-            }
-            else
-            {
-                // We assume CloudEvent.Data is not null due to the way this is called.
-                throw new ArgumentException($"{nameof(JsonEventFormatter)} cannot serialize data of type {cloudEvent.Data!.GetType()} with content type '{cloudEvent.DataContentType}'");
-            }
+            writer.WritePropertyName(DataPropertyName);
+            Serializer.Serialize(writer, cloudEvent.Data);
+            return;
         }
+        if (cloudEvent.Data is string text && dataContentType.MediaType.StartsWith("text/"))
+        {
+            writer.WritePropertyName(DataPropertyName);
+            writer.WriteValue(text);
+            return;
+        }
+        // We assume CloudEvent.Data is not null due to the way this is called.
+        throw new ArgumentException($"{nameof(JsonEventFormatter)} cannot serialize data of type {cloudEvent.Data!.GetType()} with content type '{cloudEvent.DataContentType}'");
     }
 
     /// <inheritdoc />

--- a/src/CloudNative.CloudEvents.SystemTextJson/JsonEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.SystemTextJson/JsonEventFormatter.cs
@@ -540,26 +540,24 @@ public class JsonEventFormatter : CloudEventFormatter
         {
             writer.WritePropertyName(DataBase64PropertyName);
             writer.WriteStringValue(Convert.ToBase64String(binary));
+            return;
         }
-        else
+
+        var dataContentType = new ContentType(cloudEvent.DataContentType ?? JsonMediaType);
+        if (IsJsonMediaType(dataContentType.MediaType))
         {
-            ContentType dataContentType = new ContentType(cloudEvent.DataContentType ?? JsonMediaType);
-            if (IsJsonMediaType(dataContentType.MediaType))
-            {
-                writer.WritePropertyName(DataPropertyName);
-                JsonSerializer.Serialize(writer, cloudEvent.Data, SerializerOptions);
-            }
-            else if (cloudEvent.Data is string text && dataContentType.MediaType.StartsWith("text/"))
-            {
-                writer.WritePropertyName(DataPropertyName);
-                writer.WriteStringValue(text);
-            }
-            else
-            {
-                // We assume CloudEvent.Data is not null due to the way this is called.
-                throw new ArgumentException($"{nameof(JsonEventFormatter)} cannot serialize data of type {cloudEvent.Data!.GetType()} with content type '{cloudEvent.DataContentType}'");
-            }
+            writer.WritePropertyName(DataPropertyName);
+            JsonSerializer.Serialize(writer, cloudEvent.Data, SerializerOptions);
+            return;
         }
+        if (cloudEvent.Data is string text && dataContentType.MediaType.StartsWith("text/"))
+        {
+            writer.WritePropertyName(DataPropertyName);
+            writer.WriteStringValue(text);
+            return;
+        }
+        // We assume CloudEvent.Data is not null due to the way this is called.
+        throw new ArgumentException($"{nameof(JsonEventFormatter)} cannot serialize data of type {cloudEvent.Data!.GetType()} with content type '{cloudEvent.DataContentType}'");
     }
 
     /// <inheritdoc />

--- a/src/CloudNative.CloudEvents.SystemTextJson/JsonEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.SystemTextJson/JsonEventFormatter.cs
@@ -227,7 +227,7 @@ public class JsonEventFormatter : CloudEventFormatter
         return Validation.CheckCloudEventArgument(cloudEvent, paramName);
     }
 
-    private void PopulateAttributesFromStructuredEvent(CloudEvent cloudEvent, JsonElement element)
+    private static void PopulateAttributesFromStructuredEvent(CloudEvent cloudEvent, JsonElement element)
     {
         foreach (var jsonProperty in element.EnumerateObject())
         {
@@ -274,7 +274,7 @@ public class JsonEventFormatter : CloudEventFormatter
         }
     }
 
-    private void ValidateTokenTypeForAttribute(CloudEventAttribute? attribute, JsonValueKind valueKind)
+    private static void ValidateTokenTypeForAttribute(CloudEventAttribute? attribute, JsonValueKind valueKind)
     {
         // We can't validate unknown attributes, don't check for extension attributes,
         // and null values will be ignored anyway.

--- a/src/CloudNative.CloudEvents/CloudEvent.cs
+++ b/src/CloudNative.CloudEvents/CloudEvent.cs
@@ -195,7 +195,7 @@ public sealed class CloudEvent
             // (It's a simple way of populating extensions after the fact...)
             if (knownAttribute is null)
             {
-                Validation.CheckArgument(value is null || value is string,
+                Validation.CheckArgument(value is null or string,
                     nameof(value), "Cannot assign value of type {0} to unknown attribute '{1}'",
                     value?.GetType(), attributeName);
                 knownAttribute = CloudEventAttribute.CreateExtension(attributeName, CloudEventAttributeType.String);

--- a/src/CloudNative.CloudEvents/CloudEventAttribute.cs
+++ b/src/CloudNative.CloudEvents/CloudEventAttribute.cs
@@ -16,8 +16,8 @@ namespace CloudNative.CloudEvents;
 /// </summary>
 public class CloudEventAttribute
 {
-    private static readonly IList<string> ReservedNames = new List<string>
-        {
+    private static readonly List<string> ReservedNames = new()
+    {
             CloudEventsSpecVersion.SpecVersionAttributeName,
             "data"
         };
@@ -138,7 +138,7 @@ public class CloudEventAttribute
         }
         catch (Exception e)
         {
-            throw new ArgumentException($"Text for attribute '{Name}' is invalid: {e.Message}", nameof(value), e);
+            throw new ArgumentException($"Text for attribute '{Name}' is invalid: {e.Message}", nameof(text), e);
         }
         return Validate(value);
     }

--- a/src/CloudNative.CloudEvents/Extensions/Sampling.cs
+++ b/src/CloudNative.CloudEvents/Extensions/Sampling.cs
@@ -53,7 +53,7 @@ public static class Sampling
     {
         if ((int) value <= 0)
         {
-            throw new ArgumentOutOfRangeException("Sampled rate must be positive.");
+            throw new ArgumentOutOfRangeException(nameof(value), "Sampled rate must be positive.");
         }
     }
 }

--- a/src/CloudNative.CloudEvents/GlobalSuppressions.cs
+++ b/src/CloudNative.CloudEvents/GlobalSuppressions.cs
@@ -1,0 +1,9 @@
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Performance", "CA1835:Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'", Justification = "Should be rewritten", Scope = "member", Target = "~M:CloudNative.CloudEvents.Core.BinaryDataUtilities.CopyToStreamAsync(System.ReadOnlyMemory{System.Byte},System.IO.Stream)~System.Threading.Tasks.Task")]
+[assembly: SuppressMessage("Performance", "CA1866:Use char overload", Justification = "Not supported for netstandard2.0", Scope = "member", Target = "~M:CloudNative.CloudEvents.CloudEventAttributeType.UriType.ParseImpl(System.String)~System.Uri")]

--- a/src/CloudNative.CloudEvents/Http/HttpClientExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpClientExtensions.cs
@@ -143,11 +143,9 @@ public static class HttpClientExtensions
         }
         else
         {
-            string? versionId = MaybeGetVersionId(headers) ?? MaybeGetVersionId(content?.Headers);
-            if (versionId is null)
-            {
-                throw new ArgumentException($"Request does not represent a CloudEvent. It has neither a {HttpUtilities.SpecVersionHttpHeader} header, nor a suitable content type.", nameof(paramName));
-            }
+            var versionId = MaybeGetVersionId(headers) ?? MaybeGetVersionId(content?.Headers)
+                ?? throw new ArgumentException($"Request does not represent a CloudEvent. It has neither a {HttpUtilities.SpecVersionHttpHeader} header, nor a suitable content type.", nameof(paramName));
+
             var version = CloudEventsSpecVersion.FromVersionId(versionId)
                 ?? throw new ArgumentException($"Unknown CloudEvents spec version '{versionId}'", paramName);
 

--- a/src/CloudNative.CloudEvents/Http/HttpListenerExtensions.cs
+++ b/src/CloudNative.CloudEvents/Http/HttpListenerExtensions.cs
@@ -179,11 +179,9 @@ public static class HttpListenerExtensions
         }
         else
         {
-            string? versionId = httpListenerRequest.Headers[HttpUtilities.SpecVersionHttpHeader];
-            if (versionId is null)
-            {
-                throw new ArgumentException($"Request does not represent a CloudEvent. It has neither a {HttpUtilities.SpecVersionHttpHeader} header, nor a suitable content type.", nameof(httpListenerRequest));
-            }
+            var versionId = httpListenerRequest.Headers[HttpUtilities.SpecVersionHttpHeader]
+                ?? throw new ArgumentException($"Request does not represent a CloudEvent. It has neither a {HttpUtilities.SpecVersionHttpHeader} header, nor a suitable content type.", nameof(httpListenerRequest));
+            
             var version = CloudEventsSpecVersion.FromVersionId(versionId)
                 ?? throw new ArgumentException($"Unknown CloudEvents spec version '{versionId}'", nameof(httpListenerRequest));
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -25,6 +25,7 @@
     <AssemblyOriginatorKeyFile>$(RepoRoot)/CloudEventsSdk.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
     <Deterministic>True</Deterministic>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <!-- Keep C# 10 explicit while supporting netstandard2.0/netstandard2.1: older defaults break nullable and file-scoped namespaces. -->
     <LangVersion>10.0</LangVersion>

--- a/test/CloudNative.CloudEvents.UnitTests/Amqp/AmqpTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Amqp/AmqpTest.cs
@@ -115,7 +115,7 @@ public class AmqpTest
         AssertDecodeThenEqual(cloudEvent, message);
     }
 
-    private void AssertDecodeThenEqual(CloudEvent cloudEvent, Message message)
+    private static void AssertDecodeThenEqual(CloudEvent cloudEvent, Message message)
     {
         var encodedAmqpMessage = message.Encode();
 

--- a/test/CloudNative.CloudEvents.UnitTests/AspNetCore/HttpRequestExtensionsTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/AspNetCore/HttpRequestExtensionsTest.cs
@@ -61,7 +61,7 @@ public class HttpRequestExtensionsTest
         // Really only present for display purposes.
         Assert.NotNull(description);
 
-        var request = CreateRequest(new byte[0], new ContentType(contentType));
+        var request = CreateRequest(Array.Empty<byte>(), new ContentType(contentType));
         CopyHeaders(headers, request);
         Assert.True(request.IsCloudEvent());
     }
@@ -74,7 +74,7 @@ public class HttpRequestExtensionsTest
         // Really only present for display purposes.
         Assert.NotNull(description);
 
-        var request = CreateRequest(new byte[0], new ContentType(contentType));
+        var request = CreateRequest(Array.Empty<byte>(), new ContentType(contentType));
         CopyHeaders(headers, request);
         Assert.False(request.IsCloudEvent());
     }
@@ -86,7 +86,7 @@ public class HttpRequestExtensionsTest
         // Really only present for display purposes.
         Assert.NotNull(description);
 
-        var request = CreateRequest(new byte[0], new ContentType(contentType));
+        var request = CreateRequest(Array.Empty<byte>(), new ContentType(contentType));
         CopyHeaders(headers, request);
         Assert.True(request.IsCloudEventBatch());
     }
@@ -99,7 +99,7 @@ public class HttpRequestExtensionsTest
         // Really only present for display purposes.
         Assert.NotNull(description);
 
-        var request = CreateRequest(new byte[0], new ContentType(contentType));
+        var request = CreateRequest(Array.Empty<byte>(), new ContentType(contentType));
         CopyHeaders(headers, request);
         Assert.False(request.IsCloudEventBatch());
     }

--- a/test/CloudNative.CloudEvents.UnitTests/Avro/Helpers/FakeGenericRecordSerializer.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Avro/Helpers/FakeGenericRecordSerializer.cs
@@ -10,12 +10,12 @@ using System.IO;
 
 namespace CloudNative.CloudEvents.UnitTests.Avro.Helpers;
 
-internal class FakeGenericRecordSerializer : IGenericRecordSerializer
+internal sealed class FakeGenericRecordSerializer : IGenericRecordSerializer
 {
     public byte[]? SerializeResponse { get; private set; }
     public GenericRecord DeserializeResponse { get; private set; }
-    public int DeserializeCalls { get; private set; } = 0;
-    public int SerializeCalls { get; private set; } = 0;
+    public int DeserializeCalls { get; private set; }
+    public int SerializeCalls { get; private set; }
 
     public FakeGenericRecordSerializer()
     {

--- a/test/CloudNative.CloudEvents.UnitTests/CloudEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/CloudEventFormatterTest.cs
@@ -50,7 +50,7 @@ public class CloudEventFormatterTest
         Assert.Null(formatter.GetOrInferDataContentType(cloudEvent));
     }
 
-    private class ContentTypeInferringFormatter : ThrowingEventFormatter
+    private sealed class ContentTypeInferringFormatter : ThrowingEventFormatter
     {
         protected override string? InferDataContentType(object data) => $"test/{data}";
     }

--- a/test/CloudNative.CloudEvents.UnitTests/ConformanceTestData/SampleBatches.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/ConformanceTestData/SampleBatches.cs
@@ -5,35 +5,36 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 
 namespace CloudNative.CloudEvents.UnitTests.ConformanceTestData;
 
 public static class SampleBatches
 {
-    private static readonly ConcurrentDictionary<string, IReadOnlyList<CloudEvent>> batchesById = new ConcurrentDictionary<string, IReadOnlyList<CloudEvent>>();
+    private static readonly ConcurrentDictionary<string, ReadOnlyCollection<CloudEvent>> batchesById = new ConcurrentDictionary<string, ReadOnlyCollection<CloudEvent>>();
 
-    private static readonly IReadOnlyList<CloudEvent> empty = Register("empty");
-    private static readonly IReadOnlyList<CloudEvent> minimal = Register("minimal", SampleEvents.Minimal);
-    private static readonly IReadOnlyList<CloudEvent> minimal2 = Register("minimal2", SampleEvents.Minimal, SampleEvents.Minimal);
-    private static readonly IReadOnlyList<CloudEvent> minimalAndAllCore = Register("minimalAndAllCore", SampleEvents.Minimal, SampleEvents.AllCore);
-    private static readonly IReadOnlyList<CloudEvent> minimalAndAllExtensionTypes =
+    private static readonly ReadOnlyCollection<CloudEvent> empty = Register("empty");
+    private static readonly ReadOnlyCollection<CloudEvent> minimal = Register("minimal", SampleEvents.Minimal);
+    private static readonly ReadOnlyCollection<CloudEvent> minimal2 = Register("minimal2", SampleEvents.Minimal, SampleEvents.Minimal);
+    private static readonly ReadOnlyCollection<CloudEvent> minimalAndAllCore = Register("minimalAndAllCore", SampleEvents.Minimal, SampleEvents.AllCore);
+    private static readonly ReadOnlyCollection<CloudEvent> minimalAndAllExtensionTypes =
         Register("minimalAndAllExtensionTypes", SampleEvents.Minimal, SampleEvents.AllExtensionTypes);
 
-    internal static IReadOnlyList<CloudEvent> Empty => Clone(empty);
-    internal static IReadOnlyList<CloudEvent> Minimal => Clone(minimal);
-    internal static IReadOnlyList<CloudEvent> Minimal2 => Clone(minimal2);
-    internal static IReadOnlyList<CloudEvent> MinimalAndAllCore => Clone(minimalAndAllCore);
-    internal static IReadOnlyList<CloudEvent> MinimalAndAllExtensionTypes => Clone(minimalAndAllExtensionTypes);
+    internal static ReadOnlyCollection<CloudEvent> Empty => Clone(empty);
+    internal static ReadOnlyCollection<CloudEvent> Minimal => Clone(minimal);
+    internal static ReadOnlyCollection<CloudEvent> Minimal2 => Clone(minimal2);
+    internal static ReadOnlyCollection<CloudEvent> MinimalAndAllCore => Clone(minimalAndAllCore);
+    internal static ReadOnlyCollection<CloudEvent> MinimalAndAllExtensionTypes => Clone(minimalAndAllExtensionTypes);
 
-    internal static IReadOnlyList<CloudEvent> FromId(string id) => batchesById.TryGetValue(id, out var batch)
+    internal static ReadOnlyCollection<CloudEvent> FromId(string id) => batchesById.TryGetValue(id, out var batch)
         ? Clone(batch)
         : throw new ArgumentException($"No such sample batch: '{id}'");
 
-    private static IReadOnlyList<CloudEvent> Clone(IReadOnlyList<CloudEvent> cloudEvents) =>
+    private static ReadOnlyCollection<CloudEvent> Clone(ReadOnlyCollection<CloudEvent> cloudEvents) =>
         cloudEvents.Select(SampleEvents.Clone).ToList().AsReadOnly();
 
-    private static IReadOnlyList<CloudEvent> Register(string id, params CloudEvent[] cloudEvents)
+    private static ReadOnlyCollection<CloudEvent> Register(string id, params CloudEvent[] cloudEvents)
     {
         var list = new List<CloudEvent>(cloudEvents).AsReadOnly();
         batchesById[id] = list;

--- a/test/CloudNative.CloudEvents.UnitTests/ConformanceTestData/TestDataProvider.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/ConformanceTestData/TestDataProvider.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace CloudNative.CloudEvents.UnitTests.ConformanceTestData;
 
-internal class TestDataProvider
+internal sealed class TestDataProvider
 {
     private static readonly string ConformanceTestDataRoot = Path.Combine(FindRepoRoot(), "conformance", "format");
 

--- a/test/CloudNative.CloudEvents.UnitTests/Kafka/KafkaTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Kafka/KafkaTest.cs
@@ -194,7 +194,7 @@ public class KafkaTest
         Assert.Equal("application/json", contentTypeValue);
     }
 
-    private class HeadersConverter : JsonConverter
+    private sealed class HeadersConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType)
         {
@@ -226,9 +226,9 @@ public class KafkaTest
         }
     }
 
-    private class HeaderConverter : JsonConverter
+    private sealed class HeaderConverter : JsonConverter
     {
-        private class HeaderContainer
+        private sealed class HeaderContainer
         {
             public string? Key { get; set; }
             public byte[]? Value { get; set; }

--- a/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/AttributedModel.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/AttributedModel.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests;
 
 [CloudEventFormatter(typeof(JsonEventFormatter<AttributedModel>))]
-internal class AttributedModel
+internal sealed class AttributedModel
 {
     public const string JsonPropertyName = "customattribute";
 

--- a/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/GenericJsonEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/GenericJsonEventFormatterTest.cs
@@ -85,7 +85,7 @@ public class GenericJsonEventFormatterTest
     {
         var formatter = CreateFormatter<AttributedModel>();
         var cloudEvent = new CloudEvent { Data = "original" };
-        formatter.DecodeBinaryModeEventData(new byte[0], cloudEvent);
+        formatter.DecodeBinaryModeEventData(Array.Empty<byte>(), cloudEvent);
         Assert.Null(cloudEvent.Data);
     }
 
@@ -167,7 +167,7 @@ public class GenericJsonEventFormatterTest
         return formatter!;
     }
 
-    private class OtherModelClass
+    private sealed class OtherModelClass
     {
         public string? Text { get; set; }
     }

--- a/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/JTokenAsserter.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/JTokenAsserter.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace CloudNative.CloudEvents.NewtonsoftJson.UnitTests;
 
-internal class JTokenAsserter : IEnumerable
+internal sealed class JTokenAsserter : IEnumerable
 {
     private readonly List<(string name, JTokenType type, object? value)> expectations = new List<(string, JTokenType, object?)>();
 

--- a/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/JsonEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/JsonEventFormatterTest.cs
@@ -435,7 +435,7 @@ public class JsonEventFormatterTest
     [Fact]
     public void EncodeBatchModeMessage_Empty()
     {
-        var cloudEvents = new CloudEvent[0];
+        var cloudEvents = Array.Empty<CloudEvent>();
         var formatter = new JsonEventFormatter();
         var bytes = formatter.EncodeBatchModeMessage(cloudEvents, out var contentType);
         Assert.Equal("application/cloudevents-batch+json; charset=utf-8", contentType.ToString());
@@ -835,14 +835,14 @@ public class JsonEventFormatterTest
     [Fact]
     public void DecodeBinaryModeEventData_EmptyData_JsonContentType()
     {
-        var data = DecodeBinaryModeEventData(new byte[0], "application/json");
+        var data = DecodeBinaryModeEventData([], "application/json");
         Assert.Null(data);
     }
 
     [Fact]
     public void DecodeBinaryModeEventData_EmptyData_TextContentType()
     {
-        var data = DecodeBinaryModeEventData(new byte[0], "text/plain");
+        var data = DecodeBinaryModeEventData([], "text/plain");
         var text = Assert.IsType<string>(data);
         Assert.Equal("", text);
     }
@@ -850,7 +850,7 @@ public class JsonEventFormatterTest
     [Fact]
     public void DecodeBinaryModeEventData_EmptyData_OtherContentType()
     {
-        var data = DecodeBinaryModeEventData(new byte[0], "application/binary");
+        var data = DecodeBinaryModeEventData([], "application/binary");
         var byteArray = Assert.IsType<byte[]>(data);
         Assert.Empty(byteArray);
     }

--- a/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/SpecializedFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/SpecializedFormatterTest.cs
@@ -152,7 +152,7 @@ public class SpecializedFormatterTest
     /// - Content type of "text/binary" is encoded in base64
     /// - Guid with a content type of "application/guid" is encoded as a string with content "guid:base64-data"
     /// </summary>
-    private class SpecializedFormatter : JsonEventFormatter
+    private sealed class SpecializedFormatter : JsonEventFormatter
     {
         protected override void DecodeStructuredModeDataBase64Property(JToken dataBase64Token, CloudEvent cloudEvent)
         {

--- a/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/SpecializedJsonReaderTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/NewtonsoftJson/SpecializedJsonReaderTest.cs
@@ -58,7 +58,7 @@ public class SpecializedJsonReaderTest
         Assert.Same(property1.Name, property2.Name);
     }
 
-    private Stream CreateJsonStream()
+    private static MemoryStream CreateJsonStream()
     {
         var cloudEvent = new CloudEvent
         {
@@ -68,13 +68,13 @@ public class SpecializedJsonReaderTest
         return BinaryDataUtilities.AsStream(bytes);
     }
 
-    private class CreateJsonReaderExposingFormatter : JsonEventFormatter
+    private sealed class CreateJsonReaderExposingFormatter : JsonEventFormatter
     {
         public JsonReader CreateJsonReaderPublic(Stream stream, Encoding? encoding) =>
             base.CreateJsonReader(stream, encoding);
     }
 
-    private class PropertyNameTableFormatter : JsonEventFormatter
+    private sealed class PropertyNameTableFormatter : JsonEventFormatter
     {
         private readonly DefaultJsonNameTable table;
 

--- a/test/CloudNative.CloudEvents.UnitTests/Protobuf/ProtobufEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/Protobuf/ProtobufEventFormatterTest.cs
@@ -294,7 +294,7 @@ public class ProtobufEventFormatterTest
     public void EncodeBatchModeMessage_Empty()
     {
         var formatter = new ProtobufEventFormatter();
-        var bytes = formatter.EncodeBatchModeMessage(new CloudEvent[0], out var contentType);
+        var bytes = formatter.EncodeBatchModeMessage([], out var contentType);
         Assert.Equal("application/cloudevents-batch+protobuf; charset=utf-8", contentType.ToString());
         var batch = V1.CloudEventBatch.Parser.ParseFrom(bytes.ToArray());
         Assert.Empty(batch.Events);

--- a/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/AttributedModel.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/AttributedModel.cs
@@ -7,7 +7,7 @@ using System.Text.Json.Serialization;
 namespace CloudNative.CloudEvents.SystemTextJson.UnitTests;
 
 [CloudEventFormatter(typeof(JsonEventFormatter<AttributedModel>))]
-internal class AttributedModel
+internal sealed class AttributedModel
 {
     public const string JsonPropertyName = "customattribute";
 

--- a/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/GenericJsonEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/GenericJsonEventFormatterTest.cs
@@ -103,7 +103,7 @@ public class GenericJsonEventFormatterTest
     {
         var formatter = CreateFormatter<AttributedModel>();
         var cloudEvent = new CloudEvent { Data = "original" };
-        formatter.DecodeBinaryModeEventData(new byte[0], cloudEvent);
+        formatter.DecodeBinaryModeEventData(Array.Empty<byte>(), cloudEvent);
         Assert.Null(cloudEvent.Data);
     }
 
@@ -184,7 +184,7 @@ public class GenericJsonEventFormatterTest
         return formatter!;
     }
 
-    private class OtherModelClass
+    private sealed class OtherModelClass
     {
         public string? Text { get; set; }
     }

--- a/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/JsonElementAsserter.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/JsonElementAsserter.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace CloudNative.CloudEvents.SystemTextJson.UnitTests;
 
-internal class JsonElementAsserter : IEnumerable
+internal sealed class JsonElementAsserter : IEnumerable
 {
     private readonly List<(string name, JsonValueKind type, object? value)> expectations = new List<(string, JsonValueKind, object?)>();
 

--- a/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/JsonEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/JsonEventFormatterTest.cs
@@ -443,7 +443,7 @@ public class JsonEventFormatterTest
     [Fact]
     public void EncodeBatchModeMessage_Empty()
     {
-        var cloudEvents = new CloudEvent[0];
+        var cloudEvents = Array.Empty<CloudEvent>();
         var formatter = new JsonEventFormatter();
         var bytes = formatter.EncodeBatchModeMessage(cloudEvents, out var contentType);
         Assert.Equal("application/cloudevents-batch+json; charset=utf-8", contentType.ToString());
@@ -855,14 +855,14 @@ public class JsonEventFormatterTest
     [Fact]
     public void DecodeBinaryModeEventData_EmptyData_JsonContentType()
     {
-        var data = DecodeBinaryModeEventData(new byte[0], "application/json");
+        var data = DecodeBinaryModeEventData([], "application/json");
         Assert.Null(data);
     }
 
     [Fact]
     public void DecodeBinaryModeEventData_EmptyData_TextContentType()
     {
-        var data = DecodeBinaryModeEventData(new byte[0], "text/plain");
+        var data = DecodeBinaryModeEventData([], "text/plain");
         var text = Assert.IsType<string>(data);
         Assert.Equal("", text);
     }
@@ -870,7 +870,7 @@ public class JsonEventFormatterTest
     [Fact]
     public void DecodeBinaryModeEventData_EmptyData_OtherContentType()
     {
-        var data = DecodeBinaryModeEventData(new byte[0], "application/binary");
+        var data = DecodeBinaryModeEventData([], "application/binary");
         var byteArray = Assert.IsType<byte[]>(data);
         Assert.Empty(byteArray);
     }
@@ -1218,7 +1218,7 @@ public class JsonEventFormatterTest
         return formatter.DecodeBatchModeMessage(bytes, s_jsonCloudEventBatchContentType, null);
     }
 
-    private class YearMonthDayConverter : JsonConverter<DateTime>
+    private sealed class YearMonthDayConverter : JsonConverter<DateTime>
     {
         public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
             DateTime.ParseExact(reader.GetString()!, "yyyy-MM-dd", CultureInfo.InvariantCulture);

--- a/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/SpecializedFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/SpecializedFormatterTest.cs
@@ -152,7 +152,7 @@ public class SpecializedFormatterTest
     /// - Content type of "text/binary" is encoded in base64
     /// - Guid with a content type of "application/guid" is encoded as a string with content "guid:base64-data"
     /// </summary>
-    private class SpecializedFormatter : JsonEventFormatter
+    private sealed class SpecializedFormatter : JsonEventFormatter
     {
         protected override void DecodeStructuredModeDataBase64Property(JsonElement dataBase64Element, CloudEvent cloudEvent)
         {

--- a/test/CloudNative.CloudEvents.UnitTests/TestHelpers.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/TestHelpers.cs
@@ -20,7 +20,7 @@ internal static class TestHelpers
     internal static IEqualityComparer<DateTimeOffset> InstantOnlyTimestampComparer => EqualityComparer<DateTimeOffset>.Default;
     internal static IEqualityComparer<DateTimeOffset> StrictTimestampComparer => StrictTimestampComparerImpl.Instance;
 
-    internal static CloudEventAttribute[] EmptyExtensionArray { get; } = new CloudEventAttribute[0];
+    internal static CloudEventAttribute[] EmptyExtensionArray { get; } = [];
     internal static IEnumerable<CloudEventAttribute> EmptyExtensionSequence { get; } = new List<CloudEventAttribute>().AsReadOnly();
 
     /// <summary>
@@ -217,7 +217,7 @@ internal static class TestHelpers
         return output;
     }
 
-    private class StrictTimestampComparerImpl : IEqualityComparer<DateTimeOffset>
+    private sealed class StrictTimestampComparerImpl : IEqualityComparer<DateTimeOffset>
     {
         internal static StrictTimestampComparerImpl Instance { get; } = new StrictTimestampComparerImpl();
 


### PR DESCRIPTION
This PR addresses some styling and analyzer issues:

- Enabled `EnforceCodeStyleInBuild` for all projects
- Sets the `Analyzer categories` to warning for Maintainability, Security, Interoperability and Performance
- Solved the analyzer issues or suppresses them where fitting
- Flattens some logic so it's easier to read (see fdc9bde97c54e7d8f20c45861aa592eb882b213d)