### PR TITLE
Cover the non transcoding stream option in the SystemTextJson JsonEventFormatter unit test

### DIFF
--- a/src/CloudNative.CloudEvents.SystemTextJson/JsonEventFormatter.cs
+++ b/src/CloudNative.CloudEvents.SystemTextJson/JsonEventFormatter.cs
@@ -104,6 +104,12 @@ public class JsonEventFormatter : CloudEventFormatter
     protected JsonDocumentOptions DocumentOptions { get; }
 
     /// <summary>
+    /// Whether non-UTF8 JSON should be transcoded to UTF-8 before parsing when the target framework supports it.
+    /// Derived classes may override this to exercise the fallback path.
+    /// </summary>
+    protected virtual bool UseTranscodingStreamForNonUtf8 => true;
+
+    /// <summary>
     /// Creates a JsonEventFormatter that uses the default <see cref="JsonSerializerOptions"/>
     /// and <see cref="JsonDocumentOptions"/> for serializing and parsing.
     /// </summary>
@@ -193,15 +199,20 @@ public class JsonEventFormatter : CloudEventFormatter
         if (encoding is not UTF8Encoding)
         {
 #if NET5_0_OR_GREATER
-            data = Encoding.CreateTranscodingStream(data, encoding, Encoding.UTF8);
-#else
-            using var reader = new StreamReader(data, encoding);
-            var json = async
-                ? await reader.ReadToEndAsync().ConfigureAwait(false)
-                : reader.ReadToEnd();
-                
-            return JsonDocument.Parse(json, DocumentOptions);
+            if (UseTranscodingStreamForNonUtf8)
+            {
+                data = Encoding.CreateTranscodingStream(data, encoding, Encoding.UTF8);
+            }
+            else
 #endif
+            {
+                using var reader = new StreamReader(data, encoding);
+                var json = async
+                    ? await reader.ReadToEndAsync().ConfigureAwait(false)
+                    : reader.ReadToEnd();
+
+                return JsonDocument.Parse(json, DocumentOptions);
+            }
         }
 
         return async

--- a/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/JsonEventFormatterTest.cs
+++ b/test/CloudNative.CloudEvents.UnitTests/SystemTextJson/JsonEventFormatterTest.cs
@@ -538,6 +538,7 @@ public class JsonEventFormatterTest
 
     [Theory]
     [InlineData("utf-8")]
+    [InlineData("utf-16")]
     [InlineData("iso-8859-1")]
     public void DecodeStructuredModeMessage_Minimal(string charset)
     {
@@ -556,6 +557,31 @@ public class JsonEventFormatterTest
         Assert.Equal("test-type", cloudEvent.Type);
         Assert.Equal("test-id", cloudEvent.Id);
         Assert.Equal(SampleUri, cloudEvent.Source);
+        Assert.Equal(NonAsciiValue, cloudEvent["text"]);
+    }
+
+    [Theory]
+    [InlineData("utf-8")]
+    [InlineData("utf-16")]
+    [InlineData("iso-8859-1")]
+    public async Task DecodeStructuredModeMessage_Minimal_ForcedNonUtf8Fallback(string charset)
+    {
+        var obj = new JObject
+        {
+            ["specversion"] = "1.0",
+            ["type"] = "test-type",
+            ["id"] = "test-id",
+            ["source"] = SampleUriText,
+            ["text"] = NonAsciiValue
+        };
+        var bytes = Encoding.GetEncoding(charset).GetBytes(obj.ToString());
+        var stream = new MemoryStream(bytes);
+        var formatter = new NonTranscodingJsonEventFormatter();
+        var cloudEvent = formatter.DecodeStructuredModeMessage(stream, new ContentType($"application/cloudevents+json; charset={charset}"), null);
+        Assert.Equal("test-type", cloudEvent.Type);
+        Assert.Equal("test-id", cloudEvent.Id);
+        Assert.Equal(SampleUri, cloudEvent.Source);
+        Assert.Equal(NonAsciiValue, cloudEvent["text"]);
     }
 
     [Fact]
@@ -1216,6 +1242,11 @@ public class JsonEventFormatterTest
         var bytes = Encoding.UTF8.GetBytes(array.ToString());
         var formatter = new JsonEventFormatter();
         return formatter.DecodeBatchModeMessage(bytes, s_jsonCloudEventBatchContentType, null);
+    }
+
+    private sealed class NonTranscodingJsonEventFormatter : JsonEventFormatter
+    {
+        protected override bool UseTranscodingStreamForNonUtf8 => false;
     }
 
     private sealed class YearMonthDayConverter : JsonConverter<DateTime>


### PR DESCRIPTION
This PR makes sure to cover the non-transcoding path.

This is a follow up of https://github.com/cloudevents/sdk-csharp/pull/342

I considered targeting `netstandard2.0` for the unit tests but that seemed to be much more work and out of proportions for this scenario.