### PR TITLE
`net10` target and drop redundant `netstandard2.1` target

### DIFF
--- a/src/CloudNative.CloudEvents.Amqp/CloudNative.CloudEvents.Amqp.csproj
+++ b/src/CloudNative.CloudEvents.Amqp/CloudNative.CloudEvents.Amqp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <Description>AMQP extensions for CloudNative.CloudEvents</Description>
     <Nullable>enable</Nullable>
     <PackageTags>cncf;cloudnative;cloudevents;events;amqp</PackageTags>

--- a/src/CloudNative.CloudEvents.AspNetCore/CloudNative.CloudEvents.AspNetCore.csproj
+++ b/src/CloudNative.CloudEvents.AspNetCore/CloudNative.CloudEvents.AspNetCore.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <Description>ASP.Net Core extensions for CloudNative.CloudEvents</Description>
     <Nullable>enable</Nullable>
     <PackageTags>cncf;cloudnative;cloudevents;events;aspnetcore;aspnet</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0' and '$(TargetFramework)' != 'netstandard2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Http" />
     <PackageReference Include="System.Text.Encodings.Web" />
   </ItemGroup>

--- a/src/CloudNative.CloudEvents.Avro/CloudNative.CloudEvents.Avro.csproj
+++ b/src/CloudNative.CloudEvents.Avro/CloudNative.CloudEvents.Avro.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <Description>Avro extensions for CloudNative.CloudEvents</Description>
     <PackageTags>cncf;cloudnative;cloudevents;events;avro</PackageTags>
     <Nullable>enable</Nullable>

--- a/src/CloudNative.CloudEvents.Kafka/CloudNative.CloudEvents.Kafka.csproj
+++ b/src/CloudNative.CloudEvents.Kafka/CloudNative.CloudEvents.Kafka.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <Description>Kafka extensions for CloudNative.CloudEvents</Description>
     <PackageTags>cncf;cloudnative;cloudevents;events;kafka</PackageTags>
     <Nullable>enable</Nullable>

--- a/src/CloudNative.CloudEvents.Mqtt/CloudNative.CloudEvents.Mqtt.csproj
+++ b/src/CloudNative.CloudEvents.Mqtt/CloudNative.CloudEvents.Mqtt.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <Description>MQTT extensions for CloudNative.CloudEvents</Description>
     <PackageTags>cncf;cloudnative;cloudevents;events;mqtt</PackageTags>
     <Version>3.$(MinorVersion).$(PatchVersion)</Version>

--- a/src/CloudNative.CloudEvents.NewtonsoftJson/CloudNative.CloudEvents.NewtonsoftJson.csproj
+++ b/src/CloudNative.CloudEvents.NewtonsoftJson/CloudNative.CloudEvents.NewtonsoftJson.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <Description>JSON support for the CNCF CloudEvents SDK, based on Newtonsoft.Json.</Description>
     <Nullable>enable</Nullable>
     <PackageTags>cncf;cloudnative;cloudevents;events;json;newtonsoft</PackageTags>

--- a/src/CloudNative.CloudEvents.Protobuf/CloudNative.CloudEvents.Protobuf.csproj
+++ b/src/CloudNative.CloudEvents.Protobuf/CloudNative.CloudEvents.Protobuf.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
 	<Description>Support for the Protobuf event format in for CloudNative.CloudEvents</Description>
 	<PackageTags>cncf;cloudnative;cloudevents;events;protobuf</PackageTags>
 	<Nullable>enable</Nullable>

--- a/src/CloudNative.CloudEvents.Protobuf/CompatibilitySuppressions.xml
+++ b/src/CloudNative.CloudEvents.Protobuf/CompatibilitySuppressions.xml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:CloudNative.CloudEvents.V1.CloudEvent.DataOneofCase</Target>
+    <Left>lib/netstandard2.1/CloudNative.CloudEvents.Protobuf.dll</Left>
+    <Right>lib/netstandard2.0/CloudNative.CloudEvents.Protobuf.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:CloudNative.CloudEvents.V1.CloudEvent.Types.CloudEventAttributeValue.AttrOneofCase</Target>
+    <Left>lib/netstandard2.1/CloudNative.CloudEvents.Protobuf.dll</Left>
+    <Right>lib/netstandard2.0/CloudNative.CloudEvents.Protobuf.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>

--- a/src/CloudNative.CloudEvents.SystemTextJson/CloudNative.CloudEvents.SystemTextJson.csproj
+++ b/src/CloudNative.CloudEvents.SystemTextJson/CloudNative.CloudEvents.SystemTextJson.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <Description>JSON support for the CNCF CloudEvents SDK, based on System.Text.Json.</Description>
     <PackageTags>cncf;cloudnative;cloudevents;events;json;systemtextjson</PackageTags>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Condition="'$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='netstandard2.1'" />
+    <PackageReference Include="System.Text.Json" Condition="'$(TargetFramework)'=='netstandard2.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CloudNative.CloudEvents/CloudNative.CloudEvents.csproj
+++ b/src/CloudNative.CloudEvents/CloudNative.CloudEvents.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <Description>CNCF CloudEvents SDK</Description>
     <Nullable>enable</Nullable>
     <PackageTags>cloudnative;cloudevents;events</PackageTags>

--- a/src/CloudNative.CloudEvents/CompatibilitySuppressions.xml
+++ b/src/CloudNative.CloudEvents/CompatibilitySuppressions.xml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:CloudNative.CloudEvents.ContentMode</Target>
+    <Left>lib/netstandard2.1/CloudNative.CloudEvents.dll</Left>
+    <Right>lib/netstandard2.0/CloudNative.CloudEvents.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:CloudNative.CloudEvents.Core.CloudEventAttributeTypeOrdinal</Target>
+    <Left>lib/netstandard2.1/CloudNative.CloudEvents.dll</Left>
+    <Right>lib/netstandard2.0/CloudNative.CloudEvents.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,7 +27,7 @@
     <Deterministic>True</Deterministic>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <!-- Keep C# 10 explicit while supporting netstandard2.0/netstandard2.1: older defaults break nullable and file-scoped namespaces. -->
+    <!-- Keep C# 10 explicit while supporting netstandard2.0: older defaults break nullable and file-scoped namespaces. -->
     <LangVersion>10.0</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>    
     <EnablePackageValidation>true</EnablePackageValidation>


### PR DESCRIPTION
Added net10 as target in the core projects. I removed netstandard2.1 as I don't see how that adds any value, it's overlapping with netstandard2.0, net8 and net10.