### PR TITLE
Run workflow on Windows too; and when on Windows, run the net48 tests explicitly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,16 @@ on:
   pull_request:
 
 jobs:
-
   build:
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-24.04
+          - windows-2025
+
+    runs-on: ${{ matrix.os }}
+
     env:
       DOTNET_NOLOGO: true
 
@@ -19,18 +26,16 @@ jobs:
         with:
           submodules: true
 
-      # Build with .NET 10.0 SDK
-      # Test with .NET 8.0 and 10.0
-      - name: Setup .NET 8.0 and 10.0
-        uses: actions/setup-dotnet@v5.2.0
-        with:
-          dotnet-version: |
-            8.0.x
-            10.0.x
+      - run: dotnet build
 
-      - name: Build
-        run: |
-          dotnet build
-          dotnet test
-          # Pack production packages to validate compatibility
-          dotnet pack -p:ContinuousIntegrationBuild=true
+      - name: Test net48
+        if: runner.os == 'Windows'
+        run: dotnet test --no-build -f net48
+        
+      - name: Test net8.0
+        run: dotnet test --no-build -f net8.0
+
+      - name: Test net10.0
+        run: dotnet test --no-build -f net10.0
+
+      - run: dotnet pack -p:ContinuousIntegrationBuild=true


### PR DESCRIPTION
Succeeding https://github.com/cloudevents/sdk-csharp/pull/353.

I made the test runners explicitly target net8, net10 and net48, because https://github.com/actions/setup-dotnet doesn't support net48. This causes them to not run parallel anymore, but I couldn't see an elegant solution to keep them parallel. However, both Linux and windows run in parallel now, and Windows is slower than Linux now anyway.

